### PR TITLE
Make available cl's `incf` definition in `haskell-indentation.el`

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -35,6 +35,7 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'cl)) ;needed for def of incf
 (require 'syntax nil t)			; Emacs 21 add-on
 
 (defgroup haskell-indentation nil


### PR DESCRIPTION
This changeset fixes the following error observable with emacs 24:

| haskell-current-column: Invalid function: incf
