### PR TITLE
Fix for send-decl (to deal with eof).

### DIFF
--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -420,6 +420,7 @@ If prefix arg \\[universal-argument] is given, just reload the previous file."
 
 (defun inferior-haskell-wrap-decl (code)
   "Wrap declaration code into :{ ... :}."
+  (setq code (concat code "\n"))
   (concat ":{\n"
           (if (string-match (concat "^\\s-*"
                                     haskell-ds-start-keywords-re)


### PR DESCRIPTION
Added concatenation of newline to declaration-code before wrapping into :{ ... :} to deal with situation, when declaration-code ends in eof.
