### PR TITLE
haskell-process-do-type now calls ":type (%s)" so it works for operators...

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -113,7 +113,7 @@
   (interactive "P")
   (haskell-process-do-simple-echo
    insert-value
-   (format ":type %s" (haskell-ident-at-point))))
+   (format ":type (%s)" (haskell-ident-at-point))))
 
 (defun haskell-process-do-info (&optional ident)
   "Print the info of the given expression."


### PR DESCRIPTION
haskell-process-do-type now calls ":type (%s)" instead of ":type %s" so it works for operators as well as alpha identifiers.
Now I can do C-c C-t on == in my Haskell source code!
