### PR TITLE
Attempt to fix issue #26: 'haskell-process-load-file doesn't reload project dependencies

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -164,6 +164,17 @@
      (format "Cabal dir%s: " (if file (format " (%s)" (file-relative-name file)) ""))
      (or dir default-directory))))
 
+(defun haskell-cabal-compute-checksum (cabal-dir) 
+  "Computes a checksum of the .cabal configuration files"
+  (let* 
+      ((cabal-file-paths (directory-files cabal-dir t "\\.cabal$"))
+       (get-file-contents (lambda (path) (with-temp-buffer (insert-file-contents path)
+                                                           (buffer-string))))
+       (cabal-file-contents (map 'list get-file-contents cabal-file-paths))
+       (cabal-config (reduce 'concat cabal-file-contents))
+       )
+    (md5 cabal-config)))
+
 (defun haskell-cabal-find-file ()
   "Return a buffer visiting the cabal file of the current directory, or nil."
   (catch 'found

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -159,6 +159,17 @@
           (goto-char (line-beginning-position))
           (insert (format "%s\n" response))))))))
 
+
+(defun haskell-process-look-config-changes(session)  
+  "Checks whether a cabal configuration file has changed. Restarts the process if that is the case"  
+    (let ((current-checksum (haskell-session-get session 'cabal-checksum))
+          (new-checksum (haskell-cabal-compute-checksum (haskell-session-get session 'cabal-dir))))
+      (when (not (equal current-checksum new-checksum))
+        (progn
+          (haskell-session-set-cabal-checksum session (haskell-session-get session 'cabal-dir))
+          (kill-process (haskell-process-name (haskell-session-process haskell-session)))
+          ))))
+
 ;;;###autoload
 (defun haskell-process-load-file ()
   "Load the current buffer file."
@@ -177,6 +188,7 @@
   (let ((session (haskell-session))
         (process (haskell-process)))
     (haskell-session-current-dir session)
+    (haskell-process-look-config-changes session)
     (haskell-process-queue-command
      process
      (haskell-command-make 

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -225,11 +225,16 @@
 
 (defun haskell-session-set-cabal-dir (s v)
   "Set the session cabal-dir."
+  (haskell-session-set-cabal-checksum s v) ;re-compute checksum for new dir
   (haskell-session-set s 'cabal-dir v))
 
 (defun haskell-session-set-current-dir (s v)
   "Set the session current directory."
   (haskell-session-set s 'current-dir v))
+
+(defun haskell-session-set-cabal-checksum (s cabal-dir)
+  "Set the session checksum of .cabal files"
+  (haskell-session-set s 'cabal-checksum (haskell-cabal-compute-checksum cabal-dir)))
 
 (defun haskell-session-current-dir (s)
   "Get the session current directory."


### PR DESCRIPTION
If a .cabal file is changed, kill the process, which results in a call to `'haskell-process-prompt-restart`.

This isn't really a perfect fix since it only restarts the process but doesn't load the file after it (another call to `'haskell-process-load-file` is necessary). I'd have preferred calling `'haskell-process-restart` instead of killing the current process, but that doesn't work well here: the caval-dev ghci buffer stops responding to commands. Is that a known/reproducible issue?
