### PR TITLE
Don't replace buffer when stylish-haskell fails.

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -760,12 +760,20 @@ This function will be called with no arguments.")
       (when haskell-tags-on-save
         (haskell-process-generate-tags)))))
 
+(defun haskell-mode-buffer-apply-command (cmd)
+  "Execute shell command CMD with current buffer as input and
+  replace the whole buffer with the output. If CMD fails the
+  buffer remains unchanged"
+  (when (= 0 (shell-command-on-region (point-min) (point-max) cmd))
+      (erase-buffer) 
+      (insert-buffer "*Shell Command Output*")))
+
 (defun haskell-mode-stylish-buffer ()
   "Apply stylish-haskell to the current buffer."
   (interactive)
   (let ((column (current-column)) 
         (line (line-number-at-pos)))
-    (shell-command-on-region (point-min) (point-max) "stylish-haskell" (current-buffer))
+    (haskell-mode-buffer-apply-command "stylish-haskell")
     (goto-line line)
     (goto-char (+ column (point)))))
 


### PR DESCRIPTION
I just opened a file I was working on yesterday and it only contained:

```
stylish-haskell: StylishHaskell.Parse.parseModule: could not parse <unknown>: ParseFailed (SrcLoc {srcFilename = "<unknown>.hs", srcLine = 34, srcColumn = 9}) "Parse error: ="
```

so I suppose something like this fix is needed.
