### PR TITLE
Find the logo better for notifications

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -103,7 +103,7 @@ has changed?"
 (defvar haskell-process-prompt-regex "\\(^[> ]*> $\\|\n[> ]*> $\\)")
 
 (defconst haskell-process-logo
-  (file-truename "logo.svg")
+  (expand-file-name "logo.svg" (file-name-directory load-file-name))
   "Haskell logo for notifications.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
I _think_ this should now better find the current location of the logo relative to the haskell-process file.

(Previously it was using the location of the first file that loaded haskell-mode.)
