### PR TITLE
Fix for incorrect identifier parsing in haskell-indentation-peek-token

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -948,7 +948,7 @@ Preserves indentation and removes extra whitespace"
 		 (t (setq current-token (haskell-indentation-peek-token))))))))
 
 (defun haskell-indentation-peek-token ()
-  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|do\\|proc\\|case\\|of\\|where\\|module\\|deriving\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alpha:]'_]\\|$\\)")
+  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|do\\|proc\\|case\\|of\\|where\\|module\\|deriving\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
 	 (match-string 1))
 	((looking-at "[][(){}[,;]")
 	 (match-string 0))


### PR DESCRIPTION
The Haskell 98 standard specifies identifiers as 

```
varid -> (small {small | large | digit | ' })
```

However, the haskell-indentation-peek-token didn't allow digits as follow-up characters in identifiers. This meant that for example

```
in3 x = 3 `elem` x
```

did not parse correctly even though it is correct Haskell code.

Fix is simple: Use `:alnum:` instead of `:alpha:` in regular expression.
