### PR TITLE
use {before/after}-save-hook instead of separate functions

### DIFF
--- a/examples/init.el
+++ b/examples/init.el
@@ -78,10 +78,6 @@
   ;; Jump to the definition of the current symbol.
   (define-key haskell-mode-map (kbd "M-.") 'haskell-mode-tag-find)
 
-  ;; Save the current buffer and generate etags (a TAGS file) for the
-  ;; whole project.
-  (define-key haskell-mode-map (kbd "C-x C-s") 'haskell-mode-save-buffer)
-
   ;; Indent the below lines on columns after the current column.
   (define-key haskell-mode-map (kbd "C-<right>")
     (lambda ()

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -115,6 +115,7 @@ has changed?"
   (haskell-process-reset (haskell-process))
   (haskell-process-set (haskell-process) 'command-queue nil))
 
+;;;###autoload
 (defun haskell-process-generate-tags (&optional and-then-find-this-tag)
   "Regenerate the TAGS table."
   (interactive)
@@ -817,3 +818,6 @@ changed. Restarts the process if that is the case."
   (setf (cdr s) (cons (cons key value)
                       (cdr s)))
   s)
+
+(provide 'haskell-process)
+


### PR DESCRIPTION
I looked to code, and found that it could be simplified - instead of using special function to save haskell code, we can use standard hooks:
- before-save-hook will call stylish before save
- after-save-hook will call hasktags after file was saved

both hooks are made buffer-local, to be called only in the haskell-mode
