### PR TITLE
Remove errornous accessor functions

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -835,17 +835,4 @@ to be loaded by ghci."
                (haskell-command-state command)
                response))))
 
-(defun haskell-command-get (s key)
-  "Get the command `key'."
-  (let ((x (assoc key s)))
-    (when x
-      (cdr x))))
-
-(defun haskell-command-set (s key value)
-  "Set the command's `key'."
-  (delete-if (lambda (prop) (equal (car prop) key)) s)
-  (setf (cdr s) (cons (cons key value)
-                      (cdr s)))
-  s)
-
 (provide 'haskell-process)


### PR DESCRIPTION
Hi again,

I think that there was an "accident" when merging a pull request, I think I fixed it.
The functions haskell-command-get/haskell-command-set are really unnecessary... since I refactored to use cl structs. All accessor are generated by defstruct.
