### PR TITLE
Fix Problem when saving a new file

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -763,7 +763,8 @@ This function will be called with no arguments.")
 (defun haskell-mode-before-save-handler ()
   "Function that will be called before buffer's saving."
   (when haskell-stylish-on-save
-    (haskell-mode-stylish-buffer)))
+    (ignore-errors ; save anyway!
+      (haskell-mode-stylish-buffer))))
 
 (defun haskell-mode-after-save-handler ()
   "Function that will be called after buffer's saving."


### PR DESCRIPTION
In case the file does not yet exist on the file system, or anything else goes
wrong, do we REALLY want to prevent the user from saving his valueable
changes?? - No I would say, hence I added 'ignore-errors' in the before save hook.

I had the case that I could not save a new haskell buffer. 
I had the stylish-haskell on save activated, so it was run in the before save hook - and crashed because the file was simply not there. Anyway I do not want that an error in stylish-haskell prevents me from saving my changes!
