### PR TITLE
Fixed #81 - just require cl since it's used at runtime

### DIFF
--- a/haskell-session.el
+++ b/haskell-session.el
@@ -25,7 +25,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 (require 'haskell-cabal)
 (require 'haskell-string)
 
@@ -113,7 +113,7 @@
 
 (defun haskell-session-from-buffer ()
   "Get the session based on the buffer."
-  (let ((sessions (remove-if-not (lambda (session) 
+  (let ((sessions (remove-if-not (lambda (session)
                                    (haskell-is-prefix-of (file-name-directory (buffer-file-name))
                                                          (haskell-session-cabal-dir session)))
                                  haskell-sessions)))
@@ -175,9 +175,9 @@
     (if (> (length file) (length cur-dir))
         (if (string= (substring file 0 (length cur-dir))
                      cur-dir)
-            (replace-regexp-in-string 
+            (replace-regexp-in-string
              "^[/\\]" ""
-             (substring file 
+             (substring file
                         (length cur-dir)))
           file)
       file)))
@@ -262,10 +262,16 @@
     (when x
       (cdr x))))
 
-(defun haskell-session-set (s key value) 
+(defun haskell-session-set (s key value)
   "Set the session's `key`."
   (delete-if (lambda (prop) (equal (car prop) key)) s)
   (setf (cdr s) (cons (cons key value)
                       (cdr s))))
 
 (provide 'haskell-session)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
+;;; haskell-session.el ends here


### PR DESCRIPTION
`(eval-when-compile)` is a bad idea when you're actually using cl functions at runtime. Simply requiring the package + suppressing the byte-compilation warnings is a better idea. This PR would fix #81. 
