### PR TITLE
Fix  "Error in timer: (wrong-type-argument characterp nil)" when the point is at the end of the buffer

### DIFF
--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1507,6 +1507,7 @@ is not."
 This function is run by an idle timer to print the type
  automatically if `haskell-doc-mode' is turned on."
   (and haskell-doc-mode
+       (not (eobp))
        (not executing-kbd-macro)
        ;; Having this mode operate in the minibuffer makes it impossible to
        ;; see what you're doing.


### PR DESCRIPTION
for newest emacs snapshot, timer will not drop error message any more.
and "(char-syntax (char-after)) " of haskell-ident-at-point  will throw error  message now.
