### PR TITLE
fix `haskell-indent-at-point' error if point is at the end of the buffer

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -353,8 +353,10 @@ May return a qualified name."
   (save-excursion
     ;; Skip whitespace if we're on it.  That way, if we're at "map ", we'll
     ;; see the word "map".
-    (if (eq ?  (char-syntax (char-after)))
+    (if (and (not (eobp))
+             (eq ?  (char-syntax (char-after))))
         (skip-chars-backward " \t"))
+
     (let ((case-fold-search nil))
       (multiple-value-bind (start end)
           (if (looking-at "\\s_")


### PR DESCRIPTION
fix `haskell-indent-at-point' error if point is at the end of the buffer
