### PR TITLE
Haskell header sorting improvements.

### DIFF
--- a/examples/init.el
+++ b/examples/init.el
@@ -78,6 +78,9 @@
   ;; Jump to the definition of the current symbol.
   (define-key haskell-mode-map (kbd "M-.") 'haskell-mode-tag-find)
 
+  ;; Sort import statements on save
+  (add-hook 'before-save-hook 'haskell-sort-imports nil 'make-it-local)
+
   ;; Indent the below lines on columns after the current column.
   (define-key haskell-mode-map (kbd "C-<right>")
     (lambda ()

--- a/general-sort.el
+++ b/general-sort.el
@@ -1,0 +1,112 @@
+;;; general-sort.el --- General field sorting function
+
+;; Copyright (C) 2013  Alexander Kjeldaas
+
+;; Author: Alexander Kjeldaas <astor@astor-SATELLITE-C870-147>
+;; Keywords: unix
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This is a general fields sorting function much like
+;; `sort-regexp-fields', but with an extra argument that selects which
+;; regexp function to use.  Emacs provides both fast-and-erroneous and
+;; slow-and-correct versions (the default and the posix version).
+
+;;; Code:
+
+(require 'sort)
+
+;;;###autoload
+(defun general-sort-regexp-fields (reverse record-regexp key-regexp beg end
+                                   rx-fn)
+  "Sort the region lexicographically as specified by RECORD-REGEXP and KEY.
+
+RECORD-REGEXP specifies the textual units which should be sorted.
+  For example, to sort lines RECORD-REGEXP would be \"^.*$\"
+KEY specifies the part of each record (ie each match for RECORD-REGEXP)
+  is to be used for sorting.
+  If it is \"\\\\digit\" then the digit'th \"\\\\(...\\\\)\" match field from
+  RECORD-REGEXP is used.
+  If it is \"\\\\&\" then the whole record is used.
+  Otherwise, it is a regular-expression for which to search within the record.
+If a match for KEY is not found within a record then that record is ignored.
+
+With a negative prefix arg sorts in reverse order.
+
+The variable `sort-fold-case' determines whether alphabetic case affects
+the sort order.
+
+For example: to sort lines in the region by the first word on each line
+ starting with the letter \"f\",
+ RECORD-REGEXP would be \"^.*$\" and KEY would be \"\\\\=\\<f\\\\w*\\\\>\"
+
+RX-FN is the forward regexp search function to use.  Typically
+this should be `re-search-forward' or `posix-search-forward'"
+  ;; using negative prefix arg to mean "reverse" is now inconsistent with
+  ;; other sort-.*fields functions but then again this was before, since it
+  ;; didn't use the magnitude of the arg to specify anything.
+  (interactive "P\nsRegexp specifying records to sort:
+sRegexp specifying key within record: \nr")
+  (cond ((or (equal key-regexp "") (equal key-regexp "\\&"))
+	 (setq key-regexp 0))
+	((string-match "\\`\\\\[1-9]\\'" key-regexp)
+	 (setq key-regexp (- (aref key-regexp 1) ?0))))
+  (save-excursion
+    (save-restriction
+      (narrow-to-region beg end)
+      (goto-char (point-min))
+      (let (sort-regexp-record-endn
+	    (sort-regexp-fields-regexp record-regexp))
+	(funcall rx-fn sort-regexp-fields-regexp nil t)
+	(setq sort-regexp-record-end (point))
+	(goto-char (match-beginning 0))
+	(sort-subr reverse
+                   (function (lambda ()
+                     (general-sort-regexp-fields-next-record rx-fn)))
+		   (function (lambda ()
+			       (goto-char sort-regexp-record-end)))
+		   (function (lambda ()
+			       (let ((n 0))
+				 (cond ((numberp key-regexp)
+					(setq n key-regexp))
+				       ((funcall rx-fn
+					  key-regexp sort-regexp-record-end t)
+					(setq n 0))
+				       (t (throw 'key nil)))
+				 (condition-case ()
+				     (cons (match-beginning n)
+					   (match-end n))
+				   ;; if there was no such register
+				   (error (throw 'key nil)))))))))))
+
+;; Move to the beginning of the next match for record-regexp,
+;; and set sort-regexp-record-end to the end of that match.
+;; If the next match is empty and does not advance point,
+;; skip one character and try again.
+(defun general-sort-regexp-fields-next-record (rx-fn)
+  (let ((oldpos (point)))
+    (and (funcall rx-fn sort-regexp-fields-regexp nil 'move)
+	 (setq sort-regexp-record-end (match-end 0))
+	 (if (= sort-regexp-record-end oldpos)
+	     (progn
+	       (forward-char 1)
+	       (funcall rx-fn sort-regexp-fields-regexp nil 'move)
+	       (setq sort-regexp-record-end (match-end 0)))
+	   t)
+	 (goto-char (match-beginning 0)))))
+
+(provide 'general-sort)
+;;; general-sort.el ends here

--- a/haskell-sort-imports.el
+++ b/haskell-sort-imports.el
@@ -21,58 +21,109 @@
 ;; License along with this program.  If not, see
 ;; <http://www.gnu.org/licenses/>.
 
+(require 'general-sort)
+
 (defvar haskell-sort-imports-regexp
-  (concat "^\\(import[ ]+\\)"
+  (concat "^"
+          ;; Optional multi-line comment that precedes the import
+          ;; statement.  This must be separated from the import by a
+          ;; single newline, or else it doesn't belong to the import.
+          "\\([ ]*--.*\n\\)*"
+          "import[ ]+"
           "\\(qualified \\)?"
           "[ ]*\\(\"[^\"]*\" \\)?"
-          "[ ]*\\([A-Za-z0-9_.']*.*\\)"))
+          ;; This (4) is the group we sort on.
+          "[ ]*\\([A-Za-z0-9_.']*.*\\)"
+          ;; This last optional regexp covers the (..) last part of
+          ;; the import statement which we allow to cover multiple
+          ;; lines.  We don't include it in the regexp field we sort
+          ;; on though.
+          ;; Note that by default emacs will not return the longest
+          ;; match, only the first match, so we need to use the posix
+          ;; regexp functions for this part of the regexp to match.
+          "\\((\\([^)]\n?\\)*).*\\)?"))
+
+(defvar haskell-sort-imports-stop-regexp
+  (concat "^[ ]*\\(::"
+          "\\|[a-zA-Z0-9 ]*="
+          "\\|[a-zA-Z0-9 ]*<-"
+          "\\|[a-zA-Z0-9 ()]*where"
+          "\\|type"
+          ;; We don't sort ifdefs correctly
+          "\\|#[ ]*if"
+          "\\|#[ ]*endif"
+          ;; Some projects use this comment-style to separate import
+          ;; sections.  We shouldn't sort across this boundary.
+          "\\|---------------"
+          "\\|data\\)")
+  "A regexp indicating the beginning/end of a region containing
+  import statements.")
 
 ;;;###autoload
-(defun haskell-sort-imports ()
+(defun haskell-sort-imports (&optional silent)
   "Sort the import list at the point."
   (interactive)
-  (when (haskell-sort-imports-line-match)
-    (let ((current-line (buffer-substring-no-properties
-                         (line-beginning-position)
-                         (line-end-position)))
-          (col (current-column)))
-      (if (use-region-p)
-          (haskell-sort-imports-sort-imports-at (region-beginning)
-                                                (region-end)
-                                                t)
-        (haskell-sort-imports-sort-imports-at
-         (save-excursion (haskell-sort-imports-goto-modules-start/end
-                          'previous-line)
-                         (point))
-         (save-excursion (haskell-sort-imports-goto-modules-start/end
-                          'next-line)
-                         (point))
-         nil)))))
+  (if (use-region-p)
+      (haskell-sort-imports-sort-imports-at (region-beginning)
+                                            (region-end))
+      (let* ((stop-rx haskell-sort-imports-stop-regexp)
+             (import-rx haskell-sort-imports-regexp)
+             ;; From current point, where does import region
+             ;; begin/end?
+             (begin (or (save-excursion
+                          (re-search-backward stop-rx (point-min) t))
+                        (point-min)))
+             (end (or (save-excursion
+                        (re-search-forward stop-rx (point-max) t))
+                      (point-max)))
+             ;; Are there any imports between begin/end - i.e. is
+             ;; point in the import region at all?
+             (importp (save-excursion
+                        (goto-char begin)
+                        (posix-search-forward import-rx end t)))
+             ;; From a global view of the buffer, where does the
+             ;; import region begin/end?
+             (global-begin (save-excursion
+                             (goto-char (point-min))
+                             (posix-search-forward import-rx (point-max) t)))
+             (global-end (save-excursion
+                           (goto-char (point-max))
+                           (posix-search-backward import-rx (point-min) t)))
+             ;; Is there any "junk" in the global import area or is it
+             ;; clean?
+             (global-junkp (save-excursion
+                             (goto-char global-begin)
+                             (re-search-forward stop-rx global-end t))))
 
-(defun haskell-sort-imports-sort-imports-at (begin end region)
+        (cond
+          ;; We're in an import section, sort what we see around us.
+          (importp
+           (let ((current-line (buffer-substring-no-properties
+                                (line-beginning-position)
+                                (line-end-position)))
+                 (col (current-column)))
+             (haskell-sort-imports-sort-imports-at begin end)
+             ;; Try to find back to where we were in the import
+             ;; section..
+             (let ((line (save-excursion (goto-char end)
+                                         (search-backward current-line))))
+               (goto-char (+ line col)))))
+          ((not (and begin end))
+           (or silent (message "No import section found")))
+          (global-junkp
+           (or silent (message "Junk found in import section, not sorting")))
+          (t
+           ;; Just sort the global import section
+           (haskell-sort-imports-sort-imports-at global-begin global-end))))))
+
+
+(defun haskell-sort-imports-sort-imports-at (begin end)
   (save-excursion
-    (sort-regexp-fields nil
-                        haskell-sort-imports-regexp
-                        "\\4"
-                        begin end))
-  (when (not region)
-    (let ((line (save-excursion (goto-char end)
-                                (search-backward current-line))))
-      (goto-char (+ line col)))))
-
-(defun haskell-sort-imports-line-match ()
-  "Try to match the current line as a regexp."
-  (let ((line (buffer-substring-no-properties (line-beginning-position)
-                                              (line-end-position))))
-    (if (string-match "^import " line)
-        line
-      nil)))
-
-(defun haskell-sort-imports-goto-modules-start/end (direction)
-  "Skip a bunch of consequtive import lines up/down."
-  (while (not (or (equal (point)
-                         (point-max))
-                  (not (haskell-sort-imports-line-match))))
-    (funcall direction)))
+    (let (sort-fold-case)
+      (general-sort-regexp-fields nil
+                                  haskell-sort-imports-regexp
+                                  "\\4"
+                                  begin end
+                                  'posix-search-forward))))
 
 (provide 'haskell-sort-imports)


### PR DESCRIPTION
-  Support sorting imports where an import cover multiple lines.

Example:

``` haskell
import           Snap.Internal.Http.Types hiding (addHeader,
                                                  setContentType,
                                                  setHeader)
import qualified Snap.Internal.Http.Types       as H
import           Snap.Internal.Parsing
import           Snap.Internal.Types            (evalSnap)
import           Snap.Iteratee                  hiding (map)
import           Snap.Core                      hiding ( addHeader
                                                       , setContentType
                                                       , setHeader )
import qualified Snap.Types.Headers             as H
```

Unfortunately, the regexp that cover multiple lines requires a regexp
engine that chooses the longest match for a string, something that
emacs does not do by default.  Thus this patch includes a
generalization of the sort-regexp-fields from emacs' sort.el in
general-sort.el.  We use this version with the 'posix-search-forward
regexp function which returns the longest match.
-  Support sorting of imports that are preceeded by a comment.  The
  comment can span multiple lines.

Example:

``` haskell
import           Snap.Internal.Http.Types hiding (addHeader,
                                                  setContentType,
                                                  setHeader)
import qualified Snap.Internal.Http.Types       as H
-- This is needed too!
-- And this is a multi-line comment
import           Snap.Internal.Parsing
import           Snap.Internal.Types            (evalSnap)
import           Snap.Iteratee                  hiding (map)
import           Snap.Core                      hiding ( addHeader
                                                       , setContentType
                                                       , setHeader )
-- Because of .. whatever
import qualified Snap.Types.Headers             as H
```
-  Remove the need to have point on a line starting with ^import
  for sorting to work.  Instead we use a regexp that indicate what
  is "out-of-bounds" and restrict the region to sort to that area.
-  If point is outside of the import region, locate the import section
  in the buffer and sort it, unless the section contains 'fishy' text,
  including
  - CPP directives
  - The separator "--------" which is sometimes used to explicitly
    separate imports into sections which should be sorted
    independently.
-  I think haskell-sort-imports now should be safe to add to
  before-save-hook like so:

``` emacs-lisp
(defun my-haskell-mode-hook ()
   ...
  (add-hook 'before-save-hook 'haskell-sort-imports nil 'make-it-local)
   ...)
```
