### PR TITLE
trim string value before compare in haskell-indent

### DIFF
--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -654,7 +654,8 @@ Returns the location of the start of the comment, nil otherwise."
          (is-where
           (string-match "where[ \t]*" haskell-indent-current-line-first-ident))
          (diff-first                 ; not a function def with the same name
-          (not(string= valname-string haskell-indent-current-line-first-ident)))
+          (not(string= (haskell-trim valname-string)
+                       (haskell-trim haskell-indent-current-line-first-ident))))
          ;; (is-type-def
          ;;  (and rhs-sign (eq (char-after rhs-sign) ?\:)))
          (test (string


### PR DESCRIPTION
in haskell-indent, 

``` haskell
oneChar :: Char -> Doc
oneChar char = undefine
```

The above can be correctly indent by cycle-indent while the below can't

``` haskell
oneChar      :: Char -> Doc
oneChar char = undefine
```

It is because we are using "string=" to compare "oneChar " and "oneChar&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;", the indenter thinks they are not the same variables. 
