### PR TITLE
Tiny fix: update conid regex to accomodate DataKinds.

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -272,7 +272,8 @@ Returns keywords suitable for `font-lock-keywords'."
 
          ;; We allow _ as the first char to fit GHC
          (varid "\\b[[:lower:]_][[:alnum:]'_]*\\b")
-         (conid "\\b[[:upper:]][[:alnum:]'_]*\\b")
+         ;; We allow ' preceding conids because of DataKinds/PolyKinds
+         (conid "\\b'?[[:upper:]][[:alnum:]'_]*\\b")
 	 (modid (concat "\\b" conid "\\(\\." conid "\\)*\\b"))
          (qvarid (concat modid "\\." varid))
          (qconid (concat modid "\\." conid))


### PR DESCRIPTION
The recent `DataKinds` extension mandates differentiation between type and constructor names, so `data T = T` becomes `data T = 'T`. I updated the regex for `conid` to allow for that.
