### PR TITLE
Highlight top-level declarations even if newlines are present.

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -315,7 +315,7 @@ Returns keywords suitable for `font-lock-keywords'."
 	 ;; Top-level declarations
 	 (topdecl-var
 	  (concat line-prefix "\\(" varid "\\)\\s-*\\([
-]*\\s-+\\)\\("
+]*\\s-+\\)*\\("
                   ;; A toplevel declaration can be followed by a definition
                   ;; (=), a type (::) or (∷), a guard, or a pattern which can
                   ;; either be a variable, a constructor, a parenthesized


### PR DESCRIPTION
This should allow the top-level declarations to be properly identified even if the information used to identify it as such is not on the same line. Accounts for the fact that

```
f
:: a -> a
```

is not valid but

```
f
 :: a -> a
```

is.
Before:
![before](https://f.cloud.github.com/assets/893115/608949/ce5ade6a-cd6d-11e2-8fb7-0817e50cb3ba.png)

After:
![after](https://f.cloud.github.com/assets/893115/608951/d65c5652-cd6d-11e2-959e-6f09bb007dba.png)

Known issues:
If written in this style, the declaration doesn't seem to be promptly highlighted. For example, the moment I write `f ::`, `f` is detected and highlighted as being a declaration. This doesn't seem to happen straight away if a newline is present. The colouring only applies after reloading the file or reloading haskell-mode or running `font-lock-fontify-block` on relevant block or `font-lock-fontify-buffer`. I'm unsure why this happens, I probably missed something.
