### PR TITLE
Silence cl byte compilation warnings

### DIFF
--- a/haskell-align-imports.el
+++ b/haskell-align-imports.el
@@ -62,7 +62,7 @@
 ;; License along with this program.  If not, see
 ;; <http://www.gnu.org/licenses/>.
 
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (defvar haskell-align-imports-regexp
   (concat "^\\(import[ ]+\\)"
@@ -171,3 +171,9 @@
                                      (line-end-position) t 1)))))
 
 (provide 'haskell-align-imports)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
+;;; haskell-align-imports.el ends here

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -31,7 +31,7 @@
 
 ;; (defun haskell-cabal-extract-fields-from-doc ()
 ;;   (require 'xml)
-;;   (require 'cl)
+;;   (with-no-warnings (require 'cl))
 ;;   (let ((section (completing-read
 ;;                   "Section: "
 ;;                   '("general-fields" "library" "executable" "buildinfo"))))
@@ -46,7 +46,7 @@
 ;;          (fields (mapcar (lambda (sym) (substring-no-properties sym 0 -1)) syms)))
 ;;     fields))
 
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (declare-function haskell-read-directory-name "haskell-process.el" (prompt default))
 
@@ -225,5 +225,9 @@
     "help"))
 
 (provide 'haskell-cabal)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-cabal.el ends here

--- a/haskell-checkers.el
+++ b/haskell-checkers.el
@@ -8,7 +8,7 @@
 ;; Status:  distributed under terms of GPL2 or above
 
 (require 'compile)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (defgroup haskell-checkers nil
   "Run HLint as inferior of Emacs, parse error messages."
@@ -156,5 +156,9 @@ name - user visible name for this mode"
 (hs-checkers-setup scan "HScan")
 
 (provide 'haskell-checkers)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-checkers.el ends here

--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -126,7 +126,7 @@
 
 (require 'haskell-mode)
 (require 'syntax)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 ;;;###autoload
 ;; As `cl' defines macros that `imenu' uses, we must require them at
@@ -714,5 +714,9 @@ Invokes `haskell-decl-scan-mode-hook'."
 ;; Provide ourselves:
 
 (provide 'haskell-decl-scan)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-decl-scan.el ends here

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -354,7 +354,7 @@
 (require 'haskell-mode)
 (require 'inf-haskell)
 (require 'imenu)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (defgroup haskell-doc nil
   "Show Haskell function types in echo area."
@@ -1984,5 +1984,9 @@ This function switches to and potentially loads many buffers."
 ;;@section Token
 
 (provide 'haskell-doc)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-doc.el ends here

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -98,7 +98,7 @@
 
 (require 'haskell-mode)
 (require 'font-lock)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (defcustom haskell-font-lock-symbols nil
   "Display \\ and -> and such using symbols in fonts.
@@ -644,5 +644,9 @@ Invokes `haskell-font-lock-hook' if not nil."
 ;; Provide ourselves:
 
 (provide 'haskell-font-lock)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-font-lock.el ends here

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -89,7 +89,7 @@
 ;;; Code:
 
 (require 'haskell-string)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (defvar haskell-literate)
 
@@ -1579,5 +1579,9 @@ Invokes `haskell-indent-hook' if not nil."
     (turn-off-haskell-indent)))
 
 (provide 'haskell-indent)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-indent.el ends here

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -34,7 +34,7 @@
 ;;; Code:
 
 (require 'syntax)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 ;; Dynamically scoped variables.
 (defvar following-token)
@@ -1002,4 +1002,9 @@ Preserves indentation and removes extra whitespace"
       (forward-comment (buffer-size)))))
 
 (provide 'haskell-indentation)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
 ;;; haskell-indentation.el ends here

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -28,7 +28,7 @@
 (require 'haskell-process)
 (require 'haskell-session)
 (require 'haskell-show)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 ;; Dynamically scoped variables.
 (defvar haskell-process-prompt-regex)
@@ -507,5 +507,9 @@ Key bindings:
 (add-hook 'kill-buffer-hook 'haskell-interactive-kill)
 
 (provide 'haskell-interactive-mode)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-interactive-mode.el ends here

--- a/haskell-menu.el
+++ b/haskell-menu.el
@@ -28,7 +28,7 @@
 (require 'haskell-compat)
 (require 'haskell-session)
 (require 'haskell-process)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (defcustom haskell-menu-buffer-name
   "*haskell-menu*"
@@ -131,4 +131,5 @@ Letters do not insert themselves; instead, they are commands."
 ;; Local Variables:
 ;; byte-compile-warnings: (not cl-functions)
 ;; End:
+
 ;;; haskell-menu.el ends here

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -149,7 +149,7 @@
 (require 'haskell-align-imports)
 (require 'haskell-sort-imports)
 (require 'haskell-string)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 ;; FIXME: code-smell: too many forward decls for haskell-session are required here
 (defvar haskell-session)
@@ -880,5 +880,9 @@ This function will be called with no arguments.")
 ;; Provide ourselves:
 
 (provide 'haskell-mode)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; haskell-mode.el ends here

--- a/haskell-package.el
+++ b/haskell-package.el
@@ -25,7 +25,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 ;; Dynamically scoped variables.
 ;; TODO What actually sets this?
@@ -151,3 +151,9 @@
       lines))))
 
 (provide 'haskell-package)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
+;;; haskell-package.el ends here

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -28,7 +28,7 @@
 (require 'haskell-mode)
 (require 'haskell-session)
 (require 'haskell-compat)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 ;; FIXME: haskell-process shouldn't depend on haskell-interactive-mode to avoid module-dep cycles
 (defvar haskell-interactive-greetings)
@@ -909,3 +909,9 @@ to be loaded by ghci."
                response))))
 
 (provide 'haskell-process)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
+;;; haskell-process.el ends here

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -27,7 +27,7 @@
 
 (require 'haskell-cabal)
 (require 'haskell-string)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (declare-function haskell-interactive-mode "haskell-interactive-mode" (session))
 (declare-function haskell-kill-session-process "haskell-process" (&optional session))
@@ -320,4 +320,5 @@
 ;; Local Variables:
 ;; byte-compile-warnings: (not cl-functions)
 ;; End:
+
 ;;; haskell-session.el ends here

--- a/haskell-show.el
+++ b/haskell-show.el
@@ -27,7 +27,7 @@
 
 (defvar sexp-show "sexp-show")
 (require 'haskell-string)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 (defun haskell-show-replace-region ()
   "Replace the given region with a pretty printed version."
@@ -251,3 +251,9 @@
           s))
 
 (provide 'haskell-show)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
+;;; haskell-show.el ends here

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -36,7 +36,7 @@
 (require 'haskell-mode)
 (require 'haskell-decl-scan)
 (require 'haskell-cabal)
-(require 'cl)
+(with-no-warnings (require 'cl))
 
 ;; Dynamically scoped variables.
 (defvar find-tag-marker-ring)
@@ -780,5 +780,9 @@ we load it."
     (if url (browse-url url) (error "Local file doesn't exist"))))
 
 (provide 'inf-haskell)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
 
 ;;; inf-haskell.el ends here


### PR DESCRIPTION
byte-recompile-directory-ing from within Emacs (and installing haskell-mode from MELPA) still causes warnings like

```
Warning: cl package required at runtime 
```

and

```
haskell-cabal.el:176:33:Warning: function `reduce' from cl package called at runtime
```

This turns them off for good.
