### PR TITLE
Match LANGUAGE pragma suggestions more precisely

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -462,7 +462,7 @@ to be loaded by ghci."
 
 (defun haskell-process-trigger-suggestions (session msg file line)
   "Trigger prompting to add any extension suggestions."
-  (cond ((string-match "\\-X\\([A-Z][A-Za-z]+\\)" msg)
+  (cond ((let ((case-fold-search nil)) (string-match " -X\\([A-Z][A-Za-z]+\\)" msg))
          (when haskell-process-suggest-language-pragmas
            (haskell-process-suggest-pragma session "LANGUAGE" (match-string 1 msg) file)))
         ((string-match " The \\(qualified \\)?import of[ ]`\\([^ ]+\\)' is redundant" msg)


### PR DESCRIPTION
The old behaviour matched one of my projects directory name (pontarius-xmpp) as a LANGUAGE pragma, leading to suggestion spam
