### PR TITLE
Auto-import in GHCi process of depended modules on load

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -124,6 +124,19 @@ has changed?"
   :type 'boolean
   :group 'haskell-interactive)
 
+(defcustom haskell-process-auto-import-loaded-modules
+  nil
+  "Auto import the modules reported by GHC to have been loaded?"
+  :type 'boolean
+  :group 'haskell-interactive)
+
+(defcustom haskell-process-auto-send-import-statements
+  nil
+  "Automatically send all import statements in the buffer after
+loading it?"
+  :type 'boolean
+  :group 'haskell-interactive)
+
 (defvar haskell-process-prompt-regex "\\(^[> ]*> $\\|\n[> ]*> $\\)")
 (defvar haskell-reload-p nil)
 
@@ -248,7 +261,7 @@ changed. Restarts the process if that is the case."
   (interactive)
   (save-buffer)
   (haskell-interactive-mode-reset-error (haskell-session))
-  (haskell-process-file-loadish (concat "load " (buffer-file-name)) nil))
+  (haskell-process-file-loadish (concat "load " (buffer-file-name)) nil (current-buffer)))
 
 ;;;###autoload
 (defun haskell-process-reload-file ()
@@ -256,7 +269,7 @@ changed. Restarts the process if that is the case."
   (interactive)
   (save-buffer)
   (haskell-interactive-mode-reset-error (haskell-session))
-  (haskell-process-file-loadish "reload" t))
+  (haskell-process-file-loadish "reload" t (current-buffer)))
 
 ;;;###autoload
 (defun haskell-process-load-or-reload (&optional toggle)
@@ -270,7 +283,7 @@ changed. Restarts the process if that is the case."
                         "Now running :load <buffer-filename>.")))
     (if haskell-reload-p (haskell-process-reload-file) (haskell-process-load-file))))
 
-(defun haskell-process-file-loadish (command reload-p)
+(defun haskell-process-file-loadish (command reload-p &optional module-buffer)
   (let ((session (haskell-session)))
     (haskell-session-current-dir session)
     (when haskell-process-check-cabal-config-on-load
@@ -279,7 +292,7 @@ changed. Restarts the process if that is the case."
       (haskell-process-queue-command
        process
        (make-haskell-command
-        :state (list session process command reload-p)
+        :state (list session process command module-buffer reload-p)
         :go (lambda (state)
               (haskell-process-send-string
                (cadr state) (format ":%s" (caddr state))))
@@ -289,7 +302,8 @@ changed. Restarts the process if that is the case."
         :complete (lambda (state response)
                     (haskell-process-load-complete
                      (car state) (cadr state) response
-                     (cadddr state))))))))
+                     (cadddr state)
+                     (cadddr (cdr state)))))))))
 
 ;;;###autoload
 (defun haskell-process-cabal-build ()
@@ -384,22 +398,84 @@ to be loaded by ghci."
   (setf (cdddr state) (list (length buffer)))
   nil)
 
-(defun haskell-process-load-complete (session process buffer reload)
+(defun haskell-process-load-complete (session process buffer module-buffer reload)
   "Handle the complete loading response."
-  (cond ((haskell-process-consume process "Ok, modules loaded: \\(.+\\)$")
-         (let ((cursor (haskell-process-response-cursor process)))
+  (cond ((haskell-process-consume process "Ok, modules loaded: \\(.+\\)\\.$")
+         (let* ((modules (haskell-process-extract-modules buffer))
+                (cursor (haskell-process-response-cursor process)))
            (haskell-process-set-response-cursor process 0)
            (let ((warning-count 0))
              (while (haskell-process-errors-warnings session process buffer)
                (setq warning-count (1+ warning-count)))
              (haskell-process-set-response-cursor process cursor)
-             (haskell-mode-message-line (if reload "Reloaded OK." "OK.")))))
-        ((haskell-process-consume process "Failed, modules loaded: \\(.+\\)$")
-         (let ((cursor (haskell-process-response-cursor process)))
+             (haskell-process-import-modules process (car modules) module-buffer)
+             (haskell-mode-message-line
+              (format (if reload "Reloaded OK %s." "OK %s.")
+                      (format "(imported %d modules: %s)"
+                              (length (car modules))
+                              (haskell-string-ellipsis (cdr modules) 80)))))))
+        ((haskell-process-consume process "Failed, modules loaded: \\(.+\\)\\.$")
+         (let* ((modules (haskell-process-extract-modules buffer))
+                (cursor (haskell-process-response-cursor process)))
            (haskell-process-set-response-cursor process 0)
            (while (haskell-process-errors-warnings session process buffer))
            (haskell-process-set-response-cursor process cursor)
-           (haskell-interactive-mode-compile-error session "Compilation failed.")))))
+           (haskell-process-import-modules process (car modules) module-buffer)
+           (haskell-interactive-mode-compile-error
+            session
+            (format "Compilation failed (but imported %d modules: %s)."
+                    (length (car modules))
+                    (haskell-string-ellipsis (cdr modules) 80)))))))
+
+(defun haskell-process-extract-modules (buffer)
+  "Extract the modules from the process buffer."
+  (let* ((modules-string (match-string 1 buffer))
+         (modules (split-string modules-string ", ")))
+    (cons modules modules-string)))
+
+(defun haskell-process-import-modules (process modules module-buffer)
+  "Import `modules' with :m +, and send any import statements
+from `module-buffer'."
+  (when haskell-process-auto-import-loaded-modules
+    (haskell-process-queue-command
+     process
+     (make-haskell-command
+      :state (cons process modules)
+      :go (lambda (state)
+            (haskell-process-send-string
+             (car state)
+             (format ":m + %s" (mapconcat 'identity (cdr state) " ")))))))
+  (when haskell-process-auto-send-import-statements
+    (dolist (import (haskell-process-get-imports module-buffer))
+     (haskell-process-queue-command
+      process
+      (make-haskell-command
+       :state (cons process import)
+       :go (lambda (state)
+             (haskell-process-send-string (car state) (cdr state))))))))
+
+(defun haskell-process-get-imports (module-buffer)
+  "Get imports in the current buffer."
+  (with-current-buffer module-buffer
+    (save-excursion
+      (goto-char (point-min))
+      (let ((imports (list))
+            (continue t))
+        (while continue
+          (if (search-forward-regexp "^import " nil t 1)
+              (push (replace-regexp-in-string
+                     "[\n]+"
+                     " "
+                     (buffer-substring-no-properties
+                      (line-beginning-position)
+                      (or (let ((end (search-forward-regexp "^[^\t ]" nil t 1)))
+                            (when end
+                              (goto-char (line-beginning-position))
+                              (1+ (search-backward-regexp "[^\n\t ]"))))
+                          (point-max))))
+                    imports)
+            (setq continue nil)))
+        imports))))
 
 (defun haskell-process-live-build (process buffer echo-in-repl)
   "Show live updates for loading files."

--- a/haskell-string.el
+++ b/haskell-string.el
@@ -18,6 +18,14 @@
   "Is x string a prefix of y string?"
   (string= x (substring y 0 (min (length y) (length x)))))
 
+;;;###autoload
+(defun haskell-string-ellipsis (string n)
+  "Ellipsize a string."
+  (let ((e (haskell-string-take string n)))
+    (if (> (length string) (length e))
+        (concat e "…")
+      string)))
+
 (defun haskell-string ())
 
 (provide 'haskell-string)


### PR DESCRIPTION
The purpose of this change is to battle of the problem of type information not being in scope when doing things in the GHCi REPL. If you're loading with normal GHCi interpreted, then you get all type information. But if you're using `-fobject-code`, like you do in a real project of 50+ modules, that information isn't available.

So what this does is when GHCi says:

> ```
> OK, modules loaded: Foo, Bar.
> ```

Then `haskell-process-auto-import-loaded-modules` will run:

```
> :m + Foo Bar
```

And if your project is:

```
module Zot where
import X as XXX
import T (p)
```

then `haskell-process-auto-send-import-statements` will run:

> import X as XXX
> import X (p)

This means you're pretty much working with all the type information—of top-level symbols and data types—available.
