### PR TITLE
Don't jump a whole line on DEL at the leftmost indentation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,10 @@ See also [[https://github.com/haskell/haskell-mode/compare/v13.07...v13.08][deta
 
 - Add support for [[http://www.haskell.org/ghc/docs/latest/html/users_guide/syntax-extns.html#lambda-case][LambdaCase]] syntax extension to `haskell-indentation`
 
+- Change `haskell-indentation-mode' to never jump back a whole line
+  when pressing DEL.  The old behavior can be restored by setting
+  `haskell-indentation-delete-backward-jump-line' to t.
+
 * Changes in 13.7
 
 See also [[https://github.com/haskell/haskell-mode/compare/v13.06...v13.07][detailed Git history]].

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -63,6 +63,11 @@
   :type 'boolean
   :group 'haskell-indentation)
 
+(defcustom haskell-indentation-delete-backward-jump-line nil
+  "Delete backward jumps to the previous line when removing last indentation."
+  :type 'boolean
+  :group 'haskell-indentation)
+
 (defcustom haskell-indentation-delete-indentation t
   "Delete removes indentation."
   :type 'boolean
@@ -392,7 +397,12 @@ Preserves indentation and removes extra whitespace"
                                  (progn (move-to-column ci)
                                         (point))))
                  (t
-                  (delete-char (- 1)))))))
+                  (if (not haskell-indentation-delete-backward-jump-line)
+                      (delete-char (- 1))
+                    (beginning-of-line)
+                    (delete-region (max (point-min) (- (point) 1))
+                                   (progn (move-to-column ci)
+                                          (point)))))))))
     (t (delete-char (- n))))))
 
 (defun haskell-indentation-delete-char (n)


### PR DESCRIPTION
The previous behavior was to jump to the previous line by hitting DEL
just once when there were no indentation points to the left anymore.
This was quite confusing and almost never intended from the user's
point of view.  If the user is still backspacing when there are no
indentation points left, chances are that we screwed up something
already and the user is intending to indent somewhere unknown.  Better
to just fallback to regular DEL behavior then.
