### PR TITLE
Fix bug with certain kinds of indentation.

### DIFF
--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -654,8 +654,10 @@ Returns the location of the start of the comment, nil otherwise."
          (is-where
           (string-match "where[ \t]*" haskell-indent-current-line-first-ident))
          (diff-first                 ; not a function def with the same name
-          (not(string= (haskell-trim valname-string)
-                       (haskell-trim haskell-indent-current-line-first-ident))))
+          (or (null valname-string)
+              (not (string= (haskell-trim valname-string)
+                            (haskell-trim haskell-indent-current-line-first-ident)))))
+
          ;; (is-type-def
          ;;  (and rhs-sign (eq (char-after rhs-sign) ?\:)))
          (test (string


### PR DESCRIPTION
Certain indentation situations cause valname-string to be nil, which haskell-trim does not handle gracefully (naturally, since nil != ""). 
