### PR TITLE
Tweak filename and warning recognition for compilation regexps

### DIFF
--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -63,21 +63,21 @@ The `%s' placeholder is replaced by the current buffer's filename."
 
 (defconst haskell-compilation-error-regexp-alist
   `((,(concat
-       "^\\(?1:[^ \t\r\n]+?\\):"
+       "^\\(?1:.+?\\.\\(?:hs\\|lhs\\|hsc\\)\\):"
        "\\(?:"
        "\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)\\(?:-\\(?5:[0-9]+\\)\\)?" ;; "121:1" & "12:3-5"
        "\\|"
        "(\\(?2:[0-9]+\\),\\(?4:[0-9]+\\))-(\\(?3:[0-9]+\\),\\(?5:[0-9]+\\))" ;; "(289,5)-(291,36)"
        "\\)"
-       ":\\(?6: Warning:\\)?")
+       ":\\(?6:\n?[ \t]+Warning:\\)?")
      1 (2 . 3) (4 . 5) (6 . nil)) ;; error/warning locus
 
     ;; multiple declarations
-    ("^    \\(?:Declared at:\\|            \\) \\(?1:[^ \t\r\n]+\\):\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)$"
+    ("^    \\(?:Declared at:\\|            \\) \\(?1:.+?\\.\\(?:hs\\|lhs\\|hsc\\)\\):\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)$"
      1 2 4 0) ;; info locus
 
     ;; this is the weakest pattern as it's subject to line wrapping et al.
-    (" at \\(?1:[^ \t\r\n]+\\):\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)\\(?:-\\(?5:[0-9]+\\)\\)?[)]?$"
+    (" at \\(?1:.+?\\.\\(?:hs\\|lhs\\|hsc\\)\\):\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)\\(?:-\\(?5:[0-9]+\\)\\)?[)]?$"
      1 2 (4 . 5) 0)) ;; info locus
   "Regexps used for matching GHC compile messages.
 See `compilation-error-regexp-alist' for semantics.")


### PR DESCRIPTION
For example, ghc 7.4 outputs "Warning:" on different line than filename itself
and previous regexps do not handle it:

```
/home/hackerjoe/HelloWorld.hs:23:1-28:
    Warning: The import of `Control.Monad' is redundant
               except perhaps to import instances from `Control.Monad'
             To import instances alone, use: import Control.Monad()
```

Regarding spaces in filenames, they aren't the best idea, but context of
compilation regexps seems to allow reliable filename recognition since
filenames are given as full paths and beginning of filename part is either bol
or space character.
