### PR TITLE
more precise .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.elc
-*~
-haskell-mode-autoloads.el
-haskell-mode.info
-haskell-mode.tmp.texi
-dir
+/haskell-mode-autoloads.el
+/haskell-mode.info
+/haskell-mode.tmp.texi
+/dir


### PR DESCRIPTION
Be more precise about what should be ignored.

Note that *~ belongs in per-user configuration, as it depends on the
editor being used.  It might seem unlikely that vi users will be
working on this particular package, but it's the principle of the
thing!  The right way to do this is:

$ (echo "_~"; echo ".#_[0-9]") > ~/.gitignore-emacs
$ git config --global core.excludesfile ~/.gitignore-emacs
