### PR TITLE
find-haddock fails to translate internal ghc identifiers

### DIFF
--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -772,9 +772,12 @@ we load it."
                             (format "Find documentation of (default %s): " sym)
                           "Find documentation of: ")
                         nil nil sym))))
-  (setq sym (inferior-haskell-map-internal-ghc-ident sym))
   (let* (;; Find the module and look it up in the alist
          (module (inferior-haskell-get-module sym))
+         (full-name (inferior-haskell-map-internal-ghc-ident (concat module "." sym)))
+         (success (string-match "\\(.*\\)\\.\\(.*\\)" full-name))
+         (module (match-string 1 full-name))
+         (sym (match-string 2 full-name))
          (alist-record (assoc module (inferior-haskell-module-alist)))
          (package (nth 1 alist-record))
          (file-name (concat (subst-char-in-string ?. ?- module) ".html"))


### PR DESCRIPTION
`inferior-haskell-find-haddock` looks like it takes both cases where the URL would be incorrect into account:
- Where a specific function in `GHC.Base` should be forwarded to a different module (for example, `GHC.Base.return` should translate to `Control.Monad.return`
- Where the module itself can be translated in its entirety (for example `GHC.List` to `Data.List`)

However, neither case seems to work. The existing call to `inferior-haskell-map-internal-ghc-ident` is done with only the original sym, so it will always fail due to not accounting for the module. Additionally, the URL generation already takes care to separate the module (URL path) from the sym (URL anchor), but the module name and sym are never concatenated before the check nor split again afterwards to create the path and anchor pieces again.

This causes the translation to always fail for internal GHC modules and generating URLs like:

http://www.haskell.org/ghc/docs/latest/html/libraries/base/GHC-Base.html#v:return
http://www.haskell.org/ghc/docs/latest/html/libraries/base/GHC-List.html#v:tail
