### PR TITLE
Fix import.qualified.

### DIFF
--- a/snippets/haskell-mode/import.qualified
+++ b/snippets/haskell-mode/import.qualified
@@ -5,5 +5,5 @@
 # contributor: Luke Hoersten <luke@hoersten.org>
 # --
 import qualified ${1:Module} as ${2:${1:$(let ((name (car (last (split-string yas-text "\\\.")))))
-                                              (if (not (nil-blank-string name)) ""
+                                              (if (= 0 (length name)) ""
                                                   (subseq name 0 1)))}}$0


### PR DESCRIPTION
import.qualified relied on the function `nil-blank-string`, which is not available for all Emacs installs (it wasn't for mine.) Making sure instead that the `name` string is of non-zero length should work just fine, too.
