### PR TITLE
add support for operator symbol anchors to inferior-haskell-find-haddock

### DIFF
--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -69,6 +69,26 @@ Note: doesn't detect if in {--}-style comment."
         (match-string-no-properties 4))))
 
 
+(defvar haskell-utils-operator-name-chars
+  "-!#$%&*+./<=>?@^|~:\\"
+  "Characters that can constitute Haskell operators.")
+
+(defvar haskell-utils-operator-name-regexp
+  (concat "[" haskell-utils-operator-name-chars "]+")
+  "Regexp matching all operator names, including data and type operators.")
+
+(defvar haskell-utils-qualified-operator-name-regexp
+  (concat "\\(\\(?:[[:upper:]][[:alnum:]'_]*\\.\\)+\\)"
+          haskell-utils-operator-name-regexp)
+  "Regexp matching qualified operator names, e.g. ++, Data.Map.!.")
+
+(defun haskell-utils-unqualify-op (op)
+  "Remove module qualification, if any, from operator name OP."
+  (save-match-data
+    (if (string-match haskell-utils-qualified-operator-name-regexp op)
+      (replace-match "" nil nil op 1)
+      op)))
+
 (provide 'haskell-utils)
 
 ;;; haskell-utils.el ends here

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -36,6 +36,7 @@
 (require 'haskell-mode)
 (require 'haskell-decl-scan)
 (require 'haskell-cabal)
+(require 'haskell-utils)
 (with-no-warnings (require 'cl))
 
 ;; Dynamically scoped variables.
@@ -778,14 +779,24 @@ we load it."
          (package (nth 1 alist-record))
          (file-name (concat (subst-char-in-string ?. ?- module) ".html"))
          (local-path (concat (nth 2 alist-record) "/" file-name))
+         ;; Jump to the symbol anchor within Haddock.
+         (symbol-anchor
+          (concat "#v:"
+                  (if (string-match-p haskell-utils-operator-name-regexp sym)
+                    ;; Encode operator names just like haddock does,
+                    ;; but strip any module qualification beforehand since
+                    ;; module would be specified by a file-name anyway.
+                    (mapconcat (lambda (c) (format "-%d-" c))
+                               (haskell-utils-unqualify-op sym)
+                               "")
+                    sym)))
          (url (if (or (eq inferior-haskell-use-web-docs 'always)
                       (and (not (file-exists-p local-path))
                            (eq inferior-haskell-use-web-docs 'fallback)))
                   (concat inferior-haskell-web-docs-base package "/" file-name
-                          ;; Jump to the symbol anchor within Haddock.
-                          "#v:" sym)
+                          symbol-anchor)
                 (and (file-exists-p local-path)
-                     (concat "file://" local-path)))))
+                     (concat "file://" local-path symbol-anchor)))))
     (if url (browse-url url) (error "Local file doesn't exist"))))
 
 (provide 'inf-haskell)

--- a/tests/haskell-utils-tests.el
+++ b/tests/haskell-utils-tests.el
@@ -1,0 +1,22 @@
+;; unit tests for haskell-utils.el
+
+(require 'ert)
+
+(require 'haskell-utils ) ;; implementation under test
+
+(ert-deftest haskell-utils-unqualify-op ()
+  (should (string= (haskell-utils-unqualify-op "++")   "++"))
+  (should (string= (haskell-utils-unqualify-op ":-->") ":-->"))
+  (should (string= (haskell-utils-unqualify-op "<$>")  "<$>"))
+  (should (string= (haskell-utils-unqualify-op "<*>")  "<*>"))
+  (should (string= (haskell-utils-unqualify-op ">>=")  ">>="))
+  (should (string= (haskell-utils-unqualify-op "~>")   "~>"))
+  (should (string= (haskell-utils-unqualify-op ":+:")  ":+:"))
+
+  (should (string= (haskell-utils-unqualify-op "Foo.:+:")           ":+:"))
+  (should (string= (haskell-utils-unqualify-op "Control.Arrrow.~>") "~>"))
+  (should (string= (haskell-utils-unqualify-op "Data.List.++")      "++"))
+  (should (string= (haskell-utils-unqualify-op "L.++")              "++"))
+  (should (string= (haskell-utils-unqualify-op "L.++")              "++"))
+  (should (string= (haskell-utils-unqualify-op "GHC.Base.*")        "*")))
+


### PR DESCRIPTION
For operator anchors encode operator names into sequence of `-<ascii-code>-` strings for each operator character, as haddock does. As operators may be qualified, which is not a rare case for `Data.Map.!` and other container-oriented operators, the function for qualification removal along with tests is introduced. And supply anchor for local paths.

Also, I've added regexps for vanilla and qualified operator names, since the only other place where remotely similar regexp can be found is syntax definitions in haskell-mode.el, but `-` and `\` characters are treated differently there. If this addition seems redundant or if better solution exists, please tell me.
