### PR TITLE
Allow whitespace before settings.

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -133,7 +133,7 @@
     (let ((case-fold-search t))
       (goto-char (point-min))
       (when (re-search-forward
-             (concat "^" (regexp-quote name)
+             (concat "^[ \t]*" (regexp-quote name)
                      ":[ \t]*\\(.*\\(\n[ \t]+[ \t\n].*\\)*\\)")
              nil t)
         (let ((val (match-string 1))


### PR DESCRIPTION
This is essential to pick up the right project root for most non-trivial .cabal files, where "hs-source-dirs:" is indented e.g. below a "library" section etc.
