### PR TITLE
Let haskell-process-hoogle-ident fail silently on error

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -774,15 +774,16 @@ now."
 (defun haskell-process-hoogle-ident (ident)
   "Hoogle for IDENT, returns a list of modules."
   (with-temp-buffer
-    (call-process "hoogle" nil t nil "search" "--exact" ident)
-    (goto-char (point-min))
-    (unless (or (looking-at "^No results found")
-                (looking-at "^package "))
-      (while (re-search-forward "^\\([^ ]+\\).*$" nil t)
-        (replace-match "\\1" nil nil))
-      (remove-if (lambda (a) (string= "" a))
-                 (split-string (buffer-string)
-                               "\n")))))
+    (let ((hoogle-error (call-process "hoogle" nil t nil "search" "--exact" ident)))
+      (goto-char (point-min))
+      (unless (or hoogle-error
+                  (looking-at "^No results found")
+                  (looking-at "^package "))
+        (while (re-search-forward "^\\([^ ]+\\).*$" nil t)
+          (replace-match "\\1" nil nil))
+        (remove-if (lambda (a) (string= "" a))
+                   (split-string (buffer-string)
+                                 "\n"))))))
 
 (defun haskell-process-suggest-remove-import (session file import line)
   "Suggest removing or commenting out IMPORT on LINE."


### PR DESCRIPTION
Small change to let haskell-process-hoogle-ident fail silently if the call to hoogle has a nonzero exit code.

In that case the output won't be valid anyway, however currently the error message is parsed and suggested as the module name to import. (E.g. 'Unknown option --exact' leads to 'import Unknown')

I don't know if failing silently is optimal in this case but at least it does not give wrong results :)

Best,
Markus
