### PR TITLE
Replace 'ido-completing-read' with 'completing-read-function'

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -715,7 +715,7 @@ Brings up the documentation for haskell-mode-hook."
     (cond ((save-excursion (forward-word -1)
                            (looking-at "^import$"))
            (insert " ")
-           (let ((module (ido-completing-read "Module: " (haskell-session-all-modules))))
+           (let ((module (funcall completing-read-function "Module: " (haskell-session-all-modules))))
              (insert module)
              (haskell-mode-format-imports)))
           ((not (string= "" (save-excursion (forward-char -1) (haskell-ident-at-point))))

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -432,7 +432,7 @@ for various things, but is optional."
   "Prompts for a Cabal command to run."
   (interactive)
   (haskell-process-do-cabal
-   (ido-completing-read "Cabal command: "
+   (funcall completing-read-function "Cabal command: "
                         haskell-cabal-commands)))
 
 (defun haskell-process-add-cabal-autogen ()
@@ -755,7 +755,7 @@ now."
            ((> (length modules) 1)
             (when (y-or-n-p (format "Identifier `%s' not in scope, choose module to import?"
                                     ident))
-              (ido-completing-read "Module: " modules)))
+              (funcall completing-read-function "Module: " modules)))
            ((= (length modules) 1)
             (when (y-or-n-p (format "Identifier `%s' not in scope, import `%s'?"
                                     ident

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -200,7 +200,7 @@ If DONTCREATE is non-nil don't create a new session."
 (defun haskell-session-choose ()
   "Find a session by choosing from a list of the current sessions."
   (when haskell-sessions
-    (let* ((session-name (ido-completing-read
+    (let* ((session-name (funcall completing-read-function
                           "Choose Haskell session: "
                           (mapcar 'haskell-session-name haskell-sessions)))
            (session (find-if (lambda (session)


### PR DESCRIPTION
Instead of calling `ido-completing-read` use `funcall completing-read-function` which is a more sane choice if someone does not use `ido` (I'm preferring helm)
