### PR TITLE
Fix error on completion in interactive-mode

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -186,7 +186,8 @@ Key bindings:
 
 (defun haskell-interactive-at-prompt ()
   "If at prompt, returns start position of user-input, otherwise returns nil."
-  (>= (point)
+  (if (>= (point)
+          haskell-interactive-mode-prompt-start)
       haskell-interactive-mode-prompt-start))
 
 (defun haskell-interactive-handle-expr ()


### PR DESCRIPTION
I noticed that when I am in the haskell-interactive repl, TAB-completion does not work.

`*messages*` shows: `haskell-interactive-mode-input-partial: Wrong type argument: integer-or-marker-p, t`

With this completion works for me again.

Best,
Markus
