### PR TITLE
Make haskell-interactive-at-prompt return position

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -186,8 +186,11 @@ Key bindings:
 
 (defun haskell-interactive-at-prompt ()
   "If at prompt, returns start position of user-input, otherwise returns nil."
-  (>= (point)
-      haskell-interactive-mode-prompt-start))
+  (if (>= (point)
+          haskell-interactive-mode-prompt-start)
+      haskell-interactive-mode-prompt-start
+    nil))
+
 
 (defun haskell-interactive-handle-expr ()
   "Handle an inputted expression at the REPL."


### PR DESCRIPTION
Instead of bool

Not sure if it makes a lot of sense, since I don't do a lot of elisp. Also my autocomplete still doesn't work saying `GHCi lacks :complete support`.
