### PR TITLE
Use haskell-process-path-cabal everywhere

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -498,10 +498,10 @@ to be loaded by ghci."
                  (haskell-session-cabal-dir (car state))
                  (format "%s %s"
                          (ecase haskell-process-type
-                           ('ghci "cabal")
-                           ('cabal-repl "cabal")
-                           ('cabal-ghci "cabal")
-                           ('cabal-dev "cabal-dev"))
+                           ('ghci haskell-process-path-cabal)
+                          ('cabal-repl haskell-process-path-cabal)
+                           ('cabal-ghci haskell-process-path-cabal)
+                           ('cabal-dev haskell-process-path-cabal-dev))
                          (caddr state)))))
 
       :live
@@ -541,10 +541,10 @@ to be loaded by ghci."
                :title (format "*%s*" (haskell-session-name (car state)))
                :body msg
                :app-name (ecase haskell-process-type
-                           ('ghci "cabal")
-                           ('cabal-repl "cabal")
-                           ('cabal-ghci "cabal")
-                           ('cabal-dev "cabal-dev"))
+                           ('ghci haskell-process-path-cabal)
+                           ('cabal-repl haskell-process-path-cabal)
+                           ('cabal-ghci haskell-process-path-cabal)
+                           ('cabal-dev haskell-process-path-cabal-dev))
                :app-icon haskell-process-logo
                )))))))))
 


### PR DESCRIPTION
When running `haskell-process-cabal-build`, I was surprised by errors like:

```
-> ":!cd /home/bergey/code/diagrams/lib/ && cabal build
"
<- "/bin/sh: cabal: command not found
```

and further surprised that setting `haskell-process-path-cabal` to an absolute path didn't fix the errors.  With the patch below, I can build my projects, but maybe there's a better way?
