### PR TITLE
Split interaction mode into two minor modes a la indentation

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -523,7 +523,7 @@ to be loaded by ghci."
                  (format "%s %s"
                          (ecase haskell-process-type
                            ('ghci haskell-process-path-cabal)
-                          ('cabal-repl haskell-process-path-cabal)
+                           ('cabal-repl haskell-process-path-cabal)
                            ('cabal-ghci haskell-process-path-cabal)
                            ('cabal-dev haskell-process-path-cabal-dev))
                          (caddr state)))))
@@ -1619,6 +1619,26 @@ function and remove this comment.
            "/"
            (haskell-guess-module-name)
            ".imports")))
+
+(defvar interactive-haskell-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-l") 'haskell-process-load-or-reload)
+    (define-key map (kbd "C-c C-t") 'haskell-process-do-type)
+    (define-key map (kbd "C-c C-i") 'haskell-process-do-info)
+    (define-key map (kbd "M-.") 'haskell-mode-jump-to-def-or-tag)
+    (define-key map (kbd "C-c C-k") 'haskell-interactive-mode-clear)
+    (define-key map (kbd "C-c C-c") 'haskell-process-cabal-build)
+    (define-key map (kbd "C-c c") 'haskell-process-cabal)
+    (define-key map [?\C-c ?\C-b] 'haskell-interactive-switch)
+    (define-key map [?\C-c ?\C-z] 'haskell-interactive-switch)
+    map)
+  "Keymap for using haskell-interactive-mode.")
+
+;;;###autoload
+(define-minor-mode interactive-haskell-mode
+  "Minor mode for enabling haskell-process interaction."
+  :lighter " Interactive"
+  :keymap interactive-haskell-mode-map)
 
 (provide 'haskell-process)
 

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -792,6 +792,35 @@ we load it."
          (url (concat url "#v:" sym)))
     (if url (browse-url url) (error "Local file doesn't exist"))))
 
+(defvar inf-haskell-mode-map
+  (let ((map (make-sparse-keymap)))
+    ;; (define-key map [?\M-C-x]     'inferior-haskell-send-defun)
+    ;; (define-key map [?\C-x ?\C-e] 'inferior-haskell-send-last-sexp)
+    ;; (define-key map [?\C-c ?\C-r] 'inferior-haskell-send-region)
+    (define-key map [?\C-x ?\C-d] 'inferior-haskell-send-decl)
+    (define-key map [?\C-c ?\C-z] 'switch-to-haskell)
+    (define-key map [?\C-c ?\C-l] 'inferior-haskell-load-file)
+    ;; I think it makes sense to bind inferior-haskell-load-and-run to C-c
+    ;; C-r, but since it used to be bound to `reload' until June 2007, I'm
+    ;; going to leave it out for now.
+    ;; (define-key map [?\C-c ?\C-r] 'inferior-haskell-load-and-run)
+    (define-key map [?\C-c ?\C-b] 'switch-to-haskell)
+    ;; (define-key map [?\C-c ?\C-s] 'inferior-haskell-start-process)
+    ;; That's what M-; is for.
+    (define-key map (kbd "C-c C-t") 'inferior-haskell-type)
+    (define-key map (kbd "C-c C-i") 'inferior-haskell-info)
+    (define-key map (kbd "C-c M-.") 'inferior-haskell-find-definition)
+    (define-key map (kbd "C-c C-d") 'inferior-haskell-find-haddock)
+    (define-key map [?\C-c ?\C-v] 'haskell-check)
+    map)
+  "Keymap for using inf-haskell.")
+
+;;;###autoload
+(define-minor-mode inf-haskell-mode
+  "Minor mode for enabling inf-haskell process interaction."
+  :lighter " Inf-Haskell"
+  :keymap inf-haskell-mode-map)
+
 (provide 'inf-haskell)
 
 ;; Local Variables:


### PR DESCRIPTION
@hvr We've been wanting to do this for a while. Took an hour to split off keybindings into minor modes, tried to make the `haskell-mode-hook` documentation more straight-forward. I removed references to things like `turn-on-X` which to me seems an unnecessary diversion from the way modes are normally enabled/disabled.

Main motivation: people keep using the old mode and finding issues, that probably no one is ever going to fix.
