### PR TITLE
Use abstract key codes in haskell-indentation.el

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -120,9 +120,9 @@
 
 (defconst haskell-indentation-mode-map
   (let ((keymap (make-sparse-keymap)))
-    (define-key keymap [?\r] 'haskell-newline-and-indent)
-    (define-key keymap [backspace] 'haskell-indentation-delete-backward-char)
-    (define-key keymap [?\C-d] 'haskell-indentation-delete-char)
+    (define-key keymap (kbd "RET") 'haskell-newline-and-indent)
+    (define-key keymap (kbd "DEL") 'haskell-indentation-delete-backward-char)
+    (define-key keymap (kbd "<deletechar>") 'haskell-indentation-delete-char)
     keymap))
 
 ;; Used internally


### PR DESCRIPTION
haskell-indentation rebinds the return, backspace, and delete keys by
looking up the raw key codes for those three keys.  This commit instead
binds the more abstract key codes `"RET"`, `"DEL"`, and `"<deletechar>"`.
This has a couple of benefits.
1.  It makes the bindings work in console Emacs, i.e. Emacs run in
   a terminal with `emacs -nw`.  Raw key codes such as `[?\r]`,
   `[backspace]`, and `[?\C-d]` are only available when Emacs is running in
   an X environment, and by default Emacs translates them into
   UI-independent key codes such as `"RET"`, `"DEL"`, and `"<deletechar>"`,
   unless something binds them directly.
2.  It makes haskell-indentation more compatible with evil-mode.
   Evil-mode doesn't expect other modes to rebind raw key codes because
   of the issue above.
   
   In particular, evil-mode is supposed to treat backspace and return
   as movement commands (left and down, respectively) when in the `<N>`
   state, and release those keys back to the ambient keymap (in this
   case, the one provided by haskell-mode and haskell-indentation) when
   in the `<I>` state.
   
   However, it is currently unable to grab the backspace and return
   keys in `<N>` state because it waits for Emacs to translate the
   X-specific raw key codes before it binds them, in order to respect
   the abstraction there.  If haskell-indentation binds the raw key
   codes, evil-mode can't get to them first.

I reported this issue on the evil-mode mailing list back in September
2012 [1] but didn't get around to fixing it until today.  Sorry for the
delay!

[1] http://thread.gmane.org/gmane.emacs.vim-emulation/1667
