### PR TITLE
Colorize hoogle output

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -128,6 +128,7 @@
 (require 'compile)
 (require 'flymake)
 (require 'outline)
+(require 'ansi-color)
 (require 'haskell-complete-module)
 (require 'haskell-compat)
 (require 'haskell-align-imports)
@@ -621,11 +622,13 @@ If nil, use the Hoogle web-site."
       (with-output-to-temp-buffer temp-buffer
         (with-current-buffer standard-output
           (let ((hoogle-process
-                 (start-process "hoogle" (current-buffer) haskell-hoogle-command query))
-                (scroll-to-top
+                 (start-process "hoogle" (current-buffer) haskell-hoogle-command "--color" query))
+                (update
                  (lambda (process event)
+                   (with-current-buffer temp-buffer
+                    (ansi-color-apply-on-region (point-min) (point-max)))
                    (set-window-start (get-buffer-window temp-buffer t) 1))))
-            (set-process-sentinel hoogle-process scroll-to-top)))))))
+            (set-process-sentinel hoogle-process update)))))))
 
 ;;;###autoload
 (defalias 'hoogle 'haskell-hoogle)


### PR DESCRIPTION
Pass the --color option to hoogle, and apply the ansi escape sequences it generates in order to colorize the help buffer.

I'm not necessarily expecting that this can be merged as-is, since it assumes that
the user's "hoogle" has "--color" support, and I'm not sure if that assumption is reasonable.
