### PR TITLE
Fix user-error when opening an empty haskell file.

### DIFF
--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1855,7 +1855,7 @@ This function switches to and potentially loads many buffers."
   (save-current-buffer
     (mapcar (lambda (f)
               (set-buffer (find-file-noselect f))
-              (imenu--make-index-alist)
+              (imenu--make-index-alist t)
               (cons f
                     (mapcar (lambda (x)
                               `(,(car x) . ,(haskell-doc-grab-line x)))


### PR DESCRIPTION
Opening an empty file with decl-scan turned on produces the error
File mode specification error: (user-error "No items suitable for an \
index found in this buffer")
and prevents other functions in the mode hook from running.

Adding non-nil noerror argument fixes the problem and an empty file
loads normally.
