### PR TITLE
Customize asking to kill buffers when a session is killed.

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -211,13 +211,6 @@ imports become available?"
   :type 'boolean
   :group 'haskell-interactive)
 
-(defcustom haskell-ask-also-kill-buffers
-  t
-  "Ask whether to kill all associated buffers when a session
- process is killed."
-  :type 'boolean
-  :group 'haskell-interactive)
-
 (defvar haskell-process-prompt-regex "\4")
 (defvar haskell-reload-p nil)
 

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -41,6 +41,16 @@
 (defvar haskell-process-type)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Configuration
+
+(defcustom haskell-ask-also-kill-buffers
+  t
+  "Ask whether to kill all associated buffers when a session
+ process is killed."
+  :type 'boolean
+  :group 'haskell-interactive)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Globals
 
 (defvar haskell-sessions (list)


### PR DESCRIPTION
When a session is killed, the user is currently asked whether to kill
associated buffers. This option allows the user to set a default "no"
answer.
