### PR TITLE
Set completion-at-point-functions as local hook

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -144,7 +144,8 @@ Key bindings:
   (set (make-local-variable 'haskell-interactive-mode-completion-cache) nil)
 
   (setq next-error-function 'haskell-interactive-next-error-function)
-  (setq completion-at-point-functions '(haskell-interactive-mode-completion-at-point-function))
+  (add-hook 'completion-at-point-functions
+            'haskell-interactive-mode-completion-at-point-function nil t)
 
   (haskell-interactive-mode-prompt))
 


### PR DESCRIPTION
Using setq causes haskell-interactive-mode-completion-at-point-function
set globally, then it throws wrong-type-argument error in other modes.
