### PR TITLE
Add universal binding to switch to repl and back

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -1648,8 +1648,8 @@ function and remove this comment.
     (define-key map (kbd "C-c C-k") 'haskell-interactive-mode-clear)
     (define-key map (kbd "C-c C-c") 'haskell-process-cabal-build)
     (define-key map (kbd "C-c c") 'haskell-process-cabal)
-    (define-key map [?\C-c ?\C-b] 'haskell-interactive-mode-switch-to-relevant-repl-buffer)
-    (define-key map [?\C-c ?\C-z] 'haskell-interactive-mode-switch-to-relevant-repl-buffer)
+    (define-key map [?\C-c ?\C-b] 'haskell-interactive-switch)
+    (define-key map [?\C-c ?\C-z] 'haskell-interactive-switch)
     map)
   "Keymap for using haskell-interactive-mode.")
 


### PR DESCRIPTION
As implementation details, this adds 3 functions:
- 1 private function to switch to an haskell repl (delegating
  to existing interactive-haskell-switch).
- 1 private function to switch back to the buffer from where we came
  from.
- 1 public function to provide the same interface which will be bound to
  bindings (this dispatches to the other 2 functions depending on the
  major mode)

The default bindings used are: C-c C-b/C-c C-z.
I kept the same logic about the same function applied to those 2 bindings.

This was added to the 2 main mode map (haskell-interactive-mode-map
 and interactive-haskell-mode-map).

_Note_
I do not know the subtlety of the notation "[?C-c...]" so I kept them as
is.

(Reference to proposed Issue #318)
