### PR TITLE
Add highlighting of pragmas.

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -178,6 +178,7 @@ This is the case if the \".\" is part of a \"forall <tvar> . <type>\"."
 ;; `font-lock-function-name-face' with a result that was not consistent with
 ;; other major modes, so I just exchanged with `haskell-definition-face'.
 (defvar haskell-operator-face 'font-lock-variable-name-face)
+(defvar haskell-pragma-face 'font-lock-comment-face)
 (defvar haskell-default-face nil)
 (defvar haskell-literate-comment-face 'font-lock-doc-face
   "Face with which to fontify literate comments.
@@ -237,6 +238,26 @@ Regexp match data 0 points to the chars."
               ;; expressions is only evaluated if the text has currently
               ;; no face.  So force evaluation by using `keep'.
               keep)))))))
+
+(defun haskell-font-lock-find-pragma (end)
+  (catch 'haskell-font-lock-find-pragma
+    (while (search-forward "{-#" end t)
+      (let* ((begin (match-beginning 0))
+             (ppss (save-excursion (syntax-ppss begin))))
+        ;; We're interested only when it's not in a string or a comment.
+        (unless (or (nth 3 ppss)
+                    (nth 4 ppss))
+          ;; Find the end of the pragma.
+          (let ((end (scan-lists begin 1 0)))
+            ;; Match data contains only the opening {-#, update it to cover the
+            ;; whole pragma.
+            (set-match-data (list begin end))
+            ;; Move to the end so we don't start the next scan from inside the
+            ;; pragma we just found.
+            (goto-char end)
+            (throw 'haskell-font-lock-find-pragma t)))))
+    ;; Found no pragma.
+    nil))
 
 ;; The font lock regular expressions.
 (defun haskell-font-lock-keywords-create (literate)
@@ -383,7 +404,9 @@ Returns keywords suitable for `font-lock-keywords'."
             ;; Very expensive.
             (,sym 0 (if (eq (char-after (match-beginning 0)) ?:)
                         haskell-constructor-face
-                      haskell-operator-face))))
+                      haskell-operator-face))
+
+            (haskell-font-lock-find-pragma 0 haskell-pragma-face t)))
     (unless (boundp 'font-lock-syntactic-keywords)
       (case literate
         (bird


### PR DESCRIPTION
By default it has no observable effect. To actually see it in action change the value of `haskell-pragma-face` to a face that can be distinguished from `font-lock-comment-face`.
