### PR TITLE
Fix haskell-process-load-file

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -430,7 +430,10 @@ changed. Restarts the process if that is the case."
   (interactive)
   (save-buffer)
   (haskell-interactive-mode-reset-error (haskell-session))
-  (haskell-process-file-loadish (concat "load " (buffer-file-name))
+  (haskell-process-file-loadish (format "load \"%s\"" (replace-regexp-in-string
+                                                       "\""
+                                                       "\\\\\""
+                                                       (buffer-file-name)))
                                 nil
                                 (current-buffer)))
 


### PR DESCRIPTION
### Bug

Fixes a bug in which if buffer-file-name had a space in it, a `not a
module name or a source file` error would happen.
This was caused by `:load` argument not being in quotes.

This commit quotes the argument and replaces all `"` with `\"` - just
in case you are some crazy person who uses quotes in their file names.

The patch seems to work and when I run "make check" all checks passed.
### To reproduce

Create a folder such as "99 Haskell Problems" and use `haskell-process-load-or-reload`.
In `*haskell-process-log*` buffer error like the following should appear:

```
-> :load /Users/mgoszcz2/Code/99 Haskell problems/Main.hs
<- target `/Users/mgoszcz2/Code/99' is not a module name or a source file
```
### Expected result

```
-> :load "/Users/mgoszcz2/Code/99 Haskell problems/Main.hs"
<- [1 of 1] Compiling Main             ( /Users/mgoszcz2/Code/99 Haskell problems/Main.hs, interpreted )
<- Ok, modules loaded: Main.
```
