### PR TITLE
Remove unnecessary byte-compile-warnings file local variables.

### DIFF
--- a/haskell-align-imports.el
+++ b/haskell-align-imports.el
@@ -227,8 +227,4 @@
 
 (provide 'haskell-align-imports)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-align-imports.el ends here

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -937,8 +937,4 @@ If SILENT ist nil the user is prompted for each source-section
 
 (provide 'haskell-cabal)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-cabal.el ends here

--- a/haskell-checkers.el
+++ b/haskell-checkers.el
@@ -174,8 +174,4 @@ name - user visible name for this mode"
 
 (provide 'haskell-checkers)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-checkers.el ends here

--- a/haskell-debug.el
+++ b/haskell-debug.el
@@ -688,7 +688,4 @@ variances in source span notation."
              string))))
 
 (provide 'haskell-debug)
-
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
+;;; haskell-debug.el ends here

--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -601,8 +601,4 @@ Invokes `haskell-decl-scan-mode-hook' on activation."
 
 (provide 'haskell-decl-scan)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-decl-scan.el ends here

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1973,8 +1973,4 @@ This function switches to and potentially loads many buffers."
 
 (provide 'haskell-doc)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-doc.el ends here

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -694,7 +694,6 @@ Invokes `haskell-font-lock-hook' if not nil."
 (provide 'haskell-font-lock)
 
 ;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
 ;; tab-width: 8
 ;; End:
 

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -1583,8 +1583,4 @@ Invokes `haskell-indent-hook' if not nil."
 
 (provide 'haskell-indent)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-indent.el ends here

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -1092,7 +1092,6 @@ Preserves indentation and removes extra whitespace"
 (provide 'haskell-indentation)
 
 ;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
 ;; tab-width: 8
 ;; End:
 

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -1141,8 +1141,4 @@ don't care when the thing completes as long as it's soonish."
 
 (provide 'haskell-interactive-mode)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-interactive-mode.el ends here

--- a/haskell-menu.el
+++ b/haskell-menu.el
@@ -157,8 +157,4 @@ Letters do not insert themselves; instead, they are commands."
 
 (provide 'haskell-menu)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-menu.el ends here

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -1127,8 +1127,4 @@ given a prefix arg."
 
 (provide 'haskell-mode)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-mode.el ends here

--- a/haskell-package.el
+++ b/haskell-package.el
@@ -154,8 +154,4 @@
 
 (provide 'haskell-package)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-package.el ends here

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -1670,8 +1670,4 @@ function and remove this comment.
 
 (provide 'haskell-process)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-process.el ends here

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -393,8 +393,4 @@ Returns newly set VALUE."
 
 (provide 'haskell-session)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-session.el ends here

--- a/haskell-show.el
+++ b/haskell-show.el
@@ -256,8 +256,4 @@
 
 (provide 'haskell-show)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; haskell-show.el ends here

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -824,8 +824,4 @@ we load it."
 
 (provide 'inf-haskell)
 
-;; Local Variables:
-;; byte-compile-warnings: (not cl-functions)
-;; End:
-
 ;;; inf-haskell.el ends here


### PR DESCRIPTION
Now that we no longer use (require 'cl), we don't want to turn any warnings off.
