### PR TITLE
Introduce declarations to haskell-yas.el so it byte-compiles cleanly.

### DIFF
--- a/haskell-yas.el
+++ b/haskell-yas.el
@@ -54,6 +54,10 @@
 (defconst haskell-snippets-dir
   (expand-file-name "snippets" (file-name-directory (or (buffer-file-name) load-file-name))))
 
+(defvar yas-snippet-dirs)
+(declare-function yas-load-directory "ext:yasnippet"
+                  (top-level-dir &optional use-jit interactive))
+
 ;;;###autoload
 (defun haskell-snippets-initialize ()
   "Register haskell snippets with yasnippet."


### PR DESCRIPTION
Without them:

```
In haskell-snippets-initialize:
haskell-yas.el:60:17:Warning: reference to free variable `yas-snippet-dirs'
haskell-yas.el:61:23:Warning: assignment to free variable `yas-snippet-dirs'

In end of data:
haskell-yas.el:73:1:Warning: the function `yas-load-directory' is not known to
    be defined.
```
