### PR TITLE
Remove an individual redundant name from an import statement

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -999,14 +999,18 @@ now."
           (progn
             (haskell-process-find-file session file)
             (save-excursion
-              (goto-char (point-min))
-              (forward-line (1- line))
-              (let ((rx1 (format "(%s, " import))
-                    (rx2 (format ", ?%s," import))
-                    (rx3 (format ", ?%s)" import)))
-                (replace-regexp rx1 "(" nil (line-beginning-position) (line-end-position))
-                (replace-regexp rx2 "," nil (line-beginning-position) (line-end-position))
-                (replace-regexp rx3 ")" nil (line-beginning-position) (line-end-position)))))
+              (save-restriction
+               (goto-char (point-min))
+               (forward-line (1- line))
+               (narrow-to-region (line-beginning-position) (line-end-position))
+               (let ((rx1 (format "(%s, " import))
+                     (rx2 (format ", ?%s," import))
+                     (rx3 (format ", ?%s)" import)))
+                 (dolist (rx `((,rx1 . "(") (,rx2 . ",") (,rx3 . ")")))
+                   ;; Stupid emacs won't let me simply use replace-regexp
+                   (goto-char (point-min))
+                   (while (search-forward-regexp (car rx) nil t)
+                     (replace-match (cdr rx))))))))
         (message "Ignoring redundant import of %s" import)))))
 
 (defun haskell-process-suggest-pragma (session pragma extension file)

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -994,7 +994,7 @@ now."
     (let ((continue t)
           (first t))
       (case (read-event
-             (propertize (format "%sThe import line `%s' is redundant. Remove? (y, n, c: comment out)  "
+             (propertize (format "%sThe import `%s' is redundant. Remove? (y, n)  "
                                  (if (not first)
                                      "Please answer n or y: "
                                    "")

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -993,26 +993,19 @@ now."
   (dolist (import (split-string imports ", "))
     (let ((continue t)
           (first t))
-      (case (read-event
-             (propertize (format "%sThe import `%s' is redundant. Remove? (y, n)  "
-                                 (if (not first)
-                                     "Please answer n or y: "
-                                   "")
-                                 import)
-                         'face 'minibuffer-prompt))
-        (?y
-         (haskell-process-find-file session file)
-         (save-excursion
-           (goto-char (point-min))
-           (forward-line (1- line))
-           (let ((rx1 (format "(%s, " import))
-                 (rx2 (format ", ?%s," import))
-                 (rx3 (format ", ?%s)" import)))
-             (replace-regexp rx1 "(" nil (line-beginning-position) (line-end-position))
-             (replace-regexp rx2 "," nil (line-beginning-position) (line-end-position))
-             (replace-regexp rx3 ")" nil (line-beginning-position) (line-end-position)))))
-        (?n
-         (message "Ignoring redundant import of %s" import))))))
+      (if (y-or-n-p (format "The import `%s' is redundant. Remove?" import))
+          (progn
+            (haskell-process-find-file session file)
+            (save-excursion
+              (goto-char (point-min))
+              (forward-line (1- line))
+              (let ((rx1 (format "(%s, " import))
+                    (rx2 (format ", ?%s," import))
+                    (rx3 (format ", ?%s)" import)))
+                (replace-regexp rx1 "(" nil (line-beginning-position) (line-end-position))
+                (replace-regexp rx2 "," nil (line-beginning-position) (line-end-position))
+                (replace-regexp rx3 ")" nil (line-beginning-position) (line-end-position)))))
+        (message "Ignoring redundant import of %s" import)))))
 
 (defun haskell-process-suggest-pragma (session pragma extension file)
   "Suggest to add something to the top of the file."

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -831,7 +831,9 @@ from `module-buffer'."
                                                   line)))
         ;; This can be a multi-line output, and we only catch the
         ;; first line, but it's better than nothing
-        ((string-match " The import of[ ][‘`‛]\\(.+\\)[,’]" msg)
+        ((or
+          (string-match " The import of[ ][‘`‛]\\(.+\\)[’] from module " msg)
+          (string-match " The import of[ ][‘`‛]\\(.+\\)[,]" msg))
          (when haskell-process-suggest-remove-import-lines
            (haskell-process-suggest-remove-import-names session
                                                        file


### PR DESCRIPTION
haskell-mode does not currently remove redundant imports that are individually imported.  For example

``haskell
import Foo (a, b, c)
``

Here `a` will not be removed when ghc complains.  This change fixes that. 