### PR TITLE
Don't trigger suggestion based on deprecation warning

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -832,7 +832,8 @@ from `module-buffer'."
 (defun haskell-process-trigger-suggestions (session msg file line)
   "Trigger prompting to add any extension suggestions."
   (cond ((let ((case-fold-search nil))
-           (or (string-match " -X\\([A-Z][A-Za-z]+\\)" msg)
+           (or (and (string-match " -X\\([A-Z][A-Za-z]+\\)" msg)
+                    (not (string-match "\\([A-Z][A-Za-z]+\\) is deprecated" msg)))
                (string-match "Use \\([A-Z][A-Za-z]+\\) to permit this" msg)
                (string-match "Use \\([A-Z][A-Za-z]+\\) to allow" msg)
                (string-match "use \\([A-Z][A-Za-z]+\\)" msg)


### PR DESCRIPTION
When the DatatypeContexts LANGUAGE pragma is loaded, GHC generates a warning about it being deprecated.  This triggers a suggestion to add the DatatypeContexts pragma to the file again even though it is already there.  This patch is supposed to make the regexp that matches GHC suggestions not pick up this warning.

It's not the most efficient implementation but it works for me.  I could improve it if you have any suggestions.
