### PR TITLE
Proposal - Add Cask to deal with test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ haskell-mode-autoloads.el
 haskell-mode.info
 haskell-mode.tmp.texi
 dir
+/.cask/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ env:
     - EMACS=emacs23
     - EMACS=emacs24
     - EMACS=emacs-snapshot
+  global:
+    - PATH=$HOME/.cask/bin:$PATH
 
 matrix:
   allow_failures:
@@ -27,6 +29,9 @@ install:
         sudo apt-get install -qq emacs-snapshot &&
         sudo apt-get install -qq emacs-snapshot-el emacs-snapshot-gtk;
     fi
+  - make deps
+  - cask --version
+  - cask
 
 script:
   lsb_release -a && $EMACS --version && make EMACS=$EMACS check

--- a/Cask
+++ b/Cask
@@ -1,0 +1,11 @@
+(source gnu)
+(source melpa)
+
+(package-file "haskell-mode.el")
+
+(files "*.el")
+
+(development
+ (depends-on "ert")
+ (depends-on "ert-expectations")
+ (depends-on "el-mock"))

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ ELCHECKS=$(addprefix check-, $(ELFILES:.el=))
 
 .PHONY: all compile info clean check $(ELCHECKS) elpa package
 
+deps:
+	curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+
 all: compile $(AUTOLOADS) info
 
 compile: $(ELCFILES)
@@ -76,7 +79,7 @@ compile: $(ELCFILES)
 $(ELCHECKS): check-%: %.el %.elc
 	@$(BATCH) --eval '(when (check-declare-file "$*.el") (error "check-declare failed"))'
 	@if [ -f "$(<:%.el=tests/%-tests.el)" ]; then \
-		$(BATCH) -l "$(<:%.el=tests/%-tests.el)" -f ert-run-tests-batch-and-exit; \
+		cask exec $(BATCH) -l "$(<:%.el=tests/%-tests.el)" -f ert-run-tests-batch-and-exit; \
 	fi
 	@echo "--"
 

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -10,6 +10,7 @@
 ;;          2003      Dave Love <fx@gnu.org>
 ;; Keywords: faces files Haskell
 ;; URL: https://github.com/haskell/haskell-mode
+;; Version: 13.07
 
 ;; This file is not part of GNU Emacs.
 

--- a/tests/haskell-process-tests.el
+++ b/tests/haskell-process-tests.el
@@ -1,0 +1,99 @@
+;;; haskell-process-tests.el
+
+;;; Code:
+
+(require 'ert)
+(require 'haskell-process)
+
+(eval-when-compile (require 'cl)) ;; for tests with mock to pass...
+(require 'el-mock)
+
+(ert-deftest haskell-process-wrapper-command-function-identity ()
+  "No wrapper, return directly the command."
+  (should (equal '("ghci")
+                 (progn
+                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
+                   (apply haskell-process-wrapper-function (list '("ghci")))))))
+
+(ert-deftest haskell-process-wrapper-function-non-identity ()
+  "Wrapper as a string, return the wrapping command as a string."
+  (should (equal '("nix-shell" "default.nix" "--command" "cabal\\ run")
+                 (progn
+                   (custom-set-variables '(haskell-process-wrapper-function (lambda (argv)
+                                                                              (append '("nix-shell" "default.nix" "--command")
+                                                                                      (list (shell-quote-argument argv))))))
+                   (apply haskell-process-wrapper-function (list "cabal run"))))))
+
+(ert-deftest test-haskell-process--compute-process-log-and-command-ghci ()
+  (should (equal '("Starting inferior GHCi process ghci ..." "dumses1" nil "ghci" "-ferror-spans")
+                 (let ((haskell-process-path-ghci "ghci")
+                       (haskell-process-args-ghci '("-ferror-spans")))
+                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
+                   (mocklet (((haskell-session-name "dummy-session") => "dumses1"))
+                     (haskell-process-compute-process-log-and-command "dummy-session" 'ghci))))))
+
+(ert-deftest test-haskell-process--with-wrapper-compute-process-log-and-command-ghci ()
+  (should (equal '("Starting inferior GHCi process ghci ..." "dumses1" nil "nix-shell" "default.nix" "--command" "ghci\\ -ferror-spans")
+                 (let ((haskell-process-path-ghci "ghci")
+                       (haskell-process-args-ghci '("-ferror-spans")))
+                   (custom-set-variables '(haskell-process-wrapper-function
+                                           (lambda (argv) (append (list "nix-shell" "default.nix" "--command" )
+                                                             (list (shell-quote-argument (mapconcat 'identity argv " ")))))))
+                   (mocklet (((haskell-session-name "dummy-session") => "dumses1"))
+                     (haskell-process-compute-process-log-and-command "dummy-session" 'ghci))))))
+
+(ert-deftest test-haskell-process--compute-process-log-and-command-cabal-repl ()
+  (should (equal '("Starting inferior `cabal repl' process using cabal ..." "dumses2" nil "cabal" "repl" "--ghc-option=-ferror-spans" "dumdum-session")
+                 (let ((haskell-process-path-cabal      "cabal")
+                       (haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans")))
+                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
+                   (mocklet (((haskell-session-name "dummy-session2") => "dumses2")
+                             ((haskell-session-target "dummy-session2") => "dumdum-session"))
+                     (haskell-process-compute-process-log-and-command "dummy-session2" 'cabal-repl))))))
+
+(ert-deftest test-haskell-process--with-wrapper-compute-process-log-and-command-cabal-repl ()
+  (should (equal '("Starting inferior `cabal repl' process using cabal ..." "dumses2" nil "nix-shell" "default.nix" "--command" "cabal\\ repl\\ --ghc-option\\=-ferror-spans" "dumdum-session")
+                 (let ((haskell-process-path-cabal      "cabal")
+                       (haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans")))
+                   (custom-set-variables '(haskell-process-wrapper-function
+                                           (lambda (argv) (append (list "nix-shell" "default.nix" "--command" )
+                                                             (list (shell-quote-argument (mapconcat 'identity argv " ")))))))
+                   (mocklet (((haskell-session-name "dummy-session2") => "dumses2")
+                             ((haskell-session-target "dummy-session2") => "dumdum-session"))
+                     (haskell-process-compute-process-log-and-command "dummy-session2" 'cabal-repl))))))
+
+(ert-deftest test-haskell-process--compute-process-log-and-command-cabal-ghci ()
+  (should (equal '("Starting inferior cabal-ghci process using cabal-ghci ..." "dumses3" nil "cabal-ghci")
+                 (let ((haskell-process-path-ghci "ghci"))
+                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
+                   (mocklet (((haskell-session-name "dummy-session3") => "dumses3"))
+                     (haskell-process-compute-process-log-and-command "dummy-session3" 'cabal-ghci))))))
+
+(ert-deftest test-haskell-process--with-wrapper-compute-process-log-and-command-cabal-ghci ()
+  (should (equal '("Starting inferior cabal-ghci process using cabal-ghci ..." "dumses3" nil "nix-shell" "default.nix" "--command" "cabal-ghci")
+                 (let ((haskell-process-path-ghci "ghci"))
+                   (custom-set-variables '(haskell-process-wrapper-function
+                                           (lambda (argv) (append (list "nix-shell" "default.nix" "--command" )
+                                                             (list (shell-quote-argument (mapconcat 'identity argv " ")))))))
+                   (mocklet (((haskell-session-name "dummy-session3") => "dumses3"))
+                     (haskell-process-compute-process-log-and-command "dummy-session3" 'cabal-ghci))))))
+
+(ert-deftest test-haskell-process--compute-process-log-and-command-cabal-dev ()
+  (should (equal '("Starting inferior cabal-dev process cabal-dev -s directory/cabal-dev ..." "dumses4" nil "cabal-dev" "ghci" "-s" "directory/cabal-dev")
+                 (let ((haskell-process-path-cabal-dev "cabal-dev"))
+                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
+                   (mocklet (((haskell-session-name "dummy-session4")      => "dumses4")
+                             ((haskell-session-cabal-dir "dummy-session4") => "directory"))
+                     (haskell-process-compute-process-log-and-command "dummy-session4" 'cabal-dev))))))
+
+(ert-deftest test-haskell-process--with-wrapper-compute-process-log-and-command-cabal-dev ()
+  (should (equal '("Starting inferior cabal-dev process cabal-dev -s directory/cabal-dev ..." "dumses4" nil "run-with-docker" "cabal-dev\\ ghci\\ -s\\ directory/cabal-dev")
+                 (let ((haskell-process-path-cabal-dev "cabal-dev"))
+                   (custom-set-variables '(haskell-process-wrapper-function
+                                           (lambda (argv) (append (list "run-with-docker")
+                                                             (list (shell-quote-argument (mapconcat 'identity argv " ")))))))
+                   (mocklet (((haskell-session-name "dummy-session4") => "dumses4")
+                             ((haskell-session-cabal-dir "dummy-session4") => "directory"))
+                     (haskell-process-compute-process-log-and-command "dummy-session4" 'cabal-dev))))))
+
+;;; haskell-process-tests.el ends here


### PR DESCRIPTION
Following this [PR](https://github.com/haskell/haskell-mode/pull/370), I needed to add some unit test lib (el-mock) to tests that I did not break anything.

As no dependencies seems necessary until now, I just added a temporary HACK to solve the dependency (https://github.com/haskell/haskell-mode/pull/370#discussion-diff-20121622) at the time.
This comes to solve this HACK (and maybe later ease the installation of new deps).

Cask [seemed a proper solution for this](https://github.com/haskell/haskell-mode/pull/370#discussion_r20136791).

Here is a way to make Cask run the tests (and solve tests dependencies).

The only issue now seems that in the current ci-travis, the `emacs-snapshot` you use is an
emacs 23.3 and Cask only supports emacs >= 24... (that's why the ci break on `emacs-snapshot`)

*Note* If you accept the previous PR, you'll see only the 2 latest commits which add Cask.

Cheers,