### PR TITLE
Proposal - Add EVM (emacs version manager) to deal with emacs versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,31 @@
 language: emacs-lisp
 
 env:
+  global:
+    - PATH=$HOME/.cask/bin:$HOME/.evm/bin:$PATH
   matrix:
-    - EMACS=emacs23
-    - EMACS=emacs24
-    - EMACS=emacs-snapshot
+    #   # Cask does not support emacs < 24
+    # - EVM_EMACS=emacs-23.4-bin
+    #   # dependencies break in ghc-core.el about cl-lib
+    # - EVM_EMACS=emacs-24.1-bin
+    #   # dependencies break in ghc-core.el about cl-lib
+    # - EVM_EMACS=emacs-24.2-bin
+    - EVM_EMACS=emacs-24.3-bin
+    - EVM_EMACS=emacs-24.4-bin
+  # allow_failures:
+  #   - EVM_EMACS=emacs-23.4-bin
+  #   - EVM_EMACS=emacs-24.1-bin
+  #   - EVM_EMACS=emacs-24.2-bin
 
-matrix:
-  allow_failures:
-    - env:
-        - EMACS=emacs-snapshot
-
-install:
-  - if [ "$EMACS" = "emacs23" ]; then
-        sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs23-gtk emacs23-el;
-    fi
-  - if [ "$EMACS" = "emacs24" ]; then
-        sudo add-apt-repository -y ppa:cassou/emacs &&
-        sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs24 emacs24-el;
-    fi
-  - if [ "$EMACS" = "emacs-snapshot" ]; then
-        sudo add-apt-repository -y ppa:cassou/emacs &&
-        sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs-snapshot &&
-        sudo apt-get install -qq emacs-snapshot-el emacs-snapshot-gtk;
-    fi
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/7736123/raw > travis.sh && source ./travis.sh
+  # install the matrix's emacs version
+  - evm install $EVM_EMACS --use --skip
+  # install deps for cask
+  - cask
 
 script:
-  lsb_release -a && $EMACS --version && make EMACS=$EMACS check
+  lsb_release -a && emacs --version && make check
 
 notifications:
   email: false


### PR DESCRIPTION
Again, it's a proposal (this eases the .travis.yml's readability).

Also, this reduces the use of [Damien Cassou's PPA which is no longer
maintained](https://launchpad.net/~cassou/+archive/ubuntu/emacs).

What are the targeted versions for emacs?

At the moment, it's ok with emacs-24.3 and emacs-24.4 but otherwise, there are limitations:
- emacs-23.4 -> limit from cask not supporting before emacs 24
- emacs 24.1 -> pb in ghc-core.el regarding cl-lib
- emacs 24.2 -> the same

Cheers,