### PR TITLE
Highlight error, undefined with font-lock-warning-face.

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -415,6 +415,9 @@ Returns keywords suitable for `font-lock-keywords'."
              (2 haskell-keyword-face nil lax)
              (3 haskell-keyword-face nil lax))
 
+            ;; Highlight 'error' and 'undefined', like 'error' in emacs-lisp-mode
+            ("\\_<\\(error\\|undefined\\)\\_>" 0 'font-lock-warning-face)
+
             ;; Toplevel Declarations.
             ;; Place them *before* generic id-and-op highlighting.
             (,topdecl-var  (1 haskell-definition-face))


### PR DESCRIPTION
Both are very special symbols; this is similar to emacs-lisp-mode, for
example.