### PR TITLE
Explicitly require cl-lib wherever it's used.

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -17,6 +17,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'haskell-process)
 (require 'haskell-font-lock)
 (require 'haskell-interactive-mode)

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -17,7 +17,7 @@
 
 ;;; Code:
 
-(with-no-warnings (require 'cl))
+(require 'cl-lib)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Customization variables

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -17,6 +17,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'haskell-process)
 (require 'haskell-interactive-mode)
 (require 'haskell-commands)

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -23,6 +23,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'json)
 (require 'url-util)
 (require 'haskell-session)

--- a/haskell-repl.el
+++ b/haskell-repl.el
@@ -17,6 +17,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'haskell-interactive-mode)
 
 (defun haskell-interactive-handle-expr ()

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -27,6 +27,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'haskell-cabal)
 (require 'haskell-string)
 (require 'haskell-customize)

--- a/haskell.el
+++ b/haskell.el
@@ -17,6 +17,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'haskell-mode)
 (require 'haskell-process)
 (require 'haskell-debug)


### PR DESCRIPTION
Don't depend on other files to load cl-lib, because whether a file uses it or not is an implementation detail.

Also, remove a (require 'cl) introduced in c3a44b6bd23ea.
