### PR TITLE
Restore autoload for haskell-process-load-file

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -264,6 +264,7 @@
       (display-buffer buffer)
       (other-window 1))))
 
+;;;###autoload
 (defun haskell-process-load-file ()
   "Load the current buffer file."
   (interactive)


### PR DESCRIPTION
Restore the autoload directive for `haskell-process-load-file`, which was lost during the project reorganisation.
