### PR TITLE
add `haskell-rgrep` function

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -863,4 +863,12 @@ the :uses command from GHCi."
           (error (propertize "No reply. Is :uses supported?"
                              'face 'compilation-error)))))))
 
+(defun haskell-rgrep (regexp)
+  (interactive (list (grep-read-regexp)))
+  (if buffer-file-name
+      (let* ((cabal-file (haskell-cabal-find-file (file-name-directory buffer-file-name)))
+             (proj-dir (file-name-directory cabal-file)))
+        (rgrep regexp "*.hs" proj-dir))))
+
+
 (provide 'haskell-commands)


### PR DESCRIPTION
There is one problem: when starting emacs first time function `haskell-rgrep` does not work. Fails with 

```
grep-expand-template: Wrong type argument: stringp, nil
```

But after first launch of `grep` or `rgrep` everything works. Maybe you guys know how what magic must be performed to make it work.