### PR TITLE
Highlight "varid, varid :: type".

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -353,7 +353,9 @@ Returns keywords suitable for `font-lock-keywords'."
 
          ;; Top-level declarations
          (topdecl-var
-          (concat line-prefix "\\(" varid "\\)\\s-*"
+          (concat line-prefix
+                  ;; Allow "varid, varid :: type"
+                  "\\(" varid "\\(?:,\\s-*" varid "\\)*" "\\)\\s-*"
                   ;; optionally allow for a single newline after identifier
                   ;; NOTE: not supported for bird-style .lhs files
                   (if (eq literate 'bird) nil "\\([\n]\\s-+\\)?")


### PR DESCRIPTION
The "varid, varid" used to be unhighlighted, now it's highlighted the way
"varid" in "varid :: type" would be.
