### PR TITLE
Address compiler error/warning.

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -319,7 +319,7 @@ if those exist."
   (save-excursion
     (let ((pos (haskell-ident-pos-at-point)))
       (if pos
-          (destructuring-bind (start . end) pos
+          (cl-destructuring-bind (start . end) pos
             (if (and (eq ?` (char-before start))
                      (eq ?` (char-after end)))
                 (cons (- start 1) (+ end 1))


### PR DESCRIPTION
Since it is 'cl-lib that is being imported, not 'cl, one should use the macros starting with cl-. (Try adding (require 'cl) to see this.) Usually both names would be aliases, but the byte-compiler might not be seeing that.

This makes the build not fail. See #403 
