### PR TITLE
Customizable settings for skipping questions

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -50,6 +50,7 @@
 
 (require 'cl-lib)
 (require 'haskell-utils)
+(require 'haskell-customize)
 
 (defconst haskell-cabal-general-fields
   ;; Extracted with (haskell-cabal-extract-fields-from-doc "general-fields")
@@ -183,11 +184,15 @@
 (defun haskell-cabal-get-dir ()
   "Get the Cabal dir for a new project. Various ways of figuring this out,
    and indeed just prompting the user. Do them all."
-  (let* ((file (haskell-cabal-find-file))
-         (dir (when file (file-name-directory file))))
-    (haskell-utils-read-directory-name
-     (format "Cabal dir%s: " (if file (format " (guessed from %s)" (file-relative-name file)) ""))
-     dir)))
+  (let* ((file (or (haskell-cabal-find-file) (buffer-file-name)))
+         (dir (file-name-directory file)))
+    (cond
+     ((and dir (eq haskell-cabal-use-directory t)) dir)
+     ((stringp haskell-cabal-use-directory) haskell-cabal-use-directory)
+     (t
+      (haskell-utils-read-directory-name
+       (format "Cabal dir%s: " (if file (format " (guessed from %s)" (file-relative-name file)) ""))
+       dir)))))
 
 (defun haskell-cabal-compute-checksum (dir)
   "Compute MD5 checksum of package description file in DIR.

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -74,6 +74,38 @@ a per-project basis."
   :type 'boolean
   :group 'haskell-interactive)
 
+(defcustom haskell-session-ask-new-project
+  t
+  "Ask when starting a new project."
+  :type 'boolean
+  :safe 'booleanp
+  :group 'haskell-interactive)
+
+(defcustom haskell-cabal-use-directory
+  nil
+  "Use this cabal directory (the default if t, ask if nil)."
+  :type '(choice (const :tag "Ask" nil)
+                 (const :tag "Default" t)
+                 (string :tag "Directory path"))
+  :safe 'booleanp
+  :group 'haskell-interactive)
+
+(defcustom haskell-session-current-directory
+  nil
+  "Use this current directory (use buffer's directory if t, ask if nil)."
+  :type '(choice (const :tag "Ask" nil)
+                 (const :tag "Guess from buffer" t)
+                 (string :tag "Directory path"))
+  :safe 'booleanp
+  :group 'haskell-interactive)
+
+(defcustom haskell-session-use-default-target
+  nil
+  "Whether to use the default target without asking."
+  :type 'boolean
+  :safe 'booleanp
+  :group 'haskell-interactive)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Configuration
 

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -203,10 +203,14 @@ If DONTCREATE is non-nil don't create a new session."
 (defun haskell-session-target (s)
   "Get the session build target."
   (let* ((maybe-target (haskell-session-get s 'target))
-         (target (if maybe-target maybe-target
-                   (let ((new-target
-                          (read-string "build target (empty for default):")))
-                     (haskell-session-set-target s new-target)))))
+         (target
+          (if maybe-target
+              maybe-target
+            (let ((new-target
+                   (if haskell-session-use-default-target
+                       ""
+                     (read-string "build target (empty for default):"))))
+              (haskell-session-set-target s new-target)))))
     (if (not (string= target "")) target nil)))
 
 (defun haskell-session-set-target (s target)

--- a/haskell.el
+++ b/haskell.el
@@ -25,6 +25,7 @@
 (require 'haskell-repl)
 (require 'haskell-load)
 (require 'haskell-commands)
+(require 'haskell-customize)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic configuration hooks
@@ -128,8 +129,8 @@
   "Prompt to create a new project based on a guess from the nearest Cabal file."
   (let ((name (haskell-session-default-name)))
     (unless (haskell-session-lookup name)
-      (when (y-or-n-p (format "Start a new project named “%s”? "
-                              name))
+      (when (or (not haskell-session-ask-new-project)
+                (y-or-n-p (format "Start a new project named “%s”? " name)))
         (haskell-session-make name)))))
 
 ;;;###autoload


### PR DESCRIPTION
Creating a new session in a simple project asks many questions for which
the default answers may be absolute fine.  This change adds four
customizable variables, and setting them (in file-local and dir-local
variables) would allow questions to be skipped during session creation.

See #407 

For example (to use file-local variables; dir-local variables would work too; here `t` means "default"):

```
-- Local Variables:
-- haskell-session-ask-new-project: nil
-- haskell-cabal-use-directory: t
-- haskell-session-current-directory: t
-- haskell-session-use-default-target: t
-- End:
```