### PR TITLE
Support loading a view buffer into GHCi

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -309,6 +309,11 @@
 (defun haskell-process-load-file ()
   "Load the current buffer file."
   (interactive)
+  (when (not (buffer-file-name))
+    (setq buffer-file-name (make-temp-file "haskell-temp" nil ".hs"))
+    (setq buffer-read-only nil)
+    (set-buffer-modified-p t)
+    (message "haskell-process loading a buffer backed by a temporary file"))
   (save-buffer)
   (haskell-interactive-mode-reset-error (haskell-session))
   (haskell-process-file-loadish (format "load \"%s\"" (replace-regexp-in-string


### PR DESCRIPTION
This creates a temporary file to back a buffer that has no file name so
that it may be loaded into a REPL session. The previous behavior was an
elisp error when trying to save the buffer being loaded.

My use case is this: In org mode, you can use `org-babel-expand-src-block`
to resolve noweb links and give a nice preview of a source block. This
patch lets you load such a block into a REPL session. The expanded view
is a bit tricky as it is read-only, so any changes you make to it are
not synchronized back to the source document. However, the ability to
load a tangled block of code into the REPL is quite useful.