### PR TITLE
Keep point in haskell-simple-indent.

### DIFF
--- a/haskell-simple-indent.el
+++ b/haskell-simple-indent.el
@@ -156,18 +156,28 @@ point beyond the current column, position given by
 (defun haskell-simple-indent-backtab ()
   "Indent backwards.  Dual to `haskell-simple-indent'."
   (interactive)
-  (back-to-indentation)
-  (let ((saved-column (current-column))
+  (let ((saved-column (or (save-excursion
+                             (back-to-indentation)
+                             (if (not (eolp))
+                                 (current-column)))
+                           (current-column)))
         (i 0)
         (x 0))
-    (delete-region (line-beginning-position) (point))
 
     (save-excursion
-      (while (< (current-column) saved-column)
-        (haskell-simple-indent)
-        (setq i (+ i 1))))
-    (back-to-indentation)
-    (delete-region (line-beginning-position) (point))
+      (back-to-indentation)
+      (delete-region (line-beginning-position) (point)))
+    (while (< (or (save-excursion
+                             (back-to-indentation)
+                             (if (not (eolp))
+                                 (current-column)))
+                  (current-column)) saved-column)
+      (haskell-simple-indent)
+      (setq i (+ i 1)))
+
+    (save-excursion
+      (back-to-indentation)
+      (delete-region (line-beginning-position) (point)))
     (while (< x (- i 1))
       (haskell-simple-indent)
       (setq x (+ x 1)))))

--- a/haskell-simple-indent.el
+++ b/haskell-simple-indent.el
@@ -146,9 +146,16 @@ point beyond the current column, position given by
       ;; or use tab-to-tab-stop. Try hard to keep cursor in the same
       ;; place or move it to the indentation if it was before it. And
       ;; keep content of the line intact.
-      (indent-line-to (or indent
-                          invisible-from
-                          (indent-next-tab-stop start-column)))
+      (setq indent (or indent
+		       invisible-from
+		       (if (fboundp 'indent-next-tab-stop)
+			   (indent-next-tab-stop start-column))
+		       (let ((tabs tab-stop-list))
+			 (while (and tabs (>= start-column (car tabs)))
+			   (setq tabs (cdr tabs)))
+			 (if tabs (car tabs)))
+		       (* (/ (+ start-column tab-width) tab-width) tab-width)))
+      (indent-line-to indent)
       (if (> opoint (point))
           (goto-char opoint))
       (set-marker opoint nil))))

--- a/haskell-simple-indent.el
+++ b/haskell-simple-indent.el
@@ -96,13 +96,19 @@ position and the current line.  If there is no visible indent
 point beyond the current column, position given by
 `indent-next-tab-stop' is used instead."
   (interactive)
-  (let* ((start-column (current-column))
+  (let* ((start-column (or (save-excursion
+                             (back-to-indentation)
+                             (if (not (eolp))
+                                 (current-column)))
+                           (current-column)))
          (invisible-from nil)           ; `nil' means infinity here
+         (found)
          (indent))
     (save-excursion
       ;; Loop stops if there no more lines above this one or when has
       ;; found a line starting at first column.
-      (while (and (or (not invisible-from)
+      (while (and (not found)
+                  (or (not invisible-from)
                       (not (zerop invisible-from)))
                   (zerop (forward-line -1)))
         ;; Ignore empty lines.
@@ -132,14 +138,20 @@ point beyond the current column, position given by
                                        invisible-from
                                      (current-column)))
                       ;; Signal that solution is found.
-                      (setq invisible-from 0))))))))
-    (if indent
-        (let ((opoint (point-marker)))
-          (indent-line-to indent)
-          (if (> opoint (point))
-              (goto-char opoint))
-          (set-marker opoint nil))
-      (tab-to-tab-stop))))
+                      (setq found t))))))))
+
+
+    (let ((opoint (point-marker)))
+      ;; Indent to the calculated indent or last know invisible-from
+      ;; or use tab-to-tab-stop. Try hard to keep cursor in the same
+      ;; place or move it to the indentation if it was before it. And
+      ;; keep content of the line intact.
+      (indent-line-to (or indent
+                          invisible-from
+                          (indent-next-tab-stop start-column)))
+      (if (> opoint (point))
+          (goto-char opoint))
+      (set-marker opoint nil))))
 
 (defun haskell-simple-indent-backtab ()
   "Indent backwards.  Dual to `haskell-simple-indent'."

--- a/tests/haskell-simple-indent-tests.el
+++ b/tests/haskell-simple-indent-tests.el
@@ -33,6 +33,20 @@
       (setq result-backward (cons (current-column) result-backward))
       (list (reverse result-forward) result-backward))))
 
+(defun indent-last-line (lines &optional prepare-buffer)
+  (with-temp-buffer
+    (if prepare-buffer
+        (funcall prepare-buffer))
+    (dolist (line lines)
+      (insert line)
+      (insert "\n"))
+    (forward-line -1)
+    (skip-chars-forward "^|")
+    (delete-char 1)
+    (haskell-simple-indent)
+    (insert "|")
+    (buffer-substring (line-beginning-position) (line-end-position))))
+
 (ert-deftest find-indent-positions-1 ()
   (should (equal '(5 7 10 19 26 32 40 48 56 64)
 		 (find-indent-positions '("main = do putStrLn \"Hello World!\"")))))
@@ -115,3 +129,35 @@
                                                       ""
                                                       "             e f g h"
                                                       "")))))
+
+(ert-deftest indent-last-line-1 ()
+  (should (equal "\t|"
+		 (indent-last-line '("|")))))
+
+(ert-deftest indent-last-line-2 ()
+  (should (equal "\t|x"
+		 (indent-last-line '("|x")))))
+
+(ert-deftest indent-last-line-3 ()
+  (should (equal "\t|x"
+		 (indent-last-line '("|  x")))))
+
+(ert-deftest indent-last-line-4 ()
+  (should (equal "    |x"
+		 (indent-last-line '("a b c"
+                                     "|  x")))))
+
+(ert-deftest indent-last-line-5 ()
+  (should (equal "\tx|y"
+		 (indent-last-line '("x|y")))))
+
+(ert-deftest indent-last-line-6 ()
+  (should (equal "\t\t\tx|y"
+		 (indent-last-line '("\t\t\tbase"
+                                     "x|y")))))
+
+(ert-deftest indent-last-line-7 ()
+  (should (equal "\txy    |"
+		 (indent-last-line '("    p   x"
+                                     "\t\t\tbase"
+                                     "      xy    |")))))


### PR DESCRIPTION
Keep point in sane positions after haskell-simple-indent. This commit
solves multiple problems:

- messing line content when indent offset was not found
- getting to the biggining of line in couple of cases
- failing to indent second line in the buffer in some cases

Make indentation more predictable to users.