### PR TITLE
Implement haskell-comment-function.

### DIFF
--- a/haskell-simple-indent.el
+++ b/haskell-simple-indent.el
@@ -175,6 +175,21 @@ column, `tab-to-tab-stop' is done instead."
   (haskell-simple-indent-newline-same-col)
   (insert (make-string haskell-indent-spaces ? )))
 
+(defun haskell-simple-indent-comment-indent-function ()
+  "Haskell version of `comment-indent-function'."
+  ;; This is required when filladapt is turned off.  Without it, when
+  ;; filladapt is not used, comments which start in column zero
+  ;; cascade one character to the right
+  (save-excursion
+    (beginning-of-line)
+    (let ((eol (line-end-position)))
+      (and comment-start-skip
+           (re-search-forward comment-start-skip eol t)
+           (setq eol (match-beginning 0)))
+      (goto-char eol)
+      (skip-chars-backward " \t")
+      (max comment-column (+ (current-column) (if (bolp) 0 1))))))
+
 ;;;###autoload
 (define-minor-mode haskell-simple-indent-mode
   "Simple Haskell indentation mode that uses simple heuristic.
@@ -189,6 +204,7 @@ Runs `haskell-simple-indent-hook' on activation."
   :lighter " Ind"
   :group 'haskell-simple-indent
   :keymap '(([backtab] . haskell-simple-indent-backtab))
+  (set (make-local-variable 'comment-indent-function) #'haskell-simple-indent-comment-indent-function)
   (kill-local-variable 'indent-line-function)
   (when haskell-simple-indent-mode
     (set (make-local-variable 'indent-line-function) 'haskell-simple-indent)


### PR DESCRIPTION
haskell-comment-function is useful when auto-fill-mode is enabled and comments are expected to auto-fill. This function keeps comments nicely aligned.

Fixes #279.

Note that multiline-style comments are still not supported for auto-fill mode.
