### PR TITLE
Haskell eldoc support with ghci in haskell-interaction-mode.

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -336,15 +336,24 @@ If PROMPT-VALUE is non-nil, request identifier via mini-buffer."
   (interactive "P")
   (if insert-value
       (haskell-process-insert-type)
-    (haskell-process-do-simple-echo
-     (let ((ident (haskell-ident-at-point)))
-       ;; TODO: Generalize all these `string-match' of ident calls into
-       ;; one function.
-       (format (if (string-match "^[_[:lower:][:upper:]]" ident)
-                   ":type %s"
-                 ":type (%s)")
-               ident))
-     'haskell-mode)))
+    (let* ((expr
+            (if (use-region-p)
+                (buffer-substring-no-properties (region-beginning) (region-end))
+              (haskell-ident-at-point)))
+           (expr-okay (and expr
+                         (not (string-match-p "\\`[[:space:]]*\\'" expr))
+                         (not (string-match-p "\n" expr)))))
+      ;; No newlines in expressions, and surround with parens if it
+      ;; might be a slice expression
+      (when expr-okay
+        (haskell-process-do-simple-echo
+         (format
+          (if (or (string-match-p "\\`(" expr)
+                 (string-match-p "\\`[_[:alpha:]]" expr))
+              ":type %s"
+            ":type (%s)")
+          expr)
+         'haskell-mode)))))
 
 ;;;###autoload
 (defun haskell-mode-jump-to-def-or-tag (&optional next-p)

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -77,6 +77,13 @@ a per-project basis."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Configuration
 
+(defcustom haskell-doc-prettify-types t
+  "Replace some parts of types with Unicode characters like \"∷\"
+when showing type information about symbols."
+  :group 'haskell-doc
+  :type 'boolean
+  :safe 'booleanp)
+
 (defvar haskell-process-end-hook nil
   "Hook for when the haskell process ends.")
 

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1622,8 +1622,7 @@ will be returned directly."
          sym (lambda (response)
                (setq haskell-doc-current-info--interaction-last
                      (cons 'async response))
-               (eldoc-print-current-symbol-info)))
-        'async)))))
+               (eldoc-print-current-symbol-info))))))))
 
 (defun haskell-process-get-type (expr-string &optional callback sync)
   "Asynchronously get the type of a given string.
@@ -1633,7 +1632,8 @@ EXPR-STRING should be an expression passed to :type in ghci.
 CALLBACK will be called with a formatted type string.
 
 If SYNC is non-nil, make the call synchronously instead."
-  (let ((process (haskell-process))
+  (let ((process (and (haskell-session-maybe)
+                    (haskell-session-process (haskell-session-maybe))))
         ;; Avoid passing bad strings to ghci
         (expr-okay (not (string-match-p "\n" expr-string)))
         (ghci-command (concat ":type " expr-string))
@@ -1666,7 +1666,8 @@ If SYNC is non-nil, make the call synchronously instead."
          process
          (make-haskell-command
           :go (lambda (_) (haskell-process-send-string process ghci-command))
-          :complete complete-func))))))
+          :complete complete-func))
+        'async))))
 
 (defun haskell-doc-sym-doc (sym)
   "Show the type of the function near point.

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1638,7 +1638,9 @@ If SYNC is non-nil, make the call synchronously instead."
   (let ((process (and (haskell-session-maybe)
                     (haskell-session-process (haskell-session-maybe))))
         ;; Avoid passing bad strings to ghci
-        (expr-okay (not (string-match-p "\n" expr-string)))
+        (expr-okay
+         (and (not (string-match-p "\\`[[:space:]]*\\'" expr-string))
+            (not (string-match-p "\n" expr-string))))
         (ghci-command (concat ":type " expr-string))
         (process-response
          (lambda (response)

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1648,7 +1648,11 @@ CALLBACK will be called with a formatted type string."
                       (type (propertize
                              (substring response (match-end 0))
                              'face 'eldoc-highlight-function-argument)))
-                  (setq response (concat name type))))))
+                  (setq response (concat name type)))))
+            (when haskell-doc-prettify-types
+              (dolist (re '(("::" . "∷") ("=>" . "⇒") ("->" . "→")))
+                (setq response
+                      (replace-regexp-in-string (car re) (cdr re) response)))))
           (when callback (funcall callback response))))))))
 
 (defun haskell-doc-sym-doc (sym)

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -1090,7 +1090,7 @@ haskell-present, depending on configuration."
                   ;; `haskell-process-use-presentation-mode' is t.
                   (haskell-interactive-mode-echo
                    (haskell-process-session (car state))
-                   response
+                   (replace-regexp-in-string "\n\\'" "" response)
                    (cl-caddr state))
                   (if haskell-process-use-presentation-mode
                       (progn (haskell-present (cadr state)


### PR DESCRIPTION
See #432 for what this is supposed to do. I'm not sure if I missed some corner cases, or if I broke something that I don't use myself. Is `haskell-process` the right function to check if there's a running process available?

I don't want to make synchronous calls to ghci, so the way it's written now it only works for eldoc because other functions that get type information seem to be synchronous.

Why is all this in haskell-doc anyway? Isn't a lot of it duplicating eldoc-mode?

Some of the commented-out code in haskell-doc.el and todo-items are from 2001, btw :)