### PR TITLE
Add PackageImports syntax to font-lock.

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -392,7 +392,7 @@ Returns keywords suitable for `font-lock-keywords'."
             (,reservedsym 1 haskell-operator-face)
             ;; Special case for `as', `hiding', `safe' and `qualified', which are
             ;; keywords in import statements but are not otherwise reserved.
-            ("\\<import[ \t]+\\(?:\\(safe\\>\\)[ \t]*\\)?\\(?:\\(qualified\\>\\)[ \t]*\\)?[^ \t\n()]+[ \t]*\\(?:\\(\\<as\\>\\)[ \t]*[^ \t\n()]+[ \t]*\\)?\\(\\<hiding\\>\\)?"
+            ("\\<import[ \t]+\\(?:\\(safe\\>\\)[ \t]*\\)?\\(?:\\(qualified\\>\\)[ \t]*\\)?\\(?:\"[^\"]*\"[\t ]*\\)?[^ \t\n()]+[ \t]*\\(?:\\(\\<as\\>\\)[ \t]*[^ \t\n()]+[ \t]*\\)?\\(\\<hiding\\>\\)?"
              (1 haskell-keyword-face nil lax)
              (2 haskell-keyword-face nil lax)
              (3 haskell-keyword-face nil lax)


### PR DESCRIPTION
This commit correctly highlights 'as' and 'hiding' as keywords in
statement:

import "package" A.B.C as C hiding (f)

Fixes #184.
