### PR TITLE
Add haskell-indent-tests.el.

### DIFF
--- a/tests/haskell-indent-tests.el
+++ b/tests/haskell-indent-tests.el
@@ -1,0 +1,23 @@
+(require 'ert)
+(require 'haskell-indent)
+(require 'haskell-mode)
+
+
+
+;; haskell-indent-put-region-in-literate happens to be in haskell-indent
+;; when the function is moved, move the tests also
+(ert-deftest haskell-indent-put-region-in-literate-1 ()
+  (should (equal "> literate"
+		 (with-temp-buffer
+		   (insert "literate")
+		   (literate-haskell-mode)
+		   (haskell-indent-put-region-in-literate (point-min) (point-max))
+		   (buffer-substring-no-properties (point-min) (point-max))))))
+
+(ert-deftest haskell-indent-put-region-in-literate-2 ()
+  (should (equal "literate"
+		 (with-temp-buffer
+		   (insert "> literate")
+		   (literate-haskell-mode)
+		   (haskell-indent-put-region-in-literate (point-min) (point-max) -1)
+		   (buffer-substring-no-properties (point-min) (point-max))))))


### PR DESCRIPTION
Add haskell-indent-tests.el, first two tests check haskell-indent-put-region-in-literate.

Fixes #88 in the sense that it proves there is no bug on Emacsen that we tests with.
