### PR TITLE
Allow module name completion in import statements

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -57,9 +57,9 @@
 
 (defun haskell-process-completions-at-point ()
   "A completion-at-point function using the current haskell process."
-  (let ((process (haskell-process))
-        (symbol (symbol-at-point)))
-    (when (and process symbol)
+  (when (haskell-session-maybe)
+    (let ((process (haskell-process))
+          (symbol (symbol-at-point)))
       (cl-destructuring-bind (start . end) (bounds-of-thing-at-point 'symbol)
         (let ((completions (haskell-process-get-repl-completions
                             process


### PR DESCRIPTION
I noticed that haskell-mode wasn't doing this, because ghci needs to be passed the "import " string to make it complete the module name after.

I also changed the behaviour so that it would not forcefully start a new process if there isn't one already running. I think this is standard behaviour in other modes, and it can be intrusive because it is the first thing that happens when I open a new file and it asks several questions about the new session before I can do anything else.
