### PR TITLE
OPTIONS and LANGUAGE completion using ghci

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -333,6 +333,18 @@ when Data.Map is the candidate.
   :group 'shm
   :type '(repeat 'string))
 
+(defcustom haskell-ghc-supported-languages
+  (split-string (shell-command-to-string "ghc --supported-extensions"))
+  "List of language pragmas supported by the installed version of GHC."
+  :group 'haskell
+  :type '(repeat string))
+
+(defcustom haskell-ghc-supported-options
+  (split-string (shell-command-to-string "ghc --show-options"))
+  "List of options supported by the installed version of GHC."
+  :group 'haskell
+  :type '(repeat string))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessor functions
 

--- a/haskell-yas.el
+++ b/haskell-yas.el
@@ -36,18 +36,6 @@
   :group 'haskell
   :prefix "haskell-yas-")
 
-(defcustom haskell-yas-ghc-language-pragmas
-  (split-string (shell-command-to-string "ghc --supported-extensions"))
-  "List of language pragmas supported by the installed version of GHC."
-  :group 'haskell-yas
-  :type '(repeat string))
-
-(defcustom haskell-yas-ghc-options
-  (split-string (shell-command-to-string "ghc --show-options"))
-  "List of options supported by the installed version of GHC."
-  :group 'haskell-yas
-  :type '(repeat string))
-
 (defcustom haskell-yas-completing-function 'ido-completing-read
   "Function to use for completing among alternatives."
   :group 'haskell-yas

--- a/haskell-yas.el
+++ b/haskell-yas.el
@@ -42,6 +42,12 @@
   :group 'haskell-yas
   :type '(repeat string))
 
+(defcustom haskell-yas-ghc-options
+  (split-string (shell-command-to-string "ghc --show-options"))
+  "List of options supported by the installed version of GHC."
+  :group 'haskell-yas
+  :type '(repeat string))
+
 (defcustom haskell-yas-completing-function 'ido-completing-read
   "Function to use for completing among alternatives."
   :group 'haskell-yas

--- a/haskell.el
+++ b/haskell.el
@@ -78,7 +78,7 @@
            (save-excursion
              (let ((p (point)))
                (and (search-backward "{-#" nil t)
-                  (search-forward-regexp "\\_<OPTIONS\\_>" p t))))
+                  (search-forward-regexp "\\_<OPTIONS\\(?:_GHC\\)?\\_>" p t))))
            (looking-back (rx symbol-start "-" (* (char alnum ?-)))))
         (list (match-beginning 0) (match-end 0) haskell-yas-ghc-options))
        ;; Complete LANGUAGE :complete repl ":set -X..."

--- a/haskell.el
+++ b/haskell.el
@@ -27,7 +27,6 @@
 (require 'haskell-commands)
 (require 'haskell-sandbox)
 (require 'haskell-modules)
-(require 'haskell-yas) ; import precomputed ghc options/pragmas
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic configuration hooks
@@ -80,7 +79,7 @@
                (and (search-backward "{-#" nil t)
                   (search-forward-regexp "\\_<OPTIONS\\(?:_GHC\\)?\\_>" p t))))
            (looking-back (rx symbol-start "-" (* (char alnum ?-)))))
-        (list (match-beginning 0) (match-end 0) haskell-yas-ghc-options))
+        (list (match-beginning 0) (match-end 0) haskell-ghc-supported-options))
        ;; Complete LANGUAGE :complete repl ":set -X..."
        ((and (nth 4 (syntax-ppss))
            (save-excursion
@@ -89,7 +88,7 @@
                   (search-forward-regexp "\\_<LANGUAGE\\_>" p t))))
            (setq symbol-bounds (bounds-of-thing-at-point 'symbol)))
         (list (car symbol-bounds) (cdr symbol-bounds)
-              haskell-yas-ghc-language-pragmas))
+              haskell-ghc-supported-languages))
        ((setq symbol-bounds (bounds-of-thing-at-point 'symbol))
         (cl-destructuring-bind (start . end) symbol-bounds
           (list start end

--- a/haskell.el
+++ b/haskell.el
@@ -99,11 +99,11 @@
                (names (cdr completions)) ; first string is common prefix
                (lang-options (mapcar (lambda (c) (substring c 2)) names)))
           (list start end lang-options)))
-       ((setq symbol (symbol-at-point))
-        (cl-destructuring-bind (start . end) (bounds-of-thing-at-point 'symbol)
-          (let ((completions (haskell-process-get-repl-completions
-                              process (symbol-name symbol))))
-            (list start end completions))))))))
+       ((setq symbol-bounds (bounds-of-thing-at-point 'symbol))
+        (cl-destructuring-bind (start . end) symbol-bounds
+          (list start end
+                (haskell-process-get-repl-completions
+                 process (buffer-substring-no-properties start end)))))))))
 
 ;;;###autoload
 (defun haskell-interactive-mode-return ()

--- a/snippets/haskell-mode/lang-pragma
+++ b/snippets/haskell-mode/lang-pragma
@@ -4,4 +4,4 @@
 # condition: (= (length "lang") (current-column))
 # contributor: Luke Hoersten <luke@hoersten.org>, John Wiegley
 # --
-{-# LANGUAGE `(progn (require 'haskell-yas) (haskell-yas-complete "Extension: " haskell-yas-ghc-language-pragmas))` #-}
+{-# LANGUAGE `(progn (require 'haskell-yas) (haskell-yas-complete "Extension: " haskell-ghc-supported-languages))` #-}


### PR DESCRIPTION
Similar to a previous PR, this adds completion for LANGUAGE and OPTIONS ghc pragmas inside comments, using ghci's `:complete repl ":set ..."`, which understands all language/option flags.

It's not spectacularly useful because normally (?) you'd need to type the first three (?) characters yourself before completion kicks in.

I also made a small change to some previous code to avoid some unnecessary string -> symbol -> string conversion.