### PR TITLE
haskell-cabal indent-relative on empty

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -869,7 +869,9 @@ Source names from main-is and c-sources sections are left untouched
          (indent-line-to indent)
          (beginning-of-line)
          (when (looking-at "[ ]*\\([ ]\\{2\\},[ ]*\\)")
-           (replace-match ", " t t nil 1))))))
+           (replace-match ", " t t nil 1)))))
+    (empty
+     (indent-relative)))
   (haskell-cabal-forward-to-line-entry))
 
 (defun haskell-cabal-map-sections (fun)


### PR DESCRIPTION
When on an empty line in a .cabal file, tab does an indent-relative (which was the previous behaviour).  Currently, it does nothing, so you have to hit space etc.