### PR TITLE
Add haskell-interactive-copy-to-prompt.

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -178,6 +178,21 @@ be nil.")
       (switch-to-buffer-other-window haskell-interactive-previous-buffer)
     (message "No previous buffer.")))
 
+(defun haskell-interactive-copy-to-prompt ()
+  "Copy the current line to the prompt, overwriting the current
+prompt."
+  (interactive)
+  (let ((l (buffer-substring-no-properties (line-beginning-position)
+                                           (line-end-position))))
+    ;; If it looks like the prompt is at the start of the line, chop
+    ;; it off.
+    (when (and (>= (length l) (length haskell-interactive-prompt))
+               (string= (substring l 0 (length haskell-interactive-prompt))
+                        haskell-interactive-prompt))
+      (setq l (substring l (length haskell-interactive-prompt))))
+
+    (haskell-interactive-mode-set-prompt l)))
+
 (defun haskell-interactive-mode-space (n)
   "Handle the space key."
   (interactive "p")

--- a/haskell.el
+++ b/haskell.el
@@ -83,10 +83,17 @@
   "Handle the return key."
   (interactive)
   (cond
+   ;; At a compile message, jump to the location of the error in the
+   ;; source.
    ((haskell-interactive-at-compile-message)
     (next-error-internal))
+   ;; At the input prompt, handle the expression in the usual way.
+   ((haskell-interactive-at-prompt)
+    (haskell-interactive-handle-expr))
+   ;; At any other location in the buffer, copy the line to the
+   ;; current prompt.
    (t
-    (haskell-interactive-handle-expr))))
+    (haskell-interactive-copy-to-prompt))))
 
 ;;;###autoload
 (defun haskell-session-kill (&optional leave-interactive-buffer)


### PR DESCRIPTION
This change lets you press Enter on a line in a haskell-interactive session to copy that line to the current prompt. It is a small change to make the lack of history-search (e.g. #315) slightly less painful.

In #315 Ivan suggested: "If nothing else, inf-haskell let you C-r to do a backward search in the buffer, and then hitting Enter would copy that line to the current prompt line." That's essentially what I've done.

I'm only an inexpert Emacs Lisper, so any corrections or improvements are welcome!