### PR TITLE
Fix #459: 'find-tag-marker-ring' is an obsolete variable (as of 25.1)

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -18,6 +18,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'haskell-compat)
 (require 'xref)
 (require 'haskell-process)
 (require 'haskell-font-lock)

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -18,6 +18,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'xref)
 (require 'haskell-process)
 (require 'haskell-font-lock)
 (require 'haskell-interactive-mode)
@@ -354,10 +355,9 @@ jump to the tag.
 Remember: If GHCi is busy doing something, this will delay, but
 it will always be accurate, in contrast to tags, which always
 work but are not always accurate.
-
-If the definition or tag is found, the location from which you
-jumped will be pushed onto `find-tag-marker-ring', so you can
-return to that position with `pop-tag-mark'."
+If the definition or tag is found, the location from which you jumped
+will be pushed onto `xref--marker-ring', so you can return to that
+position with `xref-pop-marker-stack'."
   (interactive "P")
   (let ((initial-loc (point-marker))
         (loc (haskell-mode-find-def (haskell-ident-at-point))))
@@ -365,8 +365,11 @@ return to that position with `pop-tag-mark'."
         (haskell-mode-handle-generic-loc loc)
       (call-interactively 'haskell-mode-tag-find))
     (unless (equal initial-loc (point-marker))
-      ;; Store position for return with `pop-tag-mark'
-      (ring-insert find-tag-marker-ring initial-loc))))
+      (save-excursion
+        (goto-char initial-loc)
+        (set-mark-command nil)
+        ;; Store position for return with `xref-pop-marker-stack'
+        (xref-push-marker-stack)))))
 
 ;;;###autoload
 (defun haskell-mode-goto-loc ()
@@ -380,7 +383,7 @@ command from GHCi."
 (defun haskell-mode-goto-span (span)
   "Jump to the span, whatever file and line and column it needs
 to to get there."
-  (ring-insert find-tag-marker-ring (point-marker))
+  (xref-push-marker-stack)
   (find-file (expand-file-name (plist-get span :path)
                                (haskell-session-cabal-dir (haskell-interactive-session))))
   (goto-char (point-min))

--- a/haskell-compat.el
+++ b/haskell-compat.el
@@ -21,6 +21,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(require 'xref nil 'noerror)
+(require 'ring)
 
 ;; Missing in Emacs23, stolen from Emacs24's `subr.el'
 (unless (fboundp 'process-live-p)
@@ -33,14 +35,12 @@ A process is considered alive if its status is `run', `open',
 
 ;; Cross-referencing commands have been replaced since Emacs 25.1.
 ;; These aliases are required to provide backward compatibility.
-(unless (require 'xref nil 'noerror)
+(unless (fboundp 'xref-push-marker-stack)
   (defalias 'xref-pop-marker-stack 'pop-tag-mark)
 
   (defun xref-push-marker-stack ()
     "Add point to the marker stack."
-    (require 'ring)
     (defvar find-tag-marker-ring)
-
     (ring-insert find-tag-marker-ring (point-marker)))
 
   (provide 'xref))

--- a/haskell-compat.el
+++ b/haskell-compat.el
@@ -31,6 +31,20 @@ A process is considered alive if its status is `run', `open',
     (memq (process-status process)
           '(run open listen connect stop))))
 
+;; Cross-referencing commands have been replaced since Emacs 25.1.
+;; These aliases are required to provide backward compatibility.
+(unless (require 'xref nil 'noerror)
+  (defalias 'xref-pop-marker-stack 'pop-tag-mark)
+
+  (defun xref-push-marker-stack ()
+    "Add point to the marker stack."
+    (require 'ring)
+    (defvar find-tag-marker-ring)
+
+    (ring-insert find-tag-marker-ring (point-marker)))
+
+  (provide 'xref))
+
 (provide 'haskell-compat)
 
 ;;; haskell-compat.el ends here

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -32,6 +32,7 @@
 
 (require 'comint)
 (require 'shell)             ; For directory tracking.
+(require 'xref)
 (require 'compile)
 (require 'haskell-mode)
 (require 'haskell-decl-scan)
@@ -568,7 +569,7 @@ The returned info is cached for reuse by `haskell-doc-mode'."
             (setq file (expand-file-name file)))
           ;; Push current location marker on the ring used by `find-tag'
           (require 'etags)
-          (ring-insert find-tag-marker-ring (point-marker))
+          (xref-push-marker-stack)
           (pop-to-buffer (find-file-noselect file))
           (when line
             (goto-char (point-min))

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -32,6 +32,7 @@
 
 (require 'comint)
 (require 'shell)             ; For directory tracking.
+(require 'haskell-compat)
 (require 'xref)
 (require 'compile)
 (require 'haskell-mode)


### PR DESCRIPTION
I have tried @vonavi's patch, proposed in #459, and it does seem to fix the described problem.

For your convenience I'm converting the patch into PR, with a hope that it can be reviewed and merged faster.