### PR TITLE
Make haskell-process-generate-tags really output TAGS

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -631,7 +631,7 @@ command from GHCi."
                (format ":!cd %s && %s | %s"
                        (haskell-session-cabal-dir
                         (haskell-process-session (car state)))
-                       "find . -name '*.hs' -or -name '*.lhs' -or -name '*.hsc' -print0"
+                       "find . -name '*.hs' -print0 -or -name '*.lhs' -print0 -or -name '*.hsc' -print0"
                        "xargs -0 hasktags -e -x"))))
       :complete (lambda (state response)
                   (when (cdr state)


### PR DESCRIPTION
The `find' invocation was only generating any output for *.hsc files.