### PR TITLE
Put Haskell symbol chars in punctuation char class.

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -465,20 +465,9 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
     (modify-syntax-entry ?\[  "(]" table)
     (modify-syntax-entry ?\]  ")[" table)
 
-    (cond ((featurep 'xemacs)
-           ;; I don't know whether this is equivalent to the below
-           ;; (modulo nesting).  -- fx
-           (modify-syntax-entry ?{  "(}5" table)
-           (modify-syntax-entry ?}  "){8" table)
-           (modify-syntax-entry ?-  "_ 1267" table))
-          (t
-           ;; In Emacs 21, the `n' indicates that they nest.
-           ;; The `b' annotation is actually ignored because it's only
-           ;; meaningful on the second char of a comment-starter, so
-           ;; on Emacs 20 and before we get wrong results.  --Stef
-           (modify-syntax-entry ?\{  "(}1nb" table)
-           (modify-syntax-entry ?\}  "){4nb" table)
-           (modify-syntax-entry ?-  "_ 123" table)))
+    (modify-syntax-entry ?\{  "(}1nb" table)
+    (modify-syntax-entry ?\}  "){4nb" table)
+    (modify-syntax-entry ?-  "_ 123" table)
     (modify-syntax-entry ?\n ">" table)
 
     (let (i lim)

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -459,7 +459,7 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
     (modify-syntax-entry ?\t " " table)
     (modify-syntax-entry ?\" "\"" table)
     (modify-syntax-entry ?\' "_" table)
-    (modify-syntax-entry ?_  "w" table)
+    (modify-syntax-entry ?_  "_" table)
     (modify-syntax-entry ?\( "()" table)
     (modify-syntax-entry ?\) ")(" table)
     (modify-syntax-entry ?\[  "(]" table)
@@ -467,36 +467,20 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
 
     (modify-syntax-entry ?\{  "(}1nb" table)
     (modify-syntax-entry ?\}  "){4nb" table)
-    (modify-syntax-entry ?-  "_ 123" table)
+    (modify-syntax-entry ?-  ". 123" table)
     (modify-syntax-entry ?\n ">" table)
-
-    (let (i lim)
-      (map-char-table
-       (lambda (k v)
-         (when (equal v '(1))
-           ;; The current Emacs 22 codebase can pass either a char
-           ;; or a char range.
-           (if (consp k)
-               (setq i (car k)
-                     lim (cdr k))
-             (setq i k
-                   lim k))
-           (while (<= i lim)
-             (when (> i 127)
-               (modify-syntax-entry i "_" table))
-             (setq i (1+ i)))))
-       (standard-syntax-table)))
 
     (modify-syntax-entry ?\` "$`" table)
     (modify-syntax-entry ?\\ "\\" table)
     (mapc (lambda (x)
-            (modify-syntax-entry x "_" table))
-          ;; Some of these are actually OK by default.
+            (modify-syntax-entry x "." table))
           "!#$%&*+./:<=>?@^|~")
 
-    ;; Precise syntax table entries for symbol characters
+    ;; Haskell symbol characters are treated as punctuation because
+    ;; they are not able to form identifiers with word constituent 'w'
+    ;; class characters.
     (dolist (charcodes haskell--char-syntax-symbols)
-      (modify-syntax-entry charcodes "_" table))
+      (modify-syntax-entry charcodes "." table))
     ;; ... and for identifier characters
     (dolist (charcodes haskell--char-syntax-identifiers)
       (modify-syntax-entry charcodes "w" table))


### PR DESCRIPTION
Emacs defines 'w' class as word chars and '_' as set that together with
'w' can form identifiers. Note that by this operators in programming
languages fall under punctuation '.' class and are treated as such by
for example c-mode, java-mode, etc.

It is confusing that characters defined in Haskell Report as 'symbol'
are NOT the same as 'symbol' character class defined in Emacs.

Fixes #311.