### PR TITLE
Force temp buffer to use spaces for indentation.

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -464,6 +464,7 @@ resultung buffer-content"
        (save-excursion
          (prog1
              (with-temp-buffer
+               (setq indent-tabs-mode nil)
                (indent-to ,start-col)
                (insert ,section-data)
                (goto-char (point-min))


### PR DESCRIPTION
This prevents the insertion of unwanted tabs in the cabal file when
auto-inserting dependencies, regardless of the user value for
`indent-tabs-mode` in the default mode (default is fundamental mode).
Solves issues #379 and #474.