### PR TITLE
DEL now deletes a region, consistent with other emacs modes

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -418,8 +418,7 @@ Preserves indentation and removes extra whitespace"
       (delete-char n)
     (on-parse-error (delete-char n)
                     (cond
-                     ((and delete-selection-mode
-                           mark-active
+                     ((and mark-active
                            (not (= (point) (mark))))
                       (delete-region (mark) (point)))
                      ((and (eq haskell-literate 'bird)


### PR DESCRIPTION
Hitting delete/backspace previously deleted only a single character, even if the region was active. This is not consistent with how other modes work. The cause was a requirement for delete-selection-mode to be active in order to delete the region. Removed this check for delete-selection-mode