### PR TITLE
Fix Haddock comment regexp

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -567,7 +567,7 @@ that should be commented under LaTeX-style literate scripts."
    ((and haskell-font-lock-haddock
          (save-excursion
            (goto-char (nth 8 state))
-           (or (looking-at "[{-]-[ \\t]*[|^*]")
+           (or (looking-at "\\({-[ ]?\\|-- \\)[|^*]")
                (and haskell-font-lock-seen-haddock
                     (looking-at "--")
                     (let ((doc nil)

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -567,7 +567,7 @@ that should be commented under LaTeX-style literate scripts."
    ((and haskell-font-lock-haddock
          (save-excursion
            (goto-char (nth 8 state))
-           (or (looking-at "\\({-[ ]?\\|-- \\)[|^*]")
+           (or (looking-at "\\(?:{- ?\\|-- \\)[|^*$]")
                (and haskell-font-lock-seen-haddock
                     (looking-at "--")
                     (let ((doc nil)


### PR DESCRIPTION
Do to some idiocy on my part, I am reopening a pull request to fix the Haddock comment regexp.  Please see the now-closed pull request #453 for some discussion and an example.

It should now only allow the following to be recognized as starting Haddock comments:

    -- docsym
    {-docsym
    {- docsym
