### PR TITLE
Make turn-on-xxx and turn-off-xxx obsolete

### DIFF
--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -36,9 +36,9 @@
 ;; To turn declaration scanning on for all Haskell buffers under the
 ;; Haskell mode of Moss&Thorn, add this to .emacs:
 ;;
-;;    (add-hook 'haskell-mode-hook 'turn-on-haskell-decl-scan)
+;;    (add-hook 'haskell-mode-hook 'haskell-decl-scan-mode)
 ;;
-;; Otherwise, call `turn-on-haskell-decl-scan'.
+;; Otherwise, call `haskell-decl-scan-mode'.
 ;;
 ;;
 ;; Customisation:
@@ -541,6 +541,7 @@ datatypes) in a Haskell file for the `imenu' package."
 (defun turn-on-haskell-decl-scan ()
   "Unconditionally activate `haskell-decl-scan-mode'."
   (interactive)
+  (declare (obsolete 'haskell-decl-scan-mode))
   (haskell-decl-scan-mode))
 
 ;;;###autoload

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1458,15 +1458,19 @@ See variable docstring."
 
 ;;;###autoload
 (defalias 'turn-on-haskell-doc-mode 'haskell-doc-mode)
+(make-obsolete 'turn-on-haskell-doc-mode 'haskell-doc-mode nil)
 
 ;;;###autoload
 (defalias 'turn-on-haskell-doc 'haskell-doc-mode)
+(make-obsolete 'turn-on-haskell-doc 'haskell-doc-mode nil)
 
 ;;@cindex  turn-off-haskell-doc-mode
 (defalias 'turn-off-haskell-doc-mode 'turn-off-haskell-doc)
+(make-obsolete 'turn-off-haskell-doc-mode 'haskell-doc-mode nil)
 
 (defun turn-off-haskell-doc ()
   "Unequivocally turn off `haskell-doc-mode' (which see)."
+  (declare (obsolete 'haskell-doc-mode nil))
   (haskell-doc-mode 0))
 
 ;;@node Check, Top level function, Switch it on or off, top

--- a/haskell-simple-indent.el
+++ b/haskell-simple-indent.el
@@ -33,9 +33,9 @@
 ;; To bind TAB to the indentation command for all Haskell buffers, add
 ;; this to .emacs:
 ;;
-;;    (add-hook 'haskell-mode-hook 'turn-on-haskell-simple-indent)
+;;    (add-hook 'haskell-mode-hook 'haskell-simple-indent)
 ;;
-;; Otherwise, call `turn-on-haskell-simple-indent'.
+;; Otherwise, call `haskell-simple-indent'.
 ;;
 ;;
 ;; Customisation:
@@ -252,11 +252,13 @@ Runs `haskell-simple-indent-hook' on activation."
 (defun turn-on-haskell-simple-indent ()
   "Turn on function `haskell-simple-indent-mode'."
   (interactive)
+  (declare (obsolete 'haskell-simple-indent-mode nil))
   (haskell-simple-indent-mode))
 
 (defun turn-off-haskell-simple-indent ()
   "Turn off function `haskell-simple-indent-mode'."
   (interactive)
+  (declare (obsolete 'haskell-simple-indent-mode nil))
   (haskell-simple-indent-mode 0))
 
 ;; Provide ourselves:


### PR DESCRIPTION
turn-on-xxx and turn-off-xxx are a very old convention. This branch modernizes usage of modes and minor modes.