### PR TITLE
Properly delimit reserverd symbols.

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -319,11 +319,11 @@ Returns keywords suitable for `font-lock-keywords'."
 
          ;; Reserved operations
          (reservedsym
-          (concat "\\S_"
+          (concat "\\S."
                   ;; (regexp-opt '(".." "::" "=" "\\" "|" "<-" "->"
                   ;;            "@" "~" "=>") t)
                   "\\(->\\|→\\|\\.\\.\\|::\\|∷\\|<-\\|←\\|=>\\|[=@\\|~]\\)"
-                  "\\S_"))
+                  "\\S."))
          ;; Reserved identifiers
          (reservedid
           (concat "\\<"


### PR DESCRIPTION
Fixes #489.