### PR TITLE
Add missing autoload cookies

### DIFF
--- a/ghc-core.el
+++ b/ghc-core.el
@@ -111,6 +111,7 @@ in the current buffer."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.hcr\\'" . ghc-core-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.dump-simpl\\'" . ghc-core-mode))
 
 ;;;###autoload

--- a/ghci-script-mode.el
+++ b/ghci-script-mode.el
@@ -27,6 +27,7 @@
     ("^:[a-z{]+ *\\+" . font-lock-keyword-face)
     ("^:[a-z{]+ " . font-lock-keyword-face)))
 
+;;;###autoload
 (define-derived-mode ghci-script-mode text-mode "GHCi-Script"
   "Major mode for working with .ghci files."
   (set (make-local-variable 'adaptive-fill-mode) nil)
@@ -48,7 +49,9 @@
   (set (make-local-variable 'dabbrev-abbrev-char-regexp) "\\sw\\|[.]")
   (setq haskell-literate nil))
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ghci\\'" . ghci-script-mode))
+
 (define-key ghci-script-mode-map (kbd "C-c C-l") 'ghci-script-mode-load)
 
 (defun ghci-script-mode-load ()


### PR DESCRIPTION
Some auto-mode-alist settings didn't have an autoload cookie applied
(correctly), making them effectively useless.  Add the missing cookies
to make the behavior consistent.