### PR TITLE
Fix font-lock-warning-face regular expression

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -372,7 +372,7 @@ Returns keywords suitable for `font-lock-keywords'."
           `(;; NOTICE the ordering below is significant
             ;;
             ("^<<<<<<< .*$" 0 'font-lock-warning-face t)
-            ("^=======" 0 'font-lock-warning-face t)
+            ("^======= .*$" 0 'font-lock-warning-face t)
             ("^>>>>>>> .*$" 0 'font-lock-warning-face t)
             ("^#.*$" 0 'font-lock-preprocessor-face t)
 


### PR DESCRIPTION
The regular expression was incorrectly matching `=======` without a
space afterwards, so headings were being incorrectly colored as
warnings.