### PR TITLE
Correct marker regexes

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -372,7 +372,8 @@ Returns keywords suitable for `font-lock-keywords'."
           `(;; NOTICE the ordering below is significant
             ;;
             ("^<<<<<<< .*$" 0 'font-lock-warning-face t)
-            ("^======= .*$" 0 'font-lock-warning-face t)
+            ("^|||||||$" 0 'font-lock-warning-face t) ; "diff3" style
+            ("^=======$" 0 'font-lock-warning-face t)
             ("^>>>>>>> .*$" 0 'font-lock-warning-face t)
             ("^#.*$" 0 'font-lock-preprocessor-face t)
 


### PR DESCRIPTION
`>>>>>>>` and `<<<<<<<` have text after, but `|||||||` and `=======`
do not.