### PR TITLE
Cleanup pragma font lock {-# .. #-}

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -173,7 +173,7 @@ This is the case if the \".\" is part of a \"forall <tvar> . <type>\"."
   :group 'haskell)
 
 (defface haskell-pragma-face
-  '((t :inherit font-lock-comment-face))
+  '((t :inherit font-lock-preprocessor-face))
   "Face used to highlight Haskell pragmas."
   :group 'haskell)
 


### PR DESCRIPTION
Fontify pragmas while fontifying comments. 	

Change default of haskell-pragma-face to font-lock-preprocessor-face as
this is closer to semantic meaning of a similar #pragma construct in cpp.