### PR TITLE
Added haskell-hayoo-url as a custom variable

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -867,6 +867,14 @@ is asked to show extra info for the items matching QUERY.."
           (hoogle-start-server)
         (error "hoogle is not installed")))))
 
+(defcustom haskell-hayoo-url "http://hayoo.fh-wedel.de/?query=%s"
+  "Default value for hayoo web site.
+"
+  :group 'haskell
+  :type '(choice
+          (const :tag "fh-wedel.de" "http://hayoo.fh-wedel.de/?query=%s")
+          string))
+
 ;;;###autoload
 (defun haskell-hayoo (query)
   "Do a Hayoo search for QUERY."
@@ -877,7 +885,7 @@ is asked to show extra info for the items matching QUERY.."
                             (format "Hayoo query (default %s): " def)
                           "Hayoo query: ")
                         nil nil def))))
-  (browse-url (format "http://holumbus.fh-wedel.de/hayoo/hayoo.html?query=%s" query)))
+  (browse-url (format haskell-hayoo-url (url-hexify-string query))))
 
 ;;;###autoload
 (defalias 'hayoo 'haskell-hayoo)


### PR DESCRIPTION
It looked like the hard-coded url was being redirected to a new url, and went with the new one as the default.  Added url-hexify-string to query.