### PR TITLE
Ensure directory exists before searching for a .cabal file

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -211,21 +211,22 @@ Return nil if no Cabal description file could be located via
 If DIR is nil, `default-directory' is used as starting point for
 directory traversal.  Upward traversal is aborted if file owner
 changes.  Uses`haskell-cabal-find-pkg-desc' internally."
-  (catch 'found
-    (let ((user (nth 2 (file-attributes (or dir default-directory))))
-          ;; Abbreviate, so as to stop when we cross ~/.
-          (root (abbreviate-file-name (or dir default-directory))))
-      ;; traverse current dir up to root as long as file owner doesn't change
-      (while (and root (equal user (nth 2 (file-attributes root))))
-        (let ((cabal-file (haskell-cabal-find-pkg-desc root)))
-          (when cabal-file
-            (throw 'found cabal-file)))
+  (let ((valid-dir (when (file-directory-p dir) dir)))
+    (catch 'found
+      (let ((user (nth 2 (file-attributes (or valid-dir default-directory))))
+            ;; Abbreviate, so as to stop when we cross ~/.
+            (root (abbreviate-file-name (or valid-dir default-directory))))
+        ;; traverse current dir up to root as long as file owner doesn't change
+        (while (and root (equal user (nth 2 (file-attributes root))))
+          (let ((cabal-file (haskell-cabal-find-pkg-desc root)))
+            (when cabal-file
+              (throw 'found cabal-file)))
 
-        (let ((proot (file-name-directory (directory-file-name root))))
-          (if (equal proot root) ;; fix-point reached?
-              (throw 'found nil)
-            (setq root proot))))
-      nil)))
+          (let ((proot (file-name-directory (directory-file-name root))))
+            (if (equal proot root) ;; fix-point reached?
+                (throw 'found nil)
+              (setq root proot))))
+        nil))))
 
 (defun haskell-cabal-find-pkg-desc (dir &optional allow-multiple)
   "Find a package description file in the directory DIR.


### PR DESCRIPTION
As requested by @gracjan in #506, this makes `haskell-cabal-find-file` check that the provided directory actually exists before using it to search for a .cabal file.