### PR TITLE
Wrap session target

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -93,9 +93,11 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
                      nil)
                (apply haskell-process-wrapper-function
                       (list
-                       (cons haskell-process-path-cabal (cons "repl" haskell-process-args-cabal-repl))))
-               (let ((target (haskell-session-target session)))
-                 (if target (list target) nil))))
+                       (append
+                        (list haskell-process-path-cabal "repl")
+                        haskell-process-args-cabal-repl
+                        (let ((target (haskell-session-target session)))
+                          (if target (list target) nil)))))))
       ('cabal-ghci
        (append (list (format "Starting inferior cabal-ghci process using %s ..."
                              haskell-process-path-cabal-ghci)

--- a/tests/haskell-process-tests.el
+++ b/tests/haskell-process-tests.el
@@ -51,7 +51,7 @@
                      (haskell-process-compute-process-log-and-command "dummy-session2" 'cabal-repl))))))
 
 (ert-deftest test-haskell-process--with-wrapper-compute-process-log-and-command-cabal-repl ()
-  (should (equal '("Starting inferior `cabal repl' process using cabal ..." "dumses2" nil "nix-shell" "default.nix" "--command" "cabal\\ repl\\ --ghc-option\\=-ferror-spans" "dumdum-session")
+  (should (equal '("Starting inferior `cabal repl' process using cabal ..." "dumses2" nil "nix-shell" "default.nix" "--command" "cabal\\ repl\\ --ghc-option\\=-ferror-spans\\ dumdum-session")
                  (let ((haskell-process-path-cabal      "cabal")
                        (haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans")))
                    (custom-set-variables '(haskell-process-wrapper-function


### PR DESCRIPTION
The session target needs to be wrapped too otherwise it gets passed as an argument to the wrapping command.