### PR TITLE
No need to specify a directory when calling cabal-find-file

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -180,7 +180,7 @@ there is no corresponding setting with that name in the .cabal
 file), then this function returns nil."
   (interactive)
   (when (and name buffer-file-name)
-    (let ((cabal-file (haskell-cabal-find-file (file-name-directory buffer-file-name))))
+    (let ((cabal-file (haskell-cabal-find-file)))
       (when (and cabal-file (file-readable-p cabal-file))
         (with-temp-buffer
           (insert-file-contents cabal-file)


### PR DESCRIPTION
It defaults to the directory of the current buffer already.