### PR TITLE
Detect advanced -- comments.

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -455,14 +455,14 @@ that should be commented under LaTeX-style literate scripts."
     ;; It's probably not worth the trouble, tho.
     ;; ("^[ \t]*\\(\\\\\\)" (1 "."))
     ;; Deal with instances of `--' which don't form a comment
-    ("\\s_\\{3,\\}" (0 (cond ((numberp (nth 4 (syntax-ppss)))
+    ("\\s.\\{3,\\}" (0 (cond ((numberp (nth 4 (syntax-ppss)))
                               ;; There are no such instances inside nestable comments
                               nil)
                              ((string-match "\\`-*\\'" (match-string 0))
                               ;; Sequence of hyphens.  Do nothing in
                               ;; case of things like `{---'.
                               nil)
-                             (t "_")))) ; other symbol sequence
+                             (t ".")))) ; other symbol sequence
     ))
 
 (defconst haskell-bird-syntactic-keywords


### PR DESCRIPTION
Double dash start a comment only when it is not a part of larger lexeme
that has symbols other than dashes. Take care of this situation properly.