### PR TITLE
Implement 'gap' rule

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -459,19 +459,19 @@ that should be commented under LaTeX-style literate scripts."
                               nil)
                              (t ".")))) ; other symbol sequence
 
-    ;; If we find a backslash inside a string that is considered to be
-    ;; escape we need to go back a little (over whitespace) and see if
-    ;; there is another backslash that is escape. In such situation
-    ;; the second one should have escape bit removed. This implements
-    ;; 'gap' rule from Haskell Report.  Backslashes outside of strings
-    ;; have their powers removed.  (Note about this strange (> 0
-    ;; (skip-syntax-backward "\\")): this skips over *escaping*
+    ;; If we find a backslash inside a string that is not preceeded by
+    ;; escaping backslash then it itself gets escape bit set. There
+    ;; can be whitespace between those two. This implements 'gap' rule
+    ;; from Haskell Report.  Backslashes outside of strings have their
+    ;; powers removed.  (Note about this strange (> 0
+    ;; (skip-syntax-backward ".")): this skips over *escaping*
     ;; backslash and leaves non-escaping onse alone.
-    ("\\s\\" (0 (when (or (not (nth 3 (syntax-ppss)))
-                          (save-excursion (and (goto-char (match-beginning 0))
-                                               (skip-syntax-backward "->")
-                                               (> 0 (skip-syntax-backward "\\")))))
-                  ".")))
+    ("\\\\" (0 (when (save-excursion (and (nth 3 (syntax-ppss))
+                                          (goto-char (match-beginning 0))
+                                          (skip-syntax-backward "->")
+                                          (or (not (eq ?\\ (char-before)))
+                                              (> 0 (skip-syntax-backward ".")))))
+                  "\\")))
     ))
 
 (defconst haskell-bird-syntactic-keywords

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -473,7 +473,7 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
     ;; defined separately.
     (mapc (lambda (x)
             (modify-syntax-entry x "." table))
-          "!#$%&*+./:<=>?@^|~")
+          "!#$%&*+./:<=>?@^|~\\")
     (modify-syntax-entry ?-  ". 123" table)
 
     (modify-syntax-entry ?\  " " table)
@@ -491,7 +491,6 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
     (modify-syntax-entry ?\n ">" table)
 
     (modify-syntax-entry ?\` "$`" table)
-    (modify-syntax-entry ?\\ "\\" table)
 
     ;; Haskell symbol characters are treated as punctuation because
     ;; they are not able to form identifiers with word constituent 'w'

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -454,6 +454,28 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
 ;; Syntax table.
 (defvar haskell-mode-syntax-table
   (let ((table (make-syntax-table)))
+
+    ;; Remove default punctuation class because because we try to use
+    ;; punctuation for a purpose of matching Haskell symbol
+    ;; characters. Previous punctuation should get an 'illegal' class,
+    ;; but Emacs does not have one. Lets treat them as whitespace as
+    ;; the next best categorization.
+    (with-syntax-table table
+      (dotimes (x 256)
+        (when (eq (char-syntax x) ?.)
+          (modify-syntax-entry x "-" table))))
+
+    ;; Now add punctuation class to characters defined by Haskell
+    ;; report as 'symbol'.  Note that ':' is also here as it is also a
+    ;; symbol although not listed among symbols. Ugh, just read
+    ;; Haskell report extra carefuly and you will understand.  Notably
+    ;; '-' is not here as it is also a comment character so has to be
+    ;; defined separately.
+    (mapc (lambda (x)
+            (modify-syntax-entry x "." table))
+          "!#$%&*+./:<=>?@^|~")
+    (modify-syntax-entry ?-  ". 123" table)
+
     (modify-syntax-entry ?\  " " table)
     (modify-syntax-entry ?\t " " table)
     (modify-syntax-entry ?\" "\"" table)
@@ -461,19 +483,15 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
     (modify-syntax-entry ?_  "_" table)
     (modify-syntax-entry ?\( "()" table)
     (modify-syntax-entry ?\) ")(" table)
-    (modify-syntax-entry ?\[  "(]" table)
-    (modify-syntax-entry ?\]  ")[" table)
+    (modify-syntax-entry ?\[ "(]" table)
+    (modify-syntax-entry ?\] ")[" table)
 
-    (modify-syntax-entry ?\{  "(}1nb" table)
-    (modify-syntax-entry ?\}  "){4nb" table)
-    (modify-syntax-entry ?-  ". 123" table)
+    (modify-syntax-entry ?\{ "(}1nb" table)
+    (modify-syntax-entry ?\} "){4nb" table)
     (modify-syntax-entry ?\n ">" table)
 
     (modify-syntax-entry ?\` "$`" table)
     (modify-syntax-entry ?\\ "\\" table)
-    (mapc (lambda (x)
-            (modify-syntax-entry x "." table))
-          "!#$%&*+./:<=>?@^|~")
 
     ;; Haskell symbol characters are treated as punctuation because
     ;; they are not able to form identifiers with word constituent 'w'


### PR DESCRIPTION
Fix #497.

Implemente rule about two backslashes separated by spaces inside of strings.

While at it fix also backslashes not being escape characters outside of strings.