### PR TITLE
add (+ tab-width) indentation proposals

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -1102,10 +1102,11 @@ the current buffer."
    (+ left-indent haskell-indentation-left-offset)))
 
 (defun haskell-indentation-push-indentation (indent)
-  (when (or (null possible-indentations)
-            (< indent (car possible-indentations)))
-    (setq possible-indentations
-          (cons indent possible-indentations))))
+  (loop for ind in (list (+ indent tab-width) indent) do
+        (when (or (null possible-indentations)
+              (< ind (car possible-indentations)))
+          (setq possible-indentations
+                (cons ind possible-indentations)))))
 
 (defun haskell-indentation-token-test ()
   (let ((current-token nil)


### PR DESCRIPTION
This adds indentation proposals on `(+ tab-indent)` 

for example, if you write

```haskell
newtype SessionId = SessionId
```

then default indentation proposals would be 


```haskell
newtype SessionId = SessionId
{ getSessionId :: Text
```

or 

```haskell
newtype SessionId = SessionId
                    { getSessionId :: Text
```

this patch adds also 

```haskell
newtype SessionId = SessionId
    { getSessionId :: Text
```

and 

```haskell
newtype SessionId = SessionId
                        { getSessionId :: Text
```

variants to indent.

In fact, it just duplicates `(+ tab-width)` for each found indentation proposal.

Unfortunately my code is hackish and this feature might be done better.