### PR TITLE
Typo in haskell-cabal-mode manual.

### DIFF
--- a/haskell-mode.texi
+++ b/haskell-mode.texi
@@ -594,7 +594,7 @@ used to visit the @file{.cabal} file.  If you wish, you can bind
 
 @lisp
 (eval-after-load "haskell-mode"
-  (define-key haskell-mode-map (kbd "C-c v c") 'haskell-cabal-visit-file))
+  '(define-key haskell-mode-map (kbd "C-c v c") 'haskell-cabal-visit-file))
 @end lisp
 
 TODO/WRITEME


### PR DESCRIPTION
There is small typo in haskell-cabal-mode manual section, ``eval-after-load`` FORM must be quoted.