### PR TITLE
Dot composition detection

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -82,9 +82,11 @@ be disabled at that position.")
 This is the case if the \".\" is part of a \"forall <tvar> . <type>\"."
   (save-excursion
     (goto-char start)
-    (not (or
-      (string= " " (string (char-after start)))
-      (string= " " (string (char-before start)))))))
+    (or (re-search-backward "\\<forall\\>[^.\"]*\\="
+                            (line-beginning-position) t)
+        (not (or
+              (string= " " (string (char-after start)))
+              (string= " " (string (char-before start))))))))
 
 (defface haskell-keyword-face
   '((t :inherit 'font-lock-keyword-face))

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -82,8 +82,9 @@ be disabled at that position.")
 This is the case if the \".\" is part of a \"forall <tvar> . <type>\"."
   (save-excursion
     (goto-char start)
-    (re-search-backward "\\<forall\\>[^.\"]*\\="
-                        (line-beginning-position) t)))
+    (not (or
+      (string= " " (string (char-after start)))
+      (string= " " (string (char-before start)))))))
 
 (defface haskell-keyword-face
   '((t :inherit 'font-lock-keyword-face))


### PR DESCRIPTION
As per https://github.com/haskell/haskell-mode/issues/589

Seems to work pretty well but I'm welcome to alternatives!

I removed the ```forall``` check since it seems redundant now.