### PR TITLE
Fix Emacs-snapshot build

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -80,7 +80,9 @@
              (let ((p (point)))
                (and (search-backward "{-#" nil t)
                   (search-forward-regexp "\\_<OPTIONS\\(?:_GHC\\)?\\_>" p t))))
-           (looking-back (rx symbol-start "-" (* (char alnum ?-)))))
+           (looking-back
+            (rx symbol-start "-" (* (char alnum ?-)))
+            (line-beginning-position)))
         (list (match-beginning 0) (match-end 0) haskell-ghc-supported-options))
        ;; Complete LANGUAGE :complete repl ":set -X..."
        ((and (nth 4 (syntax-ppss))


### PR DESCRIPTION
Currently **Emacs-snapshot** Travis-CI build fails with following error:

> In toplevel form:
> haskell.el:90:63:Error: looking-back called with 1 argument, but requires 2-3
> make: *** [haskell.elc] Error 1


~~According to documentaion of `looking-back` function in recent version
of Emacs, second and third arguments are optional. Second argument is
LIMIT, here is what documented:~~

> ~~LIMIT if non-nil speeds up the search by specifying a minimum~~
> ~~starting position, to avoid checking matches that would start~~
> ~~before LIMIT.~~

~~Thus, it turns that we can safely provide `nil` as LIMIT, which will not
affect current bahavoiur, but will fix error message.~~

Updated as suggested by @gracjan.