### PR TITLE
Check `string-match` argument type in `haskell-do-try-info` and `haskell-do-try-type`

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -581,7 +581,7 @@ command from GHCi."
             (haskell-process-send-string
              (car state)
              (if (and (stringp (cdr state))
-                      (string-match "^[A-Za-z_]" (cdr state))
+                      (string-match "^[A-Za-z_]" (cdr state)))
                  (format ":info %s" (cdr state))
                (format ":info (%s)" (cdr state)))))
       :complete (lambda (state response)
@@ -600,7 +600,7 @@ command from GHCi."
             (haskell-process-send-string
              (car state)
              (if (and (stringp (cdr state))
-                      (string-match "^[A-Za-z_]" (cdr state))
+                      (string-match "^[A-Za-z_]" (cdr state)))
                  (format ":type %s" (cdr state))
                (format ":type (%s)" (cdr state)))))
       :complete (lambda (state response)

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -580,7 +580,8 @@ command from GHCi."
       :go (lambda (state)
             (haskell-process-send-string
              (car state)
-             (if (string-match "^[A-Za-z_]" (cdr state))
+             (if (and (stringp (cdr state))
+                      (string-match "^[A-Za-z_]" (cdr state))
                  (format ":info %s" (cdr state))
                (format ":info (%s)" (cdr state)))))
       :complete (lambda (state response)
@@ -598,7 +599,8 @@ command from GHCi."
       :go (lambda (state)
             (haskell-process-send-string
              (car state)
-             (if (string-match "^[A-Za-z_]" (cdr state))
+             (if (and (stringp (cdr state))
+                      (string-match "^[A-Za-z_]" (cdr state))
                  (format ":type %s" (cdr state))
                (format ":type (%s)" (cdr state)))))
       :complete (lambda (state response)


### PR DESCRIPTION
In `haskell-do-try-info` and `haskell-do-try-type`, there is code of the form `(string-match "^[A-Za-z_]" (cdr state))` that didn't check `(stringp (cdr state))`.  This messed up my Emacs's connection to the `*haskell*` buffer when hitting space would sometimes cause an error.  Checking that `string-match` can apply to `(cdr state)` seems to have fixed this, though.