### PR TITLE
Fix `haskell-ident-at-point` uses and `haskell-ident-pos-at-point` behavior

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -621,26 +621,29 @@ command from GHCi."
   (interactive "P")
   (let ((ty (haskell-mode-type-at))
         (orig (point)))
-    (if insert-value
-        (let ((ident-pos (haskell-ident-pos-at-point)))
-          (cond
-           ((region-active-p)
-            (delete-region (region-beginning)
-                           (region-end))
-            (insert "(" ty ")")
-            (goto-char (1+ orig)))
-           ((= (line-beginning-position) (car ident-pos))
-            (goto-char (line-beginning-position))
-            (insert (haskell-fontify-as-mode ty 'haskell-mode)
-                    "\n"))
-           (t
-            (save-excursion
-	      (goto-char (car ident-pos))
-              (let ((col (current-column)))
-                (save-excursion (insert "\n")
-                                (indent-to col))
-                (insert (haskell-fontify-as-mode ty 'haskell-mode)))))))
-      (message "%s" (haskell-fontify-as-mode ty 'haskell-mode)))))
+    (unless (= (aref ty 0) ?\n)
+      ;; That seems to be what happens when `haskell-mode-type-at` fails
+      (if insert-value
+          (let ((ident-pos (or (haskell-ident-pos-at-point)
+                               (cons (point) (point)))))
+            (cond
+             ((region-active-p)
+              (delete-region (region-beginning)
+                             (region-end))
+              (insert "(" ty ")")
+              (goto-char (1+ orig)))
+             ((= (line-beginning-position) (car ident-pos))
+              (goto-char (line-beginning-position))
+              (insert (haskell-fontify-as-mode ty 'haskell-mode)
+                      "\n"))
+             (t
+              (save-excursion
+                (goto-char (car ident-pos))
+                (let ((col (current-column)))
+                  (save-excursion (insert "\n")
+                                  (indent-to col))
+                  (insert (haskell-fontify-as-mode ty 'haskell-mode)))))))
+        (message "%s" (haskell-fontify-as-mode ty 'haskell-mode))))))
 
 ;;;###autoload
 (defun haskell-process-generate-tags (&optional and-then-find-this-tag)

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1677,7 +1677,7 @@ If `haskell-doc-use-inf-haskell' is non-nil, this function will consult
 the inferior Haskell process for type/kind information, rather than using
 the haskell-doc database."
   (if haskell-doc-use-inf-haskell
-      (unless (string= "" sym)
+      (unless (or (null sym) (string= "" sym))
         (let* ((message-log-max nil)
                (result (ignore-errors
                          (unwind-protect

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -486,19 +486,18 @@ Run M-x describe-variable haskell-mode-hook for a list of such modes."))
 May return a qualified name."
   (let ((reg (haskell-ident-pos-at-point)))
     (when reg
-      (unless (= (car reg) (cdr reg))
-        (buffer-substring-no-properties (car reg) (cdr reg))))))
+      (buffer-substring-no-properties (car reg) (cdr reg)))))
 
 (defun haskell-spanable-pos-at-point ()
   "Like `haskell-ident-pos-at-point', but includes any surrounding backticks."
   (save-excursion
     (let ((pos (haskell-ident-pos-at-point)))
-      (if pos
-          (cl-destructuring-bind (start . end) pos
-            (if (and (eq ?` (char-before start))
-                     (eq ?` (char-after end)))
-                (cons (- start 1) (+ end 1))
-              (cons start end)))))))
+      (when pos
+        (cl-destructuring-bind (start . end) pos
+          (if (and (eq ?` (char-before start))
+                   (eq ?` (char-after end)))
+              (cons (- start 1) (+ end 1))
+            (cons start end)))))))
 
 (defun haskell-ident-pos-at-point ()
   "Return the span of the identifier under point, or nil if none found.
@@ -536,7 +535,8 @@ May return a qualified name."
                     (looking-at "[[:upper:]]"))
           (setq start (point)))
         ;; This is it.
-        (cons start end)))))
+        (unless (= start end)
+          (cons start end))))))
 
 (defun haskell-delete-indentation (&optional arg)
   "Like `delete-indentation' but ignoring Bird-style \">\"."

--- a/haskell.el
+++ b/haskell.el
@@ -312,7 +312,7 @@
   (let ((ident (haskell-ident-at-point))
         (tags-file-name (haskell-session-tags-filename (haskell-session)))
         (tags-revert-without-query t))
-    (when (and (stringp ident) (not (string= "" (haskell-string-trim ident))))
+    (when (and ident (not (string= "" (haskell-string-trim ident))))
       (cond ((file-exists-p tags-file-name)
              (find-tag ident next-p))
             (t (haskell-process-generate-tags ident))))))

--- a/haskell.el
+++ b/haskell.el
@@ -299,11 +299,11 @@
                           (insert (cdr mapping)))
                  (insert module)))
              (haskell-mode-format-imports)))
-          ((not (string= "" (save-excursion (forward-char -1) (haskell-ident-at-point))))
+          (t
            (let ((ident (save-excursion (forward-char -1) (haskell-ident-at-point))))
              (insert " ")
-             (haskell-process-do-try-info ident)))
-          (t (insert " ")))))
+             (when ident
+               (haskell-process-do-try-info ident)))))))
 
 ;;;###autoload
 (defun haskell-mode-jump-to-tag (&optional next-p)
@@ -312,7 +312,7 @@
   (let ((ident (haskell-ident-at-point))
         (tags-file-name (haskell-session-tags-filename (haskell-session)))
         (tags-revert-without-query t))
-    (when (not (string= "" (haskell-string-trim ident)))
+    (when (and (stringp ident) (not (string= "" (haskell-string-trim ident))))
       (cond ((file-exists-p tags-file-name)
              (find-tag ident next-p))
             (t (haskell-process-generate-tags ident))))))

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -490,7 +490,7 @@ in the buffer.  This can be done interactively with the \\[universal-argument] p
 The returned info is cached for reuse by `haskell-doc-mode'."
   (interactive
    (let ((sym (haskell-ident-at-point)))
-     (list (read-string (if (> (length sym) 0)
+     (list (read-string (if sym
                             (format "Show type of (default %s): " sym)
                           "Show type of: ")
                         nil nil sym)
@@ -526,7 +526,7 @@ The returned info is cached for reuse by `haskell-doc-mode'."
   "Query the haskell process for the kind of the given expression."
   (interactive
    (let ((type (haskell-ident-at-point)))
-     (list (read-string (if (> (length type) 0)
+     (list (read-string (if type
                             (format "Show kind of (default %s): " type)
                           "Show kind of: ")
                         nil nil type))))
@@ -539,7 +539,7 @@ The returned info is cached for reuse by `haskell-doc-mode'."
   "Query the haskell process for the info of the given expression."
   (interactive
    (let ((sym (haskell-ident-at-point)))
-     (list (read-string (if (> (length sym) 0)
+     (list (read-string (if sym
                             (format "Show info of (default %s): " sym)
                           "Show info of: ")
                         nil nil sym))))
@@ -552,7 +552,7 @@ The returned info is cached for reuse by `haskell-doc-mode'."
   "Attempt to locate and jump to the definition of the given expression."
   (interactive
    (let ((sym (haskell-ident-at-point)))
-     (list (read-string (if (> (length sym) 0)
+     (list (read-string (if sym
                             (format "Find definition of (default %s): " sym)
                           "Find definition of: ")
                         nil nil sym))))
@@ -771,7 +771,7 @@ see if this is newer than `haskell-package-conf-file' every time
 we load it."
   (interactive
    (let ((sym (haskell-ident-at-point)))
-     (list (read-string (if (> (length sym) 0)
+     (list (read-string (if sym
                             (format "Find documentation of (default %s): " sym)
                           "Find documentation of: ")
                         nil nil sym))))

--- a/tests/haskell-mode-tests.el
+++ b/tests/haskell-mode-tests.el
@@ -25,6 +25,49 @@
             (haskell-mode)
             (eq nil (haskell-ident-at-point)))))
 
+(ert-deftest empty-pos ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (eq nil (haskell-ident-pos-at-point)))))
+
+(ert-deftest empty-spanable ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (eq nil (haskell-spanable-pos-at-point)))))
+
+(ert-deftest aftercolons ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "foo ::")
+            (eq nil (haskell-ident-at-point)))))
+
+(ert-deftest aftercolons-pos ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "foo ::")
+            (eq nil (haskell-ident-pos-at-point)))))
+
+(ert-deftest beforetype ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "foo ::")
+            (save-excursion (insert " bar -> baz"))
+            (eq nil (haskell-ident-at-point)))))
+
+(ert-deftest beforetype-pos ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "foo ::")
+            (save-excursion (insert " bar -> baz"))
+            (eq nil (haskell-ident-pos-at-point)))))
+
+(ert-deftest beforetype-spanable ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "foo ::")
+            (save-excursion (insert " bar -> baz"))
+            (eq nil (haskell-spanable-pos-at-point)))))
+
 (ert-deftest single ()
   (should (with-temp-buffer
             (haskell-mode)
@@ -127,7 +170,55 @@
   (should (with-temp-buffer
             (haskell-mode)
             (insert "Äöèąċōïá")
-            (string= "Äöèąċōïá" (haskell-ident-at-point)))))
+            (string= "Äöèąċōïá" (haskell-ident-at-point)))))            
+
+(ert-deftest unicode-pos ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "åöèą5ċōïá")
+            (equal (cons (point-min) (point-max)) (haskell-ident-pos-at-point)))))
+
+(ert-deftest unicode2-pos ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "Äöèąċōïá")
+            (equal (cons (point-min) (point-max)) (haskell-ident-pos-at-point)))))
+
+(ert-deftest unicode-spanable ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "åöèą5ċōïá")
+            (equal (cons (point-min) (point-max)) (haskell-spanable-pos-at-point)))))
+
+(ert-deftest unicode2-spanable ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "Äöèąċōïá")
+            (equal (cons (point-min) (point-max)) (haskell-spanable-pos-at-point)))))
+
+(ert-deftest ident-in-backticks ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "`foo`")
+            (backward-char 2)
+            (string= "foo" (haskell-ident-at-point)))))
+
+(ert-deftest ident-pos-in-backticks ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "`foo`")
+            (backward-char 2)
+            (equal (cons (1+ (point-min)) (1- (point-max)))
+                   (haskell-ident-pos-at-point)))))
+
+(ert-deftest spanable-pos-in-backticks ()
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "`foo`")
+            (backward-char 2)
+            (equal (cons (point-min) (point-max))
+                   (haskell-spanable-pos-at-point)))))
+
 
 (defun check-fill (expected initial)
   "Check using ERT if `fill-paragraph' over `initial' gives


### PR DESCRIPTION
The documentation mandates that `haskell-ident-at-point` and `haskell-ident-pos-at-point` return `nil` if there is no identifier at point.  However:

1. Apparently, at some point `haskell-ident-at-point` instead returned `""` in that case.
2. Currently, `haskell-ident-pos-at-point` instead returns a cons cell of the form `(n . n)` in that case.

This pull request fixes two things:

1. Some code assumed that `haskell-ident-at-point` always returned a string; these assumptions have all been fixed.  (Commit f8521d90e7c200c07a84328c8d19e2993aad15ac.)
2. `haskell-ident-pos-at-point` now returns `nil` correctly, and any code relying on the old behavior was fixed.  (Commit 6a3257c54cf77084d106483090c393e18331cc4d.)

(Fixing `haskell-ident-pos-at-point` indirectly fixes `haskell-spanable-pos-at-point` in the same way.)

This directly fixes issue #334.  It also indirectly solves the problem in pull requests #601 and #602: `haskell-contextual-space` was comparing `haskell-ident-at-point` to `""` instead of `nil` at one point.