### PR TITLE
Tidy up `haskell-present` and `haskell-process-do-simple-echo` according to #607

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -300,7 +300,7 @@ If PROMPT-VALUE is non-nil, request identifier via mini-buffer."
                                   (or ident
                                       at-point))))))
         (when command
-          (haskell-process-do-simple-echo command 'haskell-mode))))))
+          (haskell-process-show-repl-response command))))))
 
 ;;;###autoload
 (defun haskell-process-do-type (&optional insert-value)
@@ -318,14 +318,13 @@ If PROMPT-VALUE is non-nil, request identifier via mini-buffer."
       ;; No newlines in expressions, and surround with parens if it
       ;; might be a slice expression
       (when expr-okay
-        (haskell-process-do-simple-echo
+        (haskell-process-show-repl-response
          (format
           (if (or (string-match-p "\\`(" expr)
-                 (string-match-p "\\`[_[:alpha:]]" expr))
+                  (string-match-p "\\`[_[:alpha:]]" expr))
               ":type %s"
             ":type (%s)")
-          expr)
-         'haskell-mode)))))
+          expr))))))
 
 ;;;###autoload
 (defun haskell-mode-jump-to-def-or-tag (&optional next-p)

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -1094,30 +1094,23 @@ don't care when the thing completes as long as it's soonish."
                           'rear-nonsticky t)))))
 
 ;;;###autoload
-(defun haskell-process-do-simple-echo (line &optional mode)
-  "Send LINE to the GHCi process and echo the result in some
-fashion, such as printing in the minibuffer, or using
-haskell-present, depending on configuration."
+(defun haskell-process-show-repl-response (line)
+  "Send LINE to the GHCi process and echo the result in some fashion.
+Result will be printed in the minibuffer or presented using
+haskell-present, depending on variable `haskell-process-use-presentation-mode'."
   (let ((process (haskell-interactive-process)))
     (haskell-process-queue-command
      process
      (make-haskell-command
-      :state (list process line mode)
+      :state (cons process line)
       :go (lambda (state)
-            (haskell-process-send-string (car state) (cadr state)))
+            (haskell-process-send-string (car state) (cdr state)))
       :complete (lambda (state response)
-                  ;; TODO: TBD: don't do this if
-                  ;; `haskell-process-use-presentation-mode' is t.
-                  (haskell-interactive-mode-echo
-                   (haskell-process-session (car state))
-                   (replace-regexp-in-string "\n\\'" "" response)
-                   (cl-caddr state))
                   (if haskell-process-use-presentation-mode
-                      (progn (haskell-present (cadr state)
-                                              (haskell-process-session (car state))
-                                              response)
-                             (haskell-session-assign
-                              (haskell-process-session (car state))))
+                      (haskell-present
+                       (cdr state)
+                       (haskell-process-session (car state))
+                       response)
                     (haskell-mode-message-line response)))))))
 
 (provide 'haskell-interactive-mode)

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -87,7 +87,11 @@
         "haskell")))
 
 (defun haskell-session-assign (session)
-  "Set the current session."
+  "Assing current buffer to SESSION.
+More verbose doc string for `haskell-session-assign`
+This could be helpfull for temporal or auxilar buffers such as
+presentation mode buffers (e.g. in case when session is killed
+with all relevant buffers)."
   (set (make-local-variable 'haskell-session) session))
 
 (defun haskell-session-choose ()


### PR DESCRIPTION
Simplify `haskell-present`:

+ do not apply text properties to hint and fontification to buffer,
  because  presentaions are fontified according to haskell mode
  automatically
+ properly assing presentation buffer to haskell session
+ make buffer readonly

Rename `haskell-process-do-simple-echo` to
`haskell-process-show-repl-response` and remove redundant mode argument

Update doc strings