### PR TITLE
Disallow leading spaces in error regexp in interactive mode.

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -444,7 +444,7 @@ SESSION, otherwise operate on the current buffer.
                                 (not visibility)))))))
 
 (defconst haskell-interactive-mode-error-regexp
-  "^\\([A-Z]?:?[^\r\n:]+\\):\\([0-9()-:]+\\):?")
+  "^\\(\\(?:[A-Z]:\\)?[^ \r\n:][^\r\n:]*\\):\\([0-9()-:]+\\):?")
 
 (defun haskell-interactive-at-compile-message ()
   "Am I on a compile message?"


### PR DESCRIPTION
Disallow leading spaces in error regexp in interactive mode.