### PR TITLE
Use haskell-ident-at-point, not thing-at-point

### DIFF
--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1604,7 +1604,7 @@ will be returned directly."
             (if (use-region-p)
                 (buffer-substring-no-properties
                  (region-beginning) (region-end))
-              (thing-at-point 'symbol 'no-properties)))
+              (haskell-ident-at-point)))
       (if sync
           (haskell-process-get-type sym #'identity t)
         (haskell-process-get-type

--- a/haskell.el
+++ b/haskell.el
@@ -93,7 +93,7 @@
            (setq symbol-bounds (bounds-of-thing-at-point 'symbol)))
         (list (car symbol-bounds) (cdr symbol-bounds)
               haskell-ghc-supported-extensions))
-       ((setq symbol-bounds (bounds-of-thing-at-point 'symbol))
+       ((setq symbol-bounds (haskell-ident-pos-at-point))
         (cl-destructuring-bind (start . end) symbol-bounds
           (list start end
                 (haskell-process-get-repl-completions


### PR DESCRIPTION
Because ?. has punctuation syntax, it doesn't get recognized as a symbol
constituent.

See also #639 