### PR TITLE
use `xref-find-definitons' instead of `find-tag'

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -702,7 +702,7 @@ happened since function invocation)."
 (defun haskell-process-generate-tags (&optional and-then-find-this-tag)
   "Regenerate the TAGS table.
 If optional AND-THEN-FIND-THIS-TAG argument is present it is used with
-function `find-tag' after new table was generated."
+function `xref-find-definitions' after new table was generated."
   (interactive)
   (let ((process (haskell-interactive-process)))
     (haskell-process-queue-command
@@ -730,7 +730,7 @@ function `find-tag' after new table was generated."
                            (haskell-process-session (car state)))))
                       (add-to-list 'tags-table-list session-tags)
                       (setq tags-file-name nil))
-                    (find-tag (cdr state)))
+                    (xref-find-definitions (cdr state)))
                   (haskell-mode-message-line "Tags generated."))))))
 
 (defun haskell-process-add-cabal-autogen ()

--- a/haskell-compat.el
+++ b/haskell-compat.el
@@ -59,6 +59,12 @@ A process is considered alive if its status is `run', `open',
 (unless (fboundp 'outline-show-subtree)
   (defalias 'outline-show-subtree 'show-subtree))
 
+(unless (fboundp 'xref-find-definitions)
+  (defun xref-find-definitions (ident)
+    (let ((next-p (and (boundp 'xref-prompt-for-identifier)
+                       xref-prompt-for-identifier)))
+      (find-tag ident next-p))))
+
 (provide 'haskell-compat)
 
 ;;; haskell-compat.el ends here

--- a/haskell.el
+++ b/haskell.el
@@ -314,7 +314,8 @@
         (tags-revert-without-query t))
     (when (and ident (not (string= "" (haskell-string-trim ident))))
       (cond ((file-exists-p tags-file-name)
-             (find-tag ident next-p))
+             (let ((xref-prompt-for-identifier next-p))
+               (xref-find-definitions ident)))
             (t (haskell-process-generate-tags ident))))))
 
 ;;;###autoload


### PR DESCRIPTION
Emacs 25 deprecates `find-tag'.  See issue #655.