### PR TITLE
Remove menu order checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,18 +119,6 @@ dir: haskell-mode.info
 	$(INSTALL_INFO) --dir=$@ $<
 
 haskell-mode.info: doc/haskell-mode.texi
-	# Check if chapter order is same as node order
-	@sed -n -e '/@chapter/ s/@code{\(.*\)}/\1/' \
-		-e 's/@chapter \(.*\)$$/* \1::/p' \
-		-e 's/@unnumbered \(.*\)$$/* \1::/p' \
-	       $< > haskell-mode-menu-order.txt
-	@sed -e '1,/@menu/ d' \
-	    -e '/end menu/,$$ d' \
-	    $< > haskell-mode-content-order.txt
-	diff -C 1 haskell-mode-menu-order.txt haskell-mode-content-order.txt
-	@rm haskell-mode-menu-order.txt haskell-mode-content-order.txt
-
-	# Processing proper
 	LANG=en_US.UTF-8 $(MAKEINFO) $(MAKEINFO_FLAGS) -o $@ $<
 
 doc/haskell-mode.html: doc/haskell-mode.texi doc/haskell-mode.css


### PR DESCRIPTION
This should be replaced with Emacs based validation. Flycheck does it,
we should check how it does it and use same method in Makefile.