### PR TITLE
Fix indentation unicode symbols.

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -587,8 +587,8 @@ the current buffer."
     ("←" . "<-")     ;; #x2190 LEFTWARDS ARROW
     ("⇒" . "=>")     ;; #x21D2 RIGHTWARDS DOUBLE ARROW
     ("∀" . "forall") ;; #x2200 FOR ALL
-    ("↢" . "-<")     ;; #x2919 LEFTWARDS ARROW-TAIL
-    ("↣" . ">-")     ;; #x291A RIGHTWARDS ARROW-TAIL
+    ("⤙" . "-<")     ;; #x2919 LEFTWARDS ARROW-TAIL
+    ("⤚" . ">-")     ;; #x291A RIGHTWARDS ARROW-TAIL
     ("⤛" . "-<<")    ;; #x291B LEFTWARDS DOUBLE ARROW-TAIL
     ("⤜" . ">>-")    ;; #x291C RIGHTWARDS DOUBLE ARROW-TAIL
     ("★" . "*"))     ;; #x2605 BLACK STAR


### PR DESCRIPTION
The GHC lexer actually uses the symbols ⤙ and ⤚ for arrow notation, and
these are the glyphs which the listed code-points and Unicode names in
the file refer to. However, the table from the GHC documentation, from
which the symbols in haskell-indentation.el seem to have been copied,
currently lists the wrong glyphs for these codepoints.

Cf.  [lexer source](https://github.com/ghc/ghc/blob/master/compiler/parser/Lexer.x). I’ve already filed a bug against the GHC docs.