### PR TITLE
Replace old completion function with new one

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -60,6 +60,9 @@
             nil
             t))
 
+(make-obsolete #'haskell-process-completions-at-point
+               #'haskell-completions-sync-completions-at-point
+               "June 19, 2015")
 (defun haskell-process-completions-at-point ()
   "A completion-at-point function using the current haskell process."
   (when (haskell-session-maybe)

--- a/haskell.el
+++ b/haskell.el
@@ -28,6 +28,7 @@
 (require 'haskell-sandbox)
 (require 'haskell-modules)
 (require 'haskell-string)
+(require 'haskell-completions)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic configuration hooks
@@ -54,7 +55,10 @@
   "Minor mode for enabling haskell-process interaction."
   :lighter " Interactive"
   :keymap interactive-haskell-mode-map
-  (add-hook 'completion-at-point-functions 'haskell-process-completions-at-point nil t))
+  (add-hook 'completion-at-point-functions
+            #'haskell-completions-sync-completions-at-point
+            nil
+            t))
 
 (defun haskell-process-completions-at-point ()
   "A completion-at-point function using the current haskell process."


### PR DESCRIPTION
New method have following features:
+ provide completions inside comments and string literals using `dabbrev` expansion
+ provide completions for pragmas (e.g. LANGUAGE, DEPRECATED, etc.)
+ provide completions for supported GHC options
+ provide completions for language extensions
+ provide completions for module names using
+ provide completions for arbitrary haskell identifiers
+ prevent Emacs to hang in case if REPL is busy

Old method does not provided completions for pragma names and words inside comments and strings.  Also it fetches completions by synchronous REPL query, this will hang Emacs for a while if REPL is busy.  New method fallbacks to dabbrev expansions immediately in this case, though the result is worst.  Old method does not provide completions for local names (e.g. defined in `let` blocks) and haskell keywords (e.g. "import", "where", etc.), and new method fallbacks to dabbrev expansions in case REPL returned no completions, so it is now possible to auto-complete local names and keywords too.  Finally, is there is no haskell session (hence REPL is not available) new method also fallbacks to dabbrev expansions.