### PR TITLE
Turn few customizable options to variables

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -336,17 +336,6 @@ same vein as `haskell-indent-spaces'."
   :group 'haskell
   :type '(repeat 'string))
 
-(defcustom haskell-ghc-supported-extensions
-  (split-string (shell-command-to-string "ghc --supported-extensions"))
-  "List of language extensions supported by the installed version of GHC."
-  :group 'haskell
-  :type '(repeat string))
-
-(defcustom haskell-ghc-supported-options
-  (split-string (shell-command-to-string "ghc --show-options"))
-  "List of options supported by the installed version of GHC."
-  :group 'haskell
-  :type '(repeat string))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessor functions

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -202,6 +202,20 @@ be set to the preferred literate style."
     map)
   "Keymap used in Haskell mode.")
 
+
+(defvar haskell-ghc-supported-extensions
+  (split-string (shell-command-to-string "ghc --supported-extensions"))
+  "List of language extensions supported by the installed version of GHC.
+This list comes from default system's GHC, i.e. first `ghc`
+executable found in PATH.")
+
+(defvar haskell-ghc-supported-options
+  (split-string (shell-command-to-string "ghc --show-options"))
+  "List of options supported by the installed version of GHC.
+This list comes from default system's GHC, i.e. first `ghc`
+executable found in PATH.")
+
+
 (defun haskell-mode-enable-process-minor-mode ()
   "Tell the user to choose a minor mode for process interaction."
   (interactive)


### PR DESCRIPTION
Turn `haskell-ghc-supported-extensions` and
`haskell-ghc-supported-options` into variables, move them outside
customize package to haskell-mode one.

Related to #730 