### PR TITLE
`haskell-interactive-bring': Use `pop-to-buffer'.

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -369,12 +369,7 @@
   (interactive)
   (let* ((session (haskell-session))
          (buffer (haskell-session-interactive-buffer session)))
-    (unless (and (cl-find-if (lambda (window) (equal (window-buffer window) buffer))
-                             (window-list))
-                 (= 2 (length (window-list))))
-      (delete-other-windows)
-      (display-buffer buffer)
-      (other-window 1))))
+    (pop-to-buffer buffer)))
 
 ;;;###autoload
 (defun haskell-process-load-file ()


### PR DESCRIPTION
This commit removes counter-intuitive logic when bringing a project buffer to the front.

One could argue that we want to make the old behavior configurable. If so, please comment here and I'll add a config option.

Fixes #710.