### PR TITLE
Add support for type/data family declarations.

### DIFF
--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -479,7 +479,8 @@ It is probably best to manipulate this data structure with the commands
     ("where" . "exp where { decl; ...; decl [;] }") ; check that ; see also class, instance, module
     ("as" . "import [qualified] modid [as modid] [impspec]")
     ("qualified" . "import [qualified] modid [as modid] [impspec]")
-    ("hiding" . "hiding ( import1 , ... , importn [ , ] )"))
+    ("hiding" . "hiding ( import1 , ... , importn [ , ] )")
+    ("family" . "(type family type [kind] [= type_fam_equations]) | (data family type [kind])")) 
   "An alist of reserved identifiers.
 Each element is of the form (ID . DOC) where both ID and DOC are strings.
 DOC should be a concise single-line string describing the construct in which

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -250,6 +250,12 @@ Returns keywords suitable for `font-lock-keywords'."
              (2 'haskell-keyword-face nil lax)
              (3 'haskell-keyword-face nil lax))
 
+            ;; Special case for `type family' and `data family'.
+            ;; `family' is only reserved in these contexts.
+            ("\\<\\(type\\|data\\)[ \t]+\\(family\\>\\)"
+             (1 'haskell-keyword-face nil lax)
+             (2 'haskell-keyword-face nil lax))
+
             ;; Toplevel Declarations.
             ;; Place them *before* generic id-and-op highlighting.
             (,topdecl-var  (1 'haskell-definition-face))

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -1163,7 +1163,7 @@ the current buffer."
 
 (defun haskell-indentation-peek-token ()
   "Return token starting at point."
-  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|rec\\|do\\|proc\\|case\\|of\\|where\\|module\\|deriving\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
+  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|rec\\|do\\|proc\\|family\\|case\\|of\\|where\\|module\\|deriving\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
          (match-string-no-properties 1))
         ((looking-at "[][(){}[,;]")
          (match-string-no-properties 0))


### PR DESCRIPTION
While type families are not part of the either the Haskell 98 or 2010 standards, they have become nearly ubiquitous. It would be nice for the syntax highlighter to support type/data family declarations. It, perhaps coincidentally, supports type/family *instance* declarations, but the word `family' is not highlighted in either 

```
type family X 
data family Y
```

This patch highlights the above correctly.