### PR TITLE
Fix regex for package version detection

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -182,7 +182,7 @@ actual Emacs buffer of the module being loaded."
            (when haskell-process-suggest-hayoo-imports
              (let ((modules (haskell-process-hayoo-ident ident)))
                (haskell-process-suggest-imports session file modules ident)))))
-        ((string-match "^[ ]+It is a member of the hidden package [‘`‛]\\(.+\\)['’].$" msg)
+        ((string-match "^[ ]+It is a member of the hidden package [‘`‛]\\([^@\r\n]+\\).*['’].$" msg)
          (when haskell-process-suggest-add-package
            (haskell-process-suggest-add-package session msg)))))
 


### PR DESCRIPTION
At least for newer ghc versions the line here looks like
```
    It is a member of the hidden package ‘xml-conduit-1.3.0@xmlco_BftDMkVAlkEFsqbeX22lfX’.
```
so only the part before the `@` should be considered.