### PR TITLE
New variable to allow user to enable/disable prompts on starting REPL

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -22,6 +22,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Customization variables
 
+(defcustom haskell-process-load-or-reload-prompt nil
+  "Nil means there will be no prompts on starting REPL. Defaults will be accepted."
+  :type 'boolean
+  :group 'haskell-interactive)
+
 (defgroup haskell nil
   "Major mode for editing Haskell programs."
   :link '(custom-manual "(haskell-mode)")

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -150,11 +150,14 @@ with all relevant buffers)."
   (haskell-session-get s 'name))
 
 (defun haskell-session-target (s)
-  "Get the session build target."
+  "Get the session build target.
+If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
   (let* ((maybe-target (haskell-session-get s 'target))
          (target (if maybe-target maybe-target
                    (let ((new-target
-                          (read-string "build target (empty for default):")))
+			  (if haskell-process-load-or-reload-prompt
+			      (read-string "build target (empty for default):")
+			    "")))
                      (haskell-session-set-target s new-target)))))
     (if (not (string= target "")) target nil)))
 

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -38,6 +38,8 @@
 ;;       require/depend-on any other haskell-mode modules in order to
 ;;       stay at the bottom of the module dependency graph.
 
+(require 'haskell-customize)
+
 (defvar haskell-utils-async-post-command-flag nil
   "Non-nil means some commands were triggered during async function execution.")
 (make-variable-buffer-local 'haskell-utils-async-post-command-flag)
@@ -45,13 +47,14 @@
 (defun haskell-utils-read-directory-name (prompt default)
   "Read directory name and normalize to true absolute path.
 Refer to `read-directory-name' for the meaning of PROMPT and
-DEFAULT."
+DEFAULT. If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
   (let ((filename (file-truename
-                   (read-directory-name prompt
-                                        default
-                                        default))))
-    (concat (replace-regexp-in-string "/$" "" filename)
-            "/")))
+		   (if haskell-process-load-or-reload-prompt
+		       (read-directory-name prompt
+					    default
+					    default)
+		     default))))
+    (concat (replace-regexp-in-string "/$" "" filename) "/")))
 
 (defun haskell-utils-parse-import-statement-at-point ()
   "Return imported module name if on import statement or nil otherwise.

--- a/haskell.el
+++ b/haskell.el
@@ -29,6 +29,8 @@
 (require 'haskell-modules)
 (require 'haskell-string)
 (require 'haskell-completions)
+(require 'haskell-utils)
+(require 'haskell-customize)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Basic configuration hooks
@@ -169,12 +171,13 @@
     session))
 
 (defun haskell-session-new-assume-from-cabal ()
-  "Prompt to create a new project based on a guess from the nearest Cabal file."
+  "Prompt to create a new project based on a guess from the nearest Cabal file.
+If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
   (let ((name (haskell-session-default-name)))
     (unless (haskell-session-lookup name)
-      (when (y-or-n-p (format "Start a new project named “%s”? "
-                              name))
-        (haskell-session-make name)))))
+      (if (or (not haskell-process-load-or-reload-prompt)
+	      (y-or-n-p (format "Start a new project named “%s”? " name)))
+	    (haskell-session-make name)))))
 
 ;;;###autoload
 (defun haskell-session ()


### PR DESCRIPTION
- Added `haskell-process-load-or-reload-p` variable with default value `t` meaning "do make prompt", so current flow is not changed unless user changes the variable to `nil`.
-  Three functions changed just to check for `haskell-process-load-or-reload-p` variable and, depending on its value, make a prompt or accept the default:
    `haskell-session-new-assume-from-cabal`

    `haskell-utils-read-directory-name`

    `haskell-session-target`