### PR TITLE
Mark various turn-on-haskell-* functions obsolete

### DIFF
--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -36,9 +36,9 @@
 ;; To turn declaration scanning on for all Haskell buffers under the
 ;; Haskell mode of Moss&Thorn, add this to .emacs:
 ;;
-;;    (add-hook 'haskell-mode-hook 'turn-on-haskell-decl-scan)
+;;    (add-hook 'haskell-mode-hook 'haskell-decl-scan-mode)
 ;;
-;; Otherwise, call `turn-on-haskell-decl-scan'.
+;; Otherwise, call `haskell-decl-scan-mode'.
 ;;
 ;;
 ;; Customisation:
@@ -542,6 +542,9 @@ datatypes) in a Haskell file for the `imenu' package."
   "Unconditionally activate `haskell-decl-scan-mode'."
   (interactive)
   (haskell-decl-scan-mode))
+(make-obsolete 'turn-on-haskell-decl-scan
+               'haskell-decl-scan-mode
+               "2015-07-23")
 
 ;;;###autoload
 (define-minor-mode haskell-decl-scan-mode

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -105,6 +105,11 @@
 ;;; Changelog:
 
 ;;  $Log: haskell-doc.el,v $
+;;  Revision 1.31 2015/07/23 10:34:20  ankhers
+;;  (turn-on-haskell-doc-mode): marked obsolete
+;;  (turn-on-haskell-doc): marked obsolete
+;;  other packages have been moving away from (turn-on-haskell-*)
+;;
 ;;  Revision 1.30  2009/02/02 21:00:33  monnier
 ;;  (haskell-doc-imported-list): Don't add current buffer
 ;;  to the imported file list if it is not (yet?) visiting a file.
@@ -1380,9 +1385,15 @@ See variable docstring."
 
 ;;;###autoload
 (defalias 'turn-on-haskell-doc-mode 'haskell-doc-mode)
+(make-obsolete 'turn-on-haskell-doc-mode
+               'haskell-doc-mode
+               "2015-07-23")
 
 ;;;###autoload
 (defalias 'turn-on-haskell-doc 'haskell-doc-mode)
+(make-obsolete 'turn-on-haskell-doc
+               'haskell-doc-mode
+               "2015-07-23")
 
 (defalias 'turn-off-haskell-doc-mode 'turn-off-haskell-doc)
 

--- a/haskell-simple-indent.el
+++ b/haskell-simple-indent.el
@@ -254,6 +254,9 @@ Runs `haskell-simple-indent-hook' on activation."
   "Turn on function `haskell-simple-indent-mode'."
   (interactive)
   (haskell-simple-indent-mode))
+(make-obsolete 'turn-on-haskell-simple-indent
+               'haskell-simple-indent-mode
+               "2015-07-23")
 
 (defun turn-off-haskell-simple-indent ()
   "Turn off function `haskell-simple-indent-mode'."


### PR DESCRIPTION
This is still a work in progress, I just want some feedback on what I have done, and what I still need to do.

1. Does it make sense to convert `turn-on-haskell-font-lock` into a minor mode?
2. I'm not really sure what to do with `turn-on-haskell-unicode-input-method`. It honestly seems fine as it is.
3. I plan on converting `turn-on-haskell-indent` into a minor mode similar to `haskell-indentation-mode`.

Fix #771 