### PR TITLE
Correctly match 'stack-ghci when running haskell-process-do-cabal.

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -201,7 +201,8 @@ actual Emacs buffer of the module being loaded."
                              (cl-ecase (haskell-process-type)
                                ('ghci haskell-process-path-cabal)
                                ('cabal-repl haskell-process-path-cabal)
-                               ('cabal-ghci haskell-process-path-cabal))
+                               ('cabal-ghci haskell-process-path-cabal)
+                               ('stack-ghci haskell-process-path-stack))
                              (cl-caddr state)))))
 
           :live
@@ -244,7 +245,8 @@ actual Emacs buffer of the module being loaded."
                    :app-name (cl-ecase (haskell-process-type)
                                ('ghci haskell-process-path-cabal)
                                ('cabal-repl haskell-process-path-cabal)
-                               ('cabal-ghci haskell-process-path-cabal))
+                               ('cabal-ghci haskell-process-path-cabal)
+                               ('stack-ghci haskell-process-path-stack))
                    :app-icon haskell-process-logo)))))))))))
 
 (defun haskell-process-echo-load-message (process buffer echo-in-repl th)


### PR DESCRIPTION
When using `stack-ghci` as a `haskell-process-type`, attempting to invoke `haskell-process-do-cabal` (or any such derived command, such as `haskell-process-cabal-build`) fails due to insufficiently comprehensive `cl-ecase` statements in haskell-load.el. Handling `stack-ghci` in these case statements makes `haskell-process-do-cabal` work as expected.