### PR TITLE
Restore `haskell-process-cd` functionality..

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -186,14 +186,16 @@ file), then this function returns nil."
           (haskell-cabal-get-setting name))))))
 
 ;;;###autoload
-(defun haskell-cabal-get-dir ()
+(defun haskell-cabal-get-dir (&optional use-defaults)
   "Get the Cabal dir for a new project. Various ways of figuring this out,
    and indeed just prompting the user. Do them all."
   (let* ((file (haskell-cabal-find-file))
          (dir (if file (file-name-directory file) default-directory)))
-    (haskell-utils-read-directory-name
-     (format "Cabal dir%s: " (if file (format " (guessed from %s)" (file-relative-name file)) ""))
-     dir)))
+    (if use-defaults
+	dir
+	(haskell-utils-read-directory-name
+	 (format "Cabal dir%s: " (if file (format " (guessed from %s)" (file-relative-name file)) ""))
+	 dir))))
 
 (defun haskell-cabal-compute-checksum (dir)
   "Compute MD5 checksum of package description file in DIR.

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -60,7 +60,7 @@ You can create new session using function `haskell-session-make'."
     (haskell-process-set (haskell-session-process session) 'is-restarting nil)
     (let ((default-directory (haskell-session-cabal-dir session))
           (log-and-command (haskell-process-compute-process-log-and-command session (haskell-process-type))))
-      (haskell-session-pwd session)
+      (haskell-session-prompt-set-current-dir session)
       (haskell-process-set-process
        process
        (progn
@@ -518,7 +518,7 @@ Requires the :loc-at command from GHCi."
   "Change directory."
   (interactive)
   (let* ((session (haskell-interactive-session))
-         (dir (haskell-session-pwd session)))
+         (dir (haskell-session-prompt-set-current-dir session)))
     (haskell-process-log
      (propertize (format "Changing directory to %s ...\n" dir)
                  'face font-lock-comment-face))
@@ -535,7 +535,7 @@ of which the latter defaults to the current buffer."
 	  (file-name-directory (buffer-file-name buffer))
 	  "~/")))
 
-(defun haskell-session-pwd (session)
+(defun haskell-session-prompt-set-current-dir (session)
   "Prompt for the current directory.
 Return current working directory for SESSION.
 Optional CHANGE argument makes user to choose new working directory for SESSION.

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -518,7 +518,7 @@ Requires the :loc-at command from GHCi."
   "Change directory."
   (interactive)
   (let* ((session (haskell-interactive-session))
-         (dir (haskell-session-pwd session t)))
+         (dir (haskell-session-pwd session)))
     (haskell-process-log
      (propertize (format "Changing directory to %s ...\n" dir)
                  'face font-lock-comment-face))
@@ -535,19 +535,16 @@ of which the latter defaults to the current buffer."
 	  (file-name-directory (buffer-file-name buffer))
 	  "~/")))
 
-(defun haskell-session-pwd (session &optional change)
+(defun haskell-session-pwd (session)
   "Prompt for the current directory.
 Return current working directory for SESSION.
 Optional CHANGE argument makes user to choose new working directory for SESSION.
 In this case new working directory path will be returned."
-  (or (unless change
-        (haskell-session-get session 'current-dir))
-      (progn
-	(haskell-session-set-current-dir
-	 session
-	 (haskell-utils-read-directory-name (if change "Change directory: " "Set current directory: ")
-					    (haskell-session-buffer-default-dir session)))
-	(haskell-session-get session 'current-dir))))
+  (haskell-session-set-current-dir
+   session
+   (haskell-utils-read-directory-name "Set current directory: "
+				      (haskell-session-buffer-default-dir session)))
+  (haskell-session-get session 'current-dir))
 
 (defun haskell-process-change-dir (session process dir)
   "Change SESSION's current directory.

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -60,7 +60,7 @@ You can create new session using function `haskell-session-make'."
     (haskell-process-set (haskell-session-process session) 'is-restarting nil)
     (let ((default-directory (haskell-session-cabal-dir session))
           (log-and-command (haskell-process-compute-process-log-and-command session (haskell-process-type))))
-      (haskell-session-prompt-set-current-dir session)
+      (haskell-session-prompt-set-current-dir session (not haskell-process-load-or-reload-prompt))
       (haskell-process-set-process
        process
        (progn
@@ -535,15 +535,15 @@ of which the latter defaults to the current buffer."
 	  (file-name-directory (buffer-file-name buffer))
 	  "~/")))
 
-(defun haskell-session-prompt-set-current-dir (session)
+(defun haskell-session-prompt-set-current-dir (session &optional use-default)
   "Prompt for the current directory.
-Return current working directory for SESSION.
-Optional CHANGE argument makes user to choose new working directory for SESSION.
-In this case new working directory path will be returned."
-  (haskell-session-set-current-dir
-   session
-   (haskell-utils-read-directory-name "Set current directory: "
-				      (haskell-session-buffer-default-dir session)))
+Return current working directory for SESSION."
+  (let ((default (haskell-session-buffer-default-dir session)))
+    (haskell-session-set-current-dir
+     session
+     (if use-default
+	 default
+	 (haskell-utils-read-directory-name "Set current directory: " default))))
   (haskell-session-get session 'current-dir))
 
 (defun haskell-process-change-dir (session process dir)

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -526,6 +526,15 @@ Requires the :loc-at command from GHCi."
                                 (haskell-interactive-process)
                                 dir)))
 
+(defun haskell-session-buffer-default-dir (session &optional buffer)
+  "Try to deduce a sensible default directory for SESSION and BUFFER,
+of which the latter defaults to the current buffer."
+  (or (haskell-session-get session 'current-dir)
+      (haskell-session-get session 'cabal-dir)
+      (if (buffer-file-name buffer)
+	  (file-name-directory (buffer-file-name buffer))
+	  "~/")))
+
 (defun haskell-session-pwd (session &optional change)
   "Prompt for the current directory.
 Return current working directory for SESSION.
@@ -533,16 +542,12 @@ Optional CHANGE argument makes user to choose new working directory for SESSION.
 In this case new working directory path will be returned."
   (or (unless change
         (haskell-session-get session 'current-dir))
-      (progn (haskell-session-set-current-dir
-              session
-              (haskell-utils-read-directory-name
-               (if change "Change directory: " "Set current directory: ")
-               (or (haskell-session-get session 'current-dir)
-                   (haskell-session-get session 'cabal-dir)
-                   (if (buffer-file-name)
-                       (file-name-directory (buffer-file-name))
-                     "~/"))))
-             (haskell-session-get session 'current-dir))))
+      (progn
+	(haskell-session-set-current-dir
+	 session
+	 (haskell-utils-read-directory-name (if change "Change directory: " "Set current directory: ")
+					    (haskell-session-buffer-default-dir session)))
+	(haskell-session-get session 'current-dir))))
 
 (defun haskell-process-change-dir (session process dir)
   "Change SESSION's current directory.

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -197,7 +197,7 @@ If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
 (defun haskell-session-cabal-dir (s)
   "Get the session cabal-dir."
   (or (haskell-session-get s 'cabal-dir)
-      (let ((set-dir (haskell-cabal-get-dir)))
+      (let ((set-dir (haskell-cabal-get-dir (not haskell-process-load-or-reload-prompt))))
 	(if set-dir
 	    (progn (haskell-session-set-cabal-dir s set-dir)
 		   set-dir)

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -62,14 +62,14 @@
   (when (and (buffer-file-name)
              (consp haskell-sessions))
     (cl-reduce (lambda (acc a)
-                 (let ((dir (haskell-session-cabal-dir a t)))
+                 (let ((dir (haskell-session-get a 'cabal-dir)))
                    (if dir
                        (if (string-prefix-p dir
 					    (file-name-directory (buffer-file-name)))
                            (if acc
                                (if (and
-                                    (> (length (haskell-session-cabal-dir a t))
-                                       (length (haskell-session-cabal-dir acc t))))
+                                    (> (length (haskell-session-get a 'cabal-dir))
+                                       (length (haskell-session-get acc 'cabal-dir))))
                                    a
                                  acc)
                              a)
@@ -194,17 +194,14 @@ If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
   (haskell-session-set s 'cabal-checksum
                        (haskell-cabal-compute-checksum cabal-dir)))
 
-(defun haskell-session-cabal-dir (s &optional no-prompt)
+(defun haskell-session-cabal-dir (s)
   "Get the session cabal-dir."
-  (let ((dir (haskell-session-get s 'cabal-dir)))
-    (if dir
-        dir
-      (unless no-prompt
-        (let ((set-dir (haskell-cabal-get-dir)))
-          (if set-dir
-              (progn (haskell-session-set-cabal-dir s set-dir)
-                     set-dir)
-            (haskell-session-cabal-dir s)))))))
+  (or (haskell-session-get s 'cabal-dir)
+      (let ((set-dir (haskell-cabal-get-dir)))
+	(if set-dir
+	    (progn (haskell-session-set-cabal-dir s set-dir)
+		   set-dir)
+	    (haskell-session-cabal-dir s)))))
 
 (defun haskell-session-modify (session key update)
   "Update the value at KEY in SESSION with UPDATE."

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -48,12 +48,7 @@
   "Read directory name and normalize to true absolute path.
 Refer to `read-directory-name' for the meaning of PROMPT and
 DEFAULT. If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
-  (let ((filename (file-truename
-		   (if haskell-process-load-or-reload-prompt
-		       (read-directory-name prompt
-					    default
-					    default)
-		     default))))
+  (let ((filename (file-truename (read-directory-name prompt default default))))
     (concat (replace-regexp-in-string "/$" "" filename) "/")))
 
 (defun haskell-utils-parse-import-statement-at-point ()


### PR DESCRIPTION
..by untangling the madness around `haskell-session-pwd`.

The names didn't correspond to the actual meanings, the branches and arguments were unused..