### PR TITLE
Scylla charybdis united

### DIFF
--- a/doc/haskell-mode.texi
+++ b/doc/haskell-mode.texi
@@ -575,10 +575,10 @@ keybindings in the @code{haskell-mode-map} keymap with the respective
   '(progn
     (define-key haskell-mode-map (kbd "C-x C-d") nil)
     (define-key haskell-mode-map (kbd "C-c C-z") 'haskell-interactive-switch)
-    (define-key haskell-mode-map (kbd "C-c C-l") 'haskell-process-load-file)
+    (define-key haskell-mode-map (kbd "C-c C-l") 'haskell-session-load-file)
     (define-key haskell-mode-map (kbd "C-c C-b") 'haskell-interactive-switch)
-    (define-key haskell-mode-map (kbd "C-c C-t") 'haskell-process-do-type)
-    (define-key haskell-mode-map (kbd "C-c C-i") 'haskell-process-do-info)
+    (define-key haskell-mode-map (kbd "C-c C-t") 'haskell-session-do-type)
+    (define-key haskell-mode-map (kbd "C-c C-i") 'haskell-session-do-info)
     (define-key haskell-mode-map (kbd "C-c M-.") nil)
     (define-key haskell-mode-map (kbd "C-c C-d") nil)))
 @end lisp

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -121,9 +121,9 @@ If I break, you can:
   3. General config:    M-x customize-mode
   4. Hide these tips:   C-h v haskell-session-show-debug-tips")))))))
 
-(defun haskell-commands-process ()
+(defun haskell-commands-session ()
   "Get the Haskell session, throws an error if not available."
-  (or (haskell-session-process (haskell-session-maybe))
+  (or (haskell-session-maybe)
       (error "No Haskell session/process associated with this
       buffer. Maybe run M-x haskell-session-change?")))
 
@@ -131,14 +131,14 @@ If I break, you can:
 (defun haskell-session-clear ()
   "Clear the current process."
   (interactive)
-  (haskell-session-reset (haskell-commands-process))
-  (haskell-session-set (haskell-commands-process) 'command-queue nil))
+  (haskell-session-reset (haskell-commands-session))
+  (haskell-session-set (haskell-commands-session) 'command-queue nil))
 
 ;;;###autoload
 (defun haskell-session-interrupt ()
   "Interrupt the process (SIGINT)."
   (interactive)
-  (interrupt-process (haskell-session-process (haskell-commands-process))))
+  (interrupt-process (haskell-session-process (haskell-commands-session))))
 
 (defun haskell-session-reload-with-fbytecode (process module-buffer)
   "Query a PROCESS to reload MODULE-BUFFER with -fbyte-code set.

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -697,8 +697,7 @@ function `xref-find-definitions' after new table was generated."
               (haskell-session-send-string
                (car state)
                (format ":!cd %s && %s | %s"
-                       (haskell-session-cabal-dir
-                        (haskell-session-session (car state)))
+                       (haskell-session-cabal-dir (car state))
                        "find . -type f \\( -name '*.hs' -or -name '*.lhs' -or -name '*.hsc' \\) -not \\( -name '#*' -or -name '.*' \\) -print0"
                        "xargs -0 hasktags -e -x"))))
       :complete (lambda (state _response)

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -94,18 +94,18 @@ You can create new session using function `haskell-session-make'."
                    "^\*\*\* WARNING: \\(.+\\) is writable by someone else, IGNORING!$")
               (let ((path (match-string 1 buffer)))
                 (haskell-session-modify
-                 (haskell-session-session process)
+                 process
                  'ignored-files
                  (lambda (files)
                    (cl-remove-duplicates (cons path files) :test 'string=)))
                 (haskell-interactive-mode-compile-warning
-                 (haskell-session-session process)
+                 process
                  (format "GHCi is ignoring: %s (run M-x haskell-session-unignore)"
                          path)))))
 
     :complete (lambda (process _)
                 (haskell-interactive-mode-echo
-                 (haskell-session-session process)
+                 process
                  (concat (nth (random (length haskell-session-greetings))
                               haskell-session-greetings)
                          (when haskell-session-show-debug-tips
@@ -692,8 +692,8 @@ function `xref-find-definitions' after new table was generated."
                 (haskell-session-send-string
                  (car state)
                  (format ":!hasktags --output=\"%s\\TAGS\" -x -e \"%s\""
-                            (haskell-session-cabal-dir (haskell-session-session (car state)))
-                            (haskell-session-cabal-dir (haskell-session-session (car state)))))
+                            (haskell-session-cabal-dir (car state))
+                            (haskell-session-cabal-dir (car state))))
               (haskell-session-send-string
                (car state)
                (format ":!cd %s && %s | %s"
@@ -705,7 +705,7 @@ function `xref-find-definitions' after new table was generated."
                   (when (cdr state)
                     (let ((session-tags
                           (haskell-session-tags-filename
-                           (haskell-session-session (car state)))))
+                           (car state))))
                       (add-to-list 'tags-table-list session-tags)
                       (setq tags-file-name nil))
                     (xref-find-definitions (cdr state)))
@@ -900,7 +900,7 @@ Requires the :uses command from GHCi."
 If variable `haskell-session-use-presentation-mode' is NIL it will output
 modified message MSG to echo area."
   (if haskell-session-use-presentation-mode
-      (let ((session (haskell-session-session (haskell-interactive-session))))
+      (let ((session (haskell-interactive-session)))
         (haskell-presentation-present session msg))
     (let ((m (haskell-utils-reduce-string msg)))
       (message m))))

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -48,36 +48,31 @@ You can create new session using function `haskell-session-make'."
   (let ((existing-process (get-process (haskell-session-name (haskell-interactive-session)))))
     (when (processp existing-process)
       (haskell-interactive-mode-echo session "Restarting process ...")
-      (haskell-session-set (haskell-session-process session) 'is-restarting t)
+      (haskell-session-set session 'is-restarting t)
       (delete-process existing-process)))
-  (let ((process (or (haskell-session-process session)
-                     (haskell-session-make (haskell-session-name session))))
-        (old-queue (haskell-session-get (haskell-session-process session)
+  (let ((old-queue (haskell-session-get session
                                         'command-queue)))
-    (haskell-session-set-process session process)
-    (haskell-session-set-session process session)
-    (haskell-session-set-cmd process nil)
-    (haskell-session-set (haskell-session-process session) 'is-restarting nil)
+    (haskell-session-set-cmd session nil)
+    (haskell-session-set session 'is-restarting nil)
     (let ((default-directory (haskell-session-cabal-dir session))
           (log-and-command (haskell-session-compute-process-log-and-command session (haskell-session-type))))
       (haskell-session-prompt-set-current-dir session (not haskell-session-load-or-reload-prompt))
       (haskell-session-set-process
-       process
+       session
        (progn
          (haskell-session-log (propertize (format "%S" log-and-command)))
          (apply #'start-process (cdr log-and-command)))))
-    (progn (set-process-sentinel (haskell-session-process process) 'haskell-session-sentinel)
-           (set-process-filter (haskell-session-process process) 'haskell-session-filter))
-    (haskell-session-send-startup process)
+    (progn (set-process-sentinel (haskell-session-process session) 'haskell-session-sentinel)
+           (set-process-filter (haskell-session-process session) 'haskell-session-filter))
+    (haskell-session-send-startup session)
     (unless (eq 'cabal-repl (haskell-session-type)) ;; "cabal repl" sets the proper CWD
       (haskell-session-change-dir session
-                                  process
+                                  session
                                   (haskell-session-current-dir session)))
-    (haskell-session-set process 'command-queue
-                         (append (haskell-session-get (haskell-session-process session)
-                                                      'command-queue)
+    (haskell-session-set session 'command-queue
+                         (append (haskell-session-get session 'command-queue)
                                  old-queue))
-    process))
+    session))
 
 (defun haskell-session-send-startup (process)
   "Send the necessary start messages to haskell PROCESS."

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -38,8 +38,8 @@
 (defun haskell-session-restart ()
   "Restart the inferior Haskell process."
   (interactive)
-  (haskell-session-reset (haskell-interactive-process))
-  (haskell-session-set (haskell-interactive-process) 'command-queue nil)
+  (haskell-session-reset (haskell-interactive-session))
+  (haskell-session-set (haskell-interactive-session) 'command-queue nil)
   (haskell-session-start (haskell-interactive-session)))
 
 (defun haskell-session-start (session)
@@ -379,7 +379,7 @@ Requires the :loc-at command from GHCi."
 Use GHCi's :type if it's possible."
   (let ((ident (haskell-ident-at-point)))
     (when ident
-      (let ((process (haskell-interactive-process))
+      (let ((process (haskell-interactive-session))
             (query (format (if (string-match "^[_[:lower:][:upper:]]" ident)
                                ":type %s"
                              ":type (%s)")
@@ -416,7 +416,7 @@ Returns:
     nil"
   (when (stringp ident)
     (let ((reply (haskell-session-queue-sync-request
-                  (haskell-interactive-process)
+                  (haskell-interactive-session)
                   (format (if (string-match "^[a-zA-Z_]" ident)
                               ":info %s"
                             ":info (%s)")
@@ -473,7 +473,7 @@ Requires the :loc-at command from GHCi."
                        (point)))))
     (when pos
       (let ((reply (haskell-session-queue-sync-request
-                    (haskell-interactive-process)
+                    (haskell-interactive-session)
                     (save-excursion
                       (format ":loc-at %s %d %d %d %d %s"
                               (buffer-file-name)
@@ -510,7 +510,7 @@ Requires the :loc-at command from GHCi."
      (propertize (format "Changing directory to %s ...\n" dir)
                  'face font-lock-comment-face))
     (haskell-session-change-dir session
-                                (haskell-interactive-process)
+                                (haskell-interactive-session)
                                 dir)))
 
 (defun haskell-session-buffer-default-dir (session &optional buffer)
@@ -556,12 +556,12 @@ Query PROCESS to `:cd` to directory DIR."
 (defun haskell-session-cabal-macros ()
   "Send the cabal macros string."
   (interactive)
-  (haskell-session-queue-without-filters (haskell-interactive-process)
+  (haskell-session-queue-without-filters (haskell-interactive-session)
                                          ":set -optP-include -optPdist/build/autogen/cabal_macros.h"))
 
 (defun haskell-session-do-try-info (sym)
   "Get info of SYM and echo in the minibuffer."
-  (let ((process (haskell-interactive-process)))
+  (let ((process (haskell-interactive-session)))
     (haskell-session-queue-command
      process
      (make-haskell-command
@@ -579,7 +579,7 @@ Query PROCESS to `:cd` to directory DIR."
 
 (defun haskell-session-do-try-type (sym)
   "Get type of SYM and echo in the minibuffer."
-  (let ((process (haskell-interactive-process)))
+  (let ((process (haskell-interactive-session)))
     (haskell-session-queue-command
      process
      (make-haskell-command
@@ -613,7 +613,7 @@ happened since function invocation)."
   (interactive "P")
   (let* ((pos (haskell-command-capture-expr-bounds))
          (req (haskell-utils-compose-type-at-command pos))
-         (process (haskell-interactive-process))
+         (process (haskell-interactive-session))
          (buf (current-buffer))
          (pos-reg (cons pos (region-active-p))))
     (haskell-session-queue-command
@@ -687,7 +687,7 @@ happened since function invocation)."
 If optional AND-THEN-FIND-THIS-TAG argument is present it is used with
 function `xref-find-definitions' after new table was generated."
   (interactive)
-  (let ((process (haskell-interactive-process)))
+  (let ((process (haskell-interactive-session)))
     (haskell-session-queue-command
      process
      (make-haskell-command
@@ -727,7 +727,7 @@ loaded by GHCi."
          (cabal-dir     (haskell-session-cabal-dir session))
          (ghci-gen-dir  (format "%sdist/build/autogen/" cabal-dir)))
       (haskell-session-queue-without-filters
-       (haskell-interactive-process)
+       (haskell-interactive-session)
        (format ":set -i%s" ghci-gen-dir)))))
 
 ;;;###autoload
@@ -869,7 +869,7 @@ Requires the :uses command from GHCi."
                        (point)))))
     (when pos
       (let ((reply (haskell-session-queue-sync-request
-                    (haskell-interactive-process)
+                    (haskell-interactive-session)
                     (save-excursion
                       (format ":uses %s %d %d %d %d %s"
                               (buffer-file-name)
@@ -905,7 +905,7 @@ Requires the :uses command from GHCi."
 If variable `haskell-session-use-presentation-mode' is NIL it will output
 modified message MSG to echo area."
   (if haskell-session-use-presentation-mode
-      (let ((session (haskell-session-session (haskell-interactive-process))))
+      (let ((session (haskell-session-session (haskell-interactive-session))))
         (haskell-presentation-present session msg))
     (let ((m (haskell-utils-reduce-string msg)))
       (message m))))

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -243,7 +243,7 @@ Returns nil if no completions available."
                           (not (eql typ 'haskell-completions-general-prefix))
                           (haskell-session-maybe)
                           (not
-                           (haskell-process-cmd (haskell-interactive-process))))
+                           (haskell-session-cmd (haskell-interactive-process))))
                      ;; if REPL is available and not busy try to query it
                      ;; for completions list in case of module name or
                      ;; identifier prefixes
@@ -256,7 +256,7 @@ Returns nil if no completions available."
 When optional IMPORT argument is non-nil complete PREFIX
 prepending \"import \" keyword (useful for module names).  This
 function is supposed for internal use."
-  (haskell-process-get-repl-completions
+  (haskell-session-get-repl-completions
    (haskell-interactive-process)
    (if import
        (concat "import " prefix)

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -243,7 +243,7 @@ Returns nil if no completions available."
                           (not (eql typ 'haskell-completions-general-prefix))
                           (haskell-session-maybe)
                           (not
-                           (haskell-session-cmd (haskell-interactive-process))))
+                           (haskell-session-cmd (haskell-interactive-session))))
                      ;; if REPL is available and not busy try to query it
                      ;; for completions list in case of module name or
                      ;; identifier prefixes
@@ -257,7 +257,7 @@ When optional IMPORT argument is non-nil complete PREFIX
 prepending \"import \" keyword (useful for module names).  This
 function is supposed for internal use."
   (haskell-session-get-repl-completions
-   (haskell-interactive-process)
+   (haskell-interactive-session)
    (if import
        (concat "import " prefix)
      prefix)))

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -23,7 +23,7 @@
 ;; Customization variables
 
 ;;;###autoload
-(defcustom haskell-process-load-or-reload-prompt nil
+(defcustom haskell-session-load-or-reload-prompt nil
   "Nil means there will be no prompts on starting REPL. Defaults will be accepted."
   :type 'boolean
   :group 'haskell-interactive)
@@ -50,7 +50,7 @@ Used for locating additional package data files.")
           (function :tag "Custom function")))
 
 ;;;###autoload
-(defcustom haskell-process-type
+(defcustom haskell-session-type
   'auto
   "The inferior Haskell process type to use.
 
@@ -71,7 +71,7 @@ If none of the above apply, ghci will be used."
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-wrapper-function
+(defcustom haskell-session-wrapper-function
   #'identity
   "Wrap or transform haskell process commands using this function.
 
@@ -110,7 +110,7 @@ when showing type information about symbols."
   :type 'boolean
   :safe 'booleanp)
 
-(defvar haskell-process-end-hook nil
+(defvar haskell-session-end-hook nil
   "Hook for when the haskell process ends.")
 
 ;;;###autoload
@@ -120,39 +120,39 @@ when showing type information about symbols."
   :group 'haskell)
 
 ;;;###autoload
-(defcustom haskell-process-path-ghci
+(defcustom haskell-session-path-ghci
   "ghci"
   "The path for starting ghci."
   :group 'haskell-interactive
   :type '(choice string (repeat string)))
 
 ;;;###autoload
-(defcustom haskell-process-path-cabal
+(defcustom haskell-session-path-cabal
   "cabal"
   "Path to the `cabal' executable."
   :group 'haskell-interactive
   :type '(choice string (repeat string)))
 
 ;;;###autoload
-(defcustom haskell-process-path-stack
+(defcustom haskell-session-path-stack
   "stack"
   "The path for starting stack."
   :group 'haskell-interactive
   :type '(choice string (repeat string)))
 
 ;;;###autoload
-(defcustom haskell-process-args-ghci
+(defcustom haskell-session-args-ghci
   '("-ferror-spans")
   "Any arguments for starting ghci."
   :group 'haskell-interactive
   :type '(repeat (string :tag "Argument")))
 
 ;;;###autoload
-(defcustom haskell-process-args-cabal-repl
+(defcustom haskell-session-args-cabal-repl
   '("--ghc-option=-ferror-spans")
   "Additional arguments for `cabal repl' invocation.
-Note: The settings in `haskell-process-path-ghci' and
-`haskell-process-args-ghci' are not automatically reused as `cabal repl'
+Note: The settings in `haskell-session-path-ghci' and
+`haskell-session-args-ghci' are not automatically reused as `cabal repl'
 currently invokes `ghc --interactive'. Use
 `--with-ghc=<path-to-executable>' if you want to use a different
 interactive GHC frontend; use `--ghc-option=<ghc-argument>' to
@@ -161,29 +161,29 @@ pass additional flags to `ghc'."
   :type '(repeat (string :tag "Argument")))
 
 ;;;###autoload
-(defcustom haskell-process-args-stack-ghci
+(defcustom haskell-session-args-stack-ghci
   '("--ghc-options=-ferror-spans")
   "Additional arguments for `stack ghci' invocation."
   :group 'haskell-interactive
   :type '(repeat (string :tag "Argument")))
 
 ;;;###autoload
-(defcustom haskell-process-do-cabal-format-string
+(defcustom haskell-session-do-cabal-format-string
   ":!cd %s && %s"
   "The way to run cabal comands. It takes two arguments -- the directory and the command.
-See `haskell-process-do-cabal' for more details."
+See `haskell-session-do-cabal' for more details."
   :group 'haskell-interactive
   :type 'string)
 
 ;;;###autoload
-(defcustom haskell-process-log
+(defcustom haskell-session-log
   nil
-  "Enable debug logging to \"*haskell-process-log*\" buffer."
+  "Enable debug logging to \"*haskell-session-log*\" buffer."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-show-debug-tips
+(defcustom haskell-session-show-debug-tips
   t
   "Show debugging tips when starting the process."
   :type 'boolean
@@ -197,42 +197,42 @@ See `haskell-process-do-cabal' for more details."
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-no-warn-orphans
+(defcustom haskell-session-suggest-no-warn-orphans
   t
   "Suggest adding -fno-warn-orphans pragma to file when getting orphan warnings."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-hoogle-imports
+(defcustom haskell-session-suggest-hoogle-imports
   nil
   "Suggest to add import statements using Hoogle as a backend."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-hayoo-imports
+(defcustom haskell-session-suggest-hayoo-imports
   nil
   "Suggest to add import statements using Hayoo as a backend."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-hayoo-query-url
+(defcustom haskell-session-hayoo-query-url
   "http://hayoo.fh-wedel.de/json/?query=%s"
   "Query url for json hayoo results."
   :type 'string
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-haskell-docs-imports
+(defcustom haskell-session-suggest-haskell-docs-imports
   nil
   "Suggest to add import statements using haskell-docs as a backend."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-add-package
+(defcustom haskell-session-suggest-add-package
   t
   "Suggest to add packages to your .cabal file when Cabal says it
 is a member of the hidden package, blah blah."
@@ -240,28 +240,28 @@ is a member of the hidden package, blah blah."
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-language-pragmas
+(defcustom haskell-session-suggest-language-pragmas
   t
   "Suggest adding LANGUAGE pragmas recommended by GHC."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-remove-import-lines
+(defcustom haskell-session-suggest-remove-import-lines
   nil
   "Suggest removing import lines as warned by GHC."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-overloaded-strings
+(defcustom haskell-session-suggest-overloaded-strings
   t
   "Suggest adding OverloadedStrings pragma to file when getting type mismatches with [Char]."
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-check-cabal-config-on-load
+(defcustom haskell-session-check-cabal-config-on-load
   t
   "Check changes cabal config on loading Haskell files and
 restart the GHCi process if changed.."
@@ -269,7 +269,7 @@ restart the GHCi process if changed.."
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-prompt-restart-on-cabal-change
+(defcustom haskell-session-prompt-restart-on-cabal-change
   t
   "Ask whether to restart the GHCi process when the Cabal file
 has changed?"
@@ -277,14 +277,14 @@ has changed?"
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-auto-import-loaded-modules
+(defcustom haskell-session-auto-import-loaded-modules
   nil
   "Auto import the modules reported by GHC to have been loaded?"
   :type 'boolean
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-reload-with-fbytecode
+(defcustom haskell-session-reload-with-fbytecode
   nil
   "When using -fobject-code, auto reload with -fbyte-code (and
 then restore the -fobject-code) so that all module info and
@@ -293,7 +293,7 @@ imports become available?"
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-use-presentation-mode
+(defcustom haskell-session-use-presentation-mode
   nil
   "Use presentation mode to show things like type info instead of
   printing to the message area."
@@ -301,7 +301,7 @@ imports become available?"
   :group 'haskell-interactive)
 
 ;;;###autoload
-(defcustom haskell-process-suggest-restart
+(defcustom haskell-session-suggest-restart
   t
   "Suggest restarting the process when it has died"
   :type 'boolean
@@ -408,9 +408,9 @@ same vein as `haskell-indent-spaces'."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessor functions
 
-(defun haskell-process-type ()
-  "Return `haskell-process-type', or a guess if that variable is 'auto."
-  (if (eq 'auto haskell-process-type)
+(defun haskell-session-type ()
+  "Return `haskell-session-type', or a guess if that variable is 'auto."
+  (if (eq 'auto haskell-session-type)
       (cond
        ;; User has explicitly initialized this project with cabal
        ((locate-dominating-file default-directory "cabal.sandbox.config")
@@ -424,6 +424,6 @@ same vein as `haskell-indent-spaces'."
            (cl-find-if (lambda (f) (string-match-p ".\\.cabal\\'" f)) (directory-files d))))
         'cabal-repl)
        (t 'ghci))
-    haskell-process-type))
+    haskell-session-type))
 
 (provide 'haskell-customize)

--- a/haskell-debug.el
+++ b/haskell-debug.el
@@ -129,7 +129,7 @@
   "Abandon the current computation."
   (interactive)
   (haskell-debug-with-breakpoints
-   (haskell-process-queue-sync-request (haskell-debug-process) ":abandon")
+   (haskell-session-queue-sync-request (haskell-debug-process) ":abandon")
    (message "Computation abandoned.")
    (setq haskell-debug-history-cache nil)
    (setq haskell-debug-bindings-cache nil)
@@ -139,7 +139,7 @@
   "Continue the current computation."
   (interactive)
   (haskell-debug-with-breakpoints
-   (haskell-process-queue-sync-request (haskell-debug-process) ":continue")
+   (haskell-session-queue-sync-request (haskell-debug-process) ":continue")
    (message "Computation continued.")
    (setq haskell-debug-history-cache nil)
    (setq haskell-debug-bindings-cache nil)
@@ -151,7 +151,7 @@
   (haskell-debug-with-modules
    (let ((ident (read-from-minibuffer "Function: "
                                       (haskell-ident-at-point))))
-     (haskell-process-queue-sync-request
+     (haskell-session-queue-sync-request
       (haskell-debug-process)
       (concat ":break "
               ident))
@@ -225,7 +225,7 @@
     (let ((break (get-text-property (point) 'break)))
       (when (y-or-n-p (format "Delete breakpoint #%d?"
                               (plist-get break :number)))
-        (haskell-process-queue-sync-request
+        (haskell-session-queue-sync-request
          (haskell-debug-process)
          (format ":delete %d"
                  (plist-get break :number)))
@@ -238,7 +238,7 @@
    (haskell-debug-with-breakpoints
     (let ((expr (read-from-minibuffer "Expression to trace: "
                                       (haskell-ident-at-point))))
-      (haskell-process-queue-sync-request
+      (haskell-session-queue-sync-request
        (haskell-debug-process)
        (concat ":trace " expr))
       (message "Tracing expression: %s" expr)
@@ -251,7 +251,7 @@
    (let* ((breakpoints (haskell-debug-get-breakpoints))
           (context (haskell-debug-get-context))
           (string
-           (haskell-process-queue-sync-request
+           (haskell-session-queue-sync-request
             (haskell-debug-process)
             (if expr
                 (concat ":step " expr)
@@ -276,7 +276,7 @@
                  (message "Reloading and resetting breakpoints...")
                  (haskell-interactive-mode-reset-error (haskell-debug-session))
                  (cl-loop for break in breakpoints
-                          do (haskell-process-queue-sync-request
+                          do (haskell-session-queue-sync-request
                               (haskell-debug-process)
                               (concat ":load " (plist-get break :path))))
                  (cl-loop for break in breakpoints
@@ -306,7 +306,7 @@
 
 (defun haskell-debug-get-breakpoints ()
   "Get the list of breakpoints currently set."
-  (let ((string (haskell-process-queue-sync-request
+  (let ((string (haskell-session-queue-sync-request
                  (haskell-debug-process)
                  ":show breaks")))
     (if (string= string "No active breakpoints.\n")
@@ -316,7 +316,7 @@
 
 (defun haskell-debug-get-modules ()
   "Get the list of modules currently set."
-  (let ((string (haskell-process-queue-sync-request
+  (let ((string (haskell-session-queue-sync-request
                  (haskell-debug-process)
                  ":show modules")))
     (if (string= string "")
@@ -326,7 +326,7 @@
 
 (defun haskell-debug-get-context ()
   "Get the current context."
-  (let ((string (haskell-process-queue-sync-request
+  (let ((string (haskell-session-queue-sync-request
                  (haskell-debug-process)
                  ":show context")))
     (if (string= string "")
@@ -335,7 +335,7 @@
 
 (defun haskell-debug-get-history ()
   "Get the step history."
-  (let ((string (haskell-process-queue-sync-request
+  (let ((string (haskell-session-queue-sync-request
                  (haskell-debug-process)
                  ":history")))
     (if (or (string= string "")
@@ -642,7 +642,7 @@ variances in source span notation."
 
 (defun haskell-debug-break (break)
   "Set BREAK breakpoint in module at line/col."
-  (haskell-process-queue-without-filters
+  (haskell-session-queue-without-filters
    (haskell-debug-process)
    (format ":break %s %s %d"
            (plist-get break :module)
@@ -651,7 +651,7 @@ variances in source span notation."
 
 (defun haskell-debug-navigate (direction)
   "Navigate in DIRECTION \"back\" or \"forward\"."
-  (let ((string (haskell-process-queue-sync-request
+  (let ((string (haskell-session-queue-sync-request
                  (haskell-debug-process)
                  (concat ":" direction))))
     (let ((bindings (haskell-debug-parse-logged string)))

--- a/haskell-debug.el
+++ b/haskell-debug.el
@@ -295,7 +295,7 @@
 
 (defun haskell-debug-process ()
   "Get the Haskell session."
-  (or (haskell-session-process (haskell-session-maybe))
+  (or (haskell-session-maybe)
       (error "No Haskell session associated with this debug
       buffer. Please just close the buffer and start again.")))
 

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1543,8 +1543,7 @@ CALLBACK will be called with a formatted type string.
 
 If SYNC is non-nil, make the call synchronously instead."
   (unless callback (setq callback (lambda (response) (message "%s" response))))
-  (let ((process (and (haskell-session-maybe)
-                    (haskell-session-process (haskell-session-maybe))))
+  (let ((process (haskell-session-maybe))
         ;; Avoid passing bad strings to ghci
         (expr-okay
          (and (not (string-match-p "\\`[[:space:]]*\\'" expr-string))

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1507,7 +1507,7 @@ current buffer."
   hasn't been displayed yet.")
 
 (defun haskell-doc-current-info--interaction (&optional sync)
-  "Asynchronous call to `haskell-process-get-type', suitable for
+  "Asynchronous call to `haskell-session-get-type', suitable for
 use in the eldoc function `haskell-doc-current-info'.
 
 If SYNC is non-nil, the call will be synchronous instead, and
@@ -1527,14 +1527,14 @@ will be returned directly."
                  (region-beginning) (region-end))
               (haskell-ident-at-point)))
       (if sync
-          (haskell-process-get-type sym #'identity t)
-        (haskell-process-get-type
+          (haskell-session-get-type sym #'identity t)
+        (haskell-session-get-type
          sym (lambda (response)
                (setq haskell-doc-current-info--interaction-last
                      (cons 'async response))
                (eldoc-print-current-symbol-info))))))))
 
-(defun haskell-process-get-type (expr-string &optional callback sync)
+(defun haskell-session-get-type (expr-string &optional callback sync)
   "Asynchronously get the type of a given string.
 
 EXPR-STRING should be an expression passed to :type in ghci.
@@ -1573,16 +1573,16 @@ If SYNC is non-nil, make the call synchronously instead."
              response))))
     (when (and process expr-okay)
       (if sync
-          (let ((response (haskell-process-queue-sync-request process ghci-command)))
+          (let ((response (haskell-session-queue-sync-request process ghci-command)))
             (funcall callback (funcall process-response response)))
         (lexical-let ((process process)
                       (callback callback)
                       (ghci-command ghci-command)
                       (process-response process-response))
-          (haskell-process-queue-command
+          (haskell-session-queue-command
            process
            (make-haskell-command
-            :go (lambda (_) (haskell-process-send-string process ghci-command))
+            :go (lambda (_) (haskell-session-send-string process ghci-command))
             :complete
             (lambda (_ response)
               (funcall callback (funcall process-response response))))))

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -710,12 +710,6 @@ FILE-NAME only."
            (haskell-session-choose)
            (error "No session associated with this buffer. Try M-x haskell-session-change or report this as a bug.")))))
 
-(defun haskell-interactive-session ()
-  "Get the Haskell session."
-  (or (haskell-session-process (haskell-interactive-session))
-      (error "No Haskell session/process associated with this
-      buffer. Maybe run M-x haskell-session-restart?")))
-
 (defun haskell-interactive-mode-do-presentation (expr)
   "Present the given expression. Requires the `present` package
   to be installed. Will automatically import it qualified as Present."

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -563,7 +563,7 @@ FILE-NAME only."
                    cabal-file))
       (haskell-cabal-add-dependency package-name version nil t)
       (when (y-or-n-p (format "Enable -package %s in the GHCi session?" package-name))
-        (haskell-session-queue-without-filters (haskell-session-process session)
+        (haskell-session-queue-without-filters session
                                                (format ":set -package %s" package-name))))))
 
 (defun haskell-session-suggest-remove-import (session file import line)

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -525,7 +525,7 @@ FILE-NAME only."
 (defun haskell-session-cabal-live (state buffer)
   "Do live updates for Cabal processes."
   (haskell-interactive-mode-insert
-   (haskell-session-session (cadr state))
+   (cadr state)
    (replace-regexp-in-string
     haskell-session-prompt-regex
     ""
@@ -1102,7 +1102,7 @@ function `haskell-presentation-present', depending on variable
       :complete (lambda (state response)
                   (if haskell-session-use-presentation-mode
                       (haskell-presentation-present
-                       (haskell-session-session (car state))
+                       (car state)
                        response)
                     (haskell-mode-message-line response)))))))
 

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -710,7 +710,7 @@ FILE-NAME only."
            (haskell-session-choose)
            (error "No session associated with this buffer. Try M-x haskell-session-change or report this as a bug.")))))
 
-(defun haskell-interactive-process ()
+(defun haskell-interactive-session ()
   "Get the Haskell session."
   (or (haskell-session-process (haskell-interactive-session))
       (error "No Haskell session/process associated with this
@@ -719,7 +719,7 @@ FILE-NAME only."
 (defun haskell-interactive-mode-do-presentation (expr)
   "Present the given expression. Requires the `present` package
   to be installed. Will automatically import it qualified as Present."
-  (let ((p (haskell-interactive-process)))
+  (let ((p (haskell-interactive-session)))
     ;; If Present.code isn't available, we probably need to run the
     ;; setup.
     (unless (string-match "^Present" (haskell-session-queue-sync-request p ":t Present.encode"))
@@ -744,7 +744,7 @@ FILE-NAME only."
 (defun haskell-interactive-mode-present-id (hash id)
   "Generate a presentation for the current expression at ID."
   ;; See below for commentary of this statement.
-  (let ((p (haskell-interactive-process)))
+  (let ((p (haskell-interactive-session)))
     (haskell-session-queue-without-filters
      p "let _it = it")
     (let* ((text (haskell-session-queue-sync-request
@@ -999,7 +999,7 @@ don't care when the thing completes as long as it's soonish."
 (defun haskell-interactive-mode-completion-at-point-function ()
   "Offer completions for partial expression between prompt and point"
   (when (haskell-interactive-at-prompt)
-    (let* ((process (haskell-interactive-process))
+    (let* ((process (haskell-interactive-session))
            (inp (haskell-interactive-mode-input-partial)))
       (if (string= inp (car-safe haskell-interactive-mode-completion-cache))
           (cdr haskell-interactive-mode-completion-cache)
@@ -1027,9 +1027,9 @@ don't care when the thing completes as long as it's soonish."
      ((and (not (haskell-interactive-mode-line-is-query (elt state 2)))
            (or (string-match "No instance for (?Show[ \n]" response)
                (string-match "Ambiguous type variable " response)))
-      (haskell-session-reset (haskell-interactive-process))
+      (haskell-session-reset (haskell-interactive-session))
       (let ((resp (haskell-session-queue-sync-request
-                   (haskell-interactive-process)
+                   (haskell-interactive-session)
                    (concat ":t "
                            (buffer-substring-no-properties
                             haskell-interactive-mode-prompt-start
@@ -1098,7 +1098,7 @@ don't care when the thing completes as long as it's soonish."
 Result will be printed in the minibuffer or presented using
 function `haskell-presentation-present', depending on variable
 `haskell-session-use-presentation-mode'."
-  (let ((process (haskell-interactive-process)))
+  (let ((process (haskell-interactive-session)))
     (haskell-session-queue-command
      process
      (make-haskell-command

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -70,7 +70,7 @@ interference with prompts that look like haskell expressions."
     (define-key map (kbd "C-a") 'haskell-interactive-mode-beginning)
     (define-key map (kbd "<home>") 'haskell-interactive-mode-beginning)
     (define-key map (kbd "C-c C-k") 'haskell-interactive-mode-clear)
-    (define-key map (kbd "C-c C-c") 'haskell-process-interrupt)
+    (define-key map (kbd "C-c C-c") 'haskell-session-interrupt)
     (define-key map (kbd "C-c C-f") 'next-error-follow-minor-mode)
     (define-key map (kbd "C-c C-z") 'haskell-interactive-switch-back)
     (define-key map (kbd "M-p") 'haskell-interactive-mode-history-previous)
@@ -522,18 +522,18 @@ FILE-NAME only."
         (switch-to-buffer-other-window buffer)
         buffer))))
 
-(defun haskell-process-cabal-live (state buffer)
+(defun haskell-session-cabal-live (state buffer)
   "Do live updates for Cabal processes."
   (haskell-interactive-mode-insert
-   (haskell-process-session (cadr state))
+   (haskell-session-session (cadr state))
    (replace-regexp-in-string
-    haskell-process-prompt-regex
+    haskell-session-prompt-regex
     ""
     (substring buffer (cl-cadddr state))))
   (setf (cl-cdddr state) (list (length buffer)))
   nil)
 
-(defun haskell-process-parse-error (string)
+(defun haskell-session-parse-error (string)
   "Parse the line number from the error."
   (let ((span nil))
     (cl-loop for regex
@@ -549,7 +549,7 @@ FILE-NAME only."
                                       (string-to-number (match-string 5 string)))))))
     span))
 
-(defun haskell-process-suggest-add-package (session msg)
+(defun haskell-session-suggest-add-package (session msg)
   "Add the (matched) module to your cabal file."
   (let* ((suggested-package (match-string 1 msg))
          (package-name (replace-regexp-in-string "-[^-]+$" "" suggested-package))
@@ -563,10 +563,10 @@ FILE-NAME only."
                    cabal-file))
       (haskell-cabal-add-dependency package-name version nil t)
       (when (y-or-n-p (format "Enable -package %s in the GHCi session?" package-name))
-        (haskell-process-queue-without-filters (haskell-session-process session)
+        (haskell-session-queue-without-filters (haskell-session-process session)
                                                (format ":set -package %s" package-name))))))
 
-(defun haskell-process-suggest-remove-import (session file import line)
+(defun haskell-session-suggest-remove-import (session file import line)
   "Suggest removing or commenting out IMPORT on LINE."
   (let ((first t))
     (cl-case (read-event
@@ -577,7 +577,7 @@ FILE-NAME only."
                                   import)
                           'face 'minibuffer-prompt))
       (?y
-       (haskell-process-find-file session file)
+       (haskell-session-find-file session file)
        (save-excursion
          (goto-char (point-min))
          (forward-line (1- line))
@@ -587,14 +587,14 @@ FILE-NAME only."
       (?n
        (message "Ignoring redundant import %s" import))
       (?c
-       (haskell-process-find-file session file)
+       (haskell-session-find-file session file)
        (save-excursion
          (goto-char (point-min))
          (forward-line (1- line))
          (goto-char (line-beginning-position))
          (insert "-- "))))))
 
-(defun haskell-process-find-file (session file)
+(defun haskell-session-find-file (session file)
   "Find the given file in the project."
   (find-file (cond ((file-exists-p (concat (haskell-session-current-dir session) "/" file))
                     (concat (haskell-session-current-dir session) "/" file))
@@ -602,11 +602,11 @@ FILE-NAME only."
                     (concat (haskell-session-cabal-dir session) "/" file))
                    (t file))))
 
-(defun haskell-process-suggest-pragma (session pragma extension file)
+(defun haskell-session-suggest-pragma (session pragma extension file)
   "Suggest to add something to the top of the file."
   (let ((string  (format "{-# %s %s #-}" pragma extension)))
     (when (y-or-n-p (format "Add %s to the top of the file? " string))
-      (haskell-process-find-file session file)
+      (haskell-session-find-file session file)
       (save-excursion
         (goto-char (point-min))
         (insert (concat string "\n"))))))
@@ -672,7 +672,7 @@ FILE-NAME only."
 
       (when (string-match haskell-interactive-mode-error-regexp orig-line)
         (let* ((msgmrk (set-marker (make-marker) (line-beginning-position)))
-               (location (haskell-process-parse-error orig-line))
+               (location (haskell-session-parse-error orig-line))
                (file (plist-get location :file))
                (line (plist-get location :line))
                (col1 (plist-get location :col))
@@ -714,7 +714,7 @@ FILE-NAME only."
   "Get the Haskell session."
   (or (haskell-session-process (haskell-interactive-session))
       (error "No Haskell session/process associated with this
-      buffer. Maybe run M-x haskell-process-restart?")))
+      buffer. Maybe run M-x haskell-session-restart?")))
 
 (defun haskell-interactive-mode-do-presentation (expr)
   "Present the given expression. Requires the `present` package
@@ -722,16 +722,16 @@ FILE-NAME only."
   (let ((p (haskell-interactive-process)))
     ;; If Present.code isn't available, we probably need to run the
     ;; setup.
-    (unless (string-match "^Present" (haskell-process-queue-sync-request p ":t Present.encode"))
+    (unless (string-match "^Present" (haskell-session-queue-sync-request p ":t Present.encode"))
       (haskell-interactive-mode-setup-presentation p))
     ;; Happily, let statements don't affect the `it' binding in any
     ;; way, so we can fake it, no pun intended.
-    (let ((error (haskell-process-queue-sync-request
+    (let ((error (haskell-session-queue-sync-request
                   p (concat "let it = Present.asData (" expr ")"))))
       (if (not (string= "" error))
           (haskell-interactive-mode-eval-result (haskell-interactive-session) (concat error "\n"))
         (let ((hash (haskell-interactive-mode-presentation-hash)))
-          (haskell-process-queue-sync-request
+          (haskell-session-queue-sync-request
            p (format "let %s = Present.asData (%s)" hash expr))
           (let* ((presentation (haskell-interactive-mode-present-id
                                 hash
@@ -745,9 +745,9 @@ FILE-NAME only."
   "Generate a presentation for the current expression at ID."
   ;; See below for commentary of this statement.
   (let ((p (haskell-interactive-process)))
-    (haskell-process-queue-without-filters
+    (haskell-session-queue-without-filters
      p "let _it = it")
-    (let* ((text (haskell-process-queue-sync-request
+    (let* ((text (haskell-session-queue-sync-request
                   p
                   (format "Present.putStr (Present.encode (Present.fromJust (Present.present (Present.fromJust (Present.fromList [%s])) %s)))"
                           (mapconcat 'identity (mapcar 'number-to-string id) ",")
@@ -758,7 +758,7 @@ FILE-NAME only."
               (read text))))
       ;; Not necessary, but nice to restore it to the expression that
       ;; the user actually typed in.
-      (haskell-process-queue-without-filters
+      (haskell-session-queue-without-filters
        p "let it = _it")
       reply)))
 
@@ -904,13 +904,13 @@ Using asynchronous queued commands as opposed to sync at this
 stage, as sync would freeze up the UI a bit, and we actually
 don't care when the thing completes as long as it's soonish."
   ;; Import dependencies under Present.* namespace
-  (haskell-process-queue-without-filters p "import qualified Data.Maybe as Present")
-  (haskell-process-queue-without-filters p "import qualified Data.ByteString.Lazy as Present")
-  (haskell-process-queue-without-filters p "import qualified Data.AttoLisp as Present")
-  (haskell-process-queue-without-filters p "import qualified Present.ID as Present")
-  (haskell-process-queue-without-filters p "import qualified Present as Present")
+  (haskell-session-queue-without-filters p "import qualified Data.Maybe as Present")
+  (haskell-session-queue-without-filters p "import qualified Data.ByteString.Lazy as Present")
+  (haskell-session-queue-without-filters p "import qualified Data.AttoLisp as Present")
+  (haskell-session-queue-without-filters p "import qualified Present.ID as Present")
+  (haskell-session-queue-without-filters p "import qualified Present as Present")
   ;; Make a dummy expression to avoid "Loading package" nonsense
-  (haskell-process-queue-without-filters
+  (haskell-session-queue-without-filters
    p "Present.present (Present.fromJust (Present.fromList [0])) ()"))
 
 (defvar haskell-interactive-mode-presentation-hash 0
@@ -991,7 +991,7 @@ don't care when the thing completes as long as it's soonish."
       (haskell-interactive-mode-prompt session)
       (haskell-session-set session 'next-error-region nil)
       (haskell-session-set session 'next-error-locus nil))
-    (with-current-buffer (get-buffer-create "*haskell-process-log*")
+    (with-current-buffer (get-buffer-create "*haskell-session-log*")
       (let ((inhibit-read-only t))
         (delete-region (point-min) (point-max)))
       (remove-overlays))))
@@ -1003,7 +1003,7 @@ don't care when the thing completes as long as it's soonish."
            (inp (haskell-interactive-mode-input-partial)))
       (if (string= inp (car-safe haskell-interactive-mode-completion-cache))
           (cdr haskell-interactive-mode-completion-cache)
-        (let* ((resp2 (haskell-process-get-repl-completions process inp))
+        (let* ((resp2 (haskell-session-get-repl-completions process inp))
                (rlen (-  (length inp) (length (car resp2))))
                (coll (append (if (string-prefix-p inp "import") '("import"))
                              (if (string-prefix-p inp "let") '("let"))
@@ -1027,8 +1027,8 @@ don't care when the thing completes as long as it's soonish."
      ((and (not (haskell-interactive-mode-line-is-query (elt state 2)))
            (or (string-match "No instance for (?Show[ \n]" response)
                (string-match "Ambiguous type variable " response)))
-      (haskell-process-reset (haskell-interactive-process))
-      (let ((resp (haskell-process-queue-sync-request
+      (haskell-session-reset (haskell-interactive-process))
+      (let ((resp (haskell-session-queue-sync-request
                    (haskell-interactive-process)
                    (concat ":t "
                            (buffer-substring-no-properties
@@ -1093,22 +1093,22 @@ don't care when the thing completes as long as it's soonish."
                           'rear-nonsticky t)))))
 
 ;;;###autoload
-(defun haskell-process-show-repl-response (line)
+(defun haskell-session-show-repl-response (line)
   "Send LINE to the GHCi process and echo the result in some fashion.
 Result will be printed in the minibuffer or presented using
 function `haskell-presentation-present', depending on variable
-`haskell-process-use-presentation-mode'."
+`haskell-session-use-presentation-mode'."
   (let ((process (haskell-interactive-process)))
-    (haskell-process-queue-command
+    (haskell-session-queue-command
      process
      (make-haskell-command
       :state (cons process line)
       :go (lambda (state)
-            (haskell-process-send-string (car state) (cdr state)))
+            (haskell-session-send-string (car state) (cdr state)))
       :complete (lambda (state response)
-                  (if haskell-process-use-presentation-mode
+                  (if haskell-session-use-presentation-mode
                       (haskell-presentation-present
-                       (haskell-process-session (car state))
+                       (haskell-session-session (car state))
                        response)
                     (haskell-mode-message-line response)))))))
 

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -177,7 +177,7 @@ actual Emacs buffer of the module being loaded."
 
 (defun haskell-session-do-cabal (command)
   "Run a Cabal command."
-  (let ((process (haskell-interactive-process)))
+  (let ((process (haskell-interactive-session)))
     (cond
      ((let ((child (haskell-session-process process)))
         (not (equal 'run (process-status child))))
@@ -498,7 +498,7 @@ access the running context across :load/:reloads in GHCi."
                                (ido-find-file)
                              (error "No DevelMain.hs buffer.")))
     (let ((session (haskell-interactive-session)))
-      (let ((process (haskell-interactive-process)))
+      (let ((process (haskell-interactive-session)))
         (haskell-session-queue-command
          process
          (make-haskell-command
@@ -522,7 +522,7 @@ access the running context across :load/:reloads in GHCi."
                        (lambda (ok)
                          (when ok
                            (haskell-session-queue-without-filters
-                            (haskell-interactive-process)
+                            (haskell-interactive-session)
                             "DevelMain.update")
                            (message "DevelMain updated.")))))))))))
 

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -114,8 +114,7 @@ actual Emacs buffer of the module being loaded."
   (cl-assert session)
   (cl-assert file)
   (cl-assert ident)
-  (let* ((process (haskell-session-process session))
-         (suggested-already (haskell-session-suggested-imports process))
+  (let* ((suggested-already (haskell-session-suggested-imports session))
          (module (cond ((> (length modules) 1)
                         (when (y-or-n-p (format "Identifier `%s' not in scope, choose module to import?"
                                                 ident))
@@ -123,7 +122,7 @@ actual Emacs buffer of the module being loaded."
                        ((= (length modules) 1)
                         (let ((module (car modules)))
                           (unless (member module suggested-already)
-                            (haskell-session-set-suggested-imports process (cons module suggested-already))
+                            (haskell-session-set-suggested-imports session (cons module suggested-already))
                             (when (y-or-n-p (format "Identifier `%s' not in scope, import `%s'?"
                                                     ident
                                                     module))

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -64,17 +64,17 @@ changed. Restarts the process if that is the case."
           "^Preprocessing executables for \\(.+?\\)\\.\\.\\.")
          (let ((msg (format "Preprocessing: %s" (match-string 1 buffer))))
            (haskell-interactive-mode-echo
-            (haskell-session-session process)
+            process
             msg)
            (haskell-mode-message-line msg)))
         ((haskell-session-consume process "Linking \\(.+?\\) \\.\\.\\.")
          (let ((msg (format "Linking: %s" (match-string 1 buffer))))
-           (haskell-interactive-mode-echo (haskell-session-session process) msg)
+           (haskell-interactive-mode-echo process msg)
            (haskell-mode-message-line msg)))
         ((haskell-session-consume process "\nBuilding \\(.+?\\)\\.\\.\\.")
          (let ((msg (format "Building: %s" (match-string 1 buffer))))
            (haskell-interactive-mode-echo
-            (haskell-session-session process)
+            process
             msg)
            (haskell-mode-message-line msg)))))
 
@@ -218,7 +218,7 @@ actual Emacs buffer of the module being loaded."
           :complete
           (lambda (state response)
             (let* ((process (cadr state))
-                   (session (haskell-session-session process))
+                   (session process)
                    (message-count 0)
                    (cursor (haskell-session-response-cursor process)))
 	      ;; XXX: what the hell about the rampant code duplication?
@@ -250,7 +250,7 @@ actual Emacs buffer of the module being loaded."
 
 (defun haskell-session-echo-load-message (process buffer echo-in-repl th)
   "Echo a load message."
-  (let ((session (haskell-session-session process))
+  (let ((session process)
         (module-name (match-string 3 buffer))
         (file-name (match-string 4 buffer)))
     (haskell-interactive-show-load-message

--- a/haskell-menu.el
+++ b/haskell-menu.el
@@ -84,7 +84,7 @@ Letters do not insert themselves; instead, they are commands."
     (haskell-menu-tabulate
      (list "Name" "PID" "Time" "RSS" "Cabal directory" "Working directory" "Command")
      (mapcar (lambda (session)
-               (let ((process (haskell-process-process (haskell-session-process session))))
+               (let ((process (haskell-session-process (haskell-session-process session))))
                  (cond
                   (process
                    (let ((id (process-id process)))

--- a/haskell-menu.el
+++ b/haskell-menu.el
@@ -84,7 +84,7 @@ Letters do not insert themselves; instead, they are commands."
     (haskell-menu-tabulate
      (list "Name" "PID" "Time" "RSS" "Cabal directory" "Working directory" "Command")
      (mapcar (lambda (session)
-               (let ((process (haskell-session-process (haskell-session-process session))))
+               (let ((process (haskell-session-process session)))
                  (cond
                   (process
                    (let ((id (process-id process)))

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -234,7 +234,7 @@ executable found in PATH.")
     ["(Un)Comment region" comment-region mark-active]
     "---"
     ["Start interpreter" haskell-interactive-switch]
-    ["Load file" haskell-process-load-file]
+    ["Load file" haskell-session-load-file]
     "---"
     ["Load tidy core" ghc-core-create-core]
     "---"

--- a/haskell-modules.el
+++ b/haskell-modules.el
@@ -64,7 +64,7 @@
   ;;
   ;; Ugliness aside, if it saves us time to type it's a winner.
   ;;
-  ;; FIXME/TODO: add support for (eq 'cabal-repl (haskell-process-type))
+  ;; FIXME/TODO: add support for (eq 'cabal-repl (haskell-session-type))
   (let ((session (haskell-session-maybe)))
     (when session
       (let ((modules (shell-command-to-string

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -312,26 +312,6 @@ Returns NIL when no completions found."
             (error "Lengths inconsistent in `:complete' reponse"))
           (cons h1 cs))))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Accessing the process
-
-(defun haskell-session-get (process key)
-  "Get the PROCESS's KEY value.
-Returns nil if KEY not set."
-  (cdr (assq key process)))
-
-(defun haskell-session-set (process key value)
-  "Set the PROCESS's KEY to VALUE.
-Returns newly set VALUE."
-  (if process
-      (let ((cell (assq key process)))
-        (if cell
-            (setcdr cell value)         ; modify cell in-place
-          (setcdr process (cons (cons key value) (cdr process))) ; new cell
-          value))
-    (display-warning 'haskell-interactive
-                     "`haskell-session-set' called with nil process")))
-
 ;; Wrappers using haskell-session-{get,set}
 
 (defun haskell-session-set-sent-stdin (p v)

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -31,13 +31,13 @@
 (require 'haskell-customize)
 (require 'haskell-string)
 
-(defconst haskell-process-prompt-regex "\4"
+(defconst haskell-session-prompt-regex "\4"
   "Used for delimiting command replies. 4 is End of Transmission.")
 
 (defvar haskell-reload-p nil
-  "Used internally for `haskell-process-loadish'.")
+  "Used internally for `haskell-session-loadish'.")
 
-(defconst haskell-process-greetings
+(defconst haskell-session-greetings
   (list "Hello, Haskell!"
         "The lambdas must flow."
         "Hours of hacking await!"
@@ -45,7 +45,7 @@
         "Your wish is my IO ().")
   "Greetings for when the Haskell process starts up.")
 
-(defconst haskell-process-logo
+(defconst haskell-session-logo
   (expand-file-name "logo.svg" haskell-mode-pkg-base-dir)
   "Haskell logo for notifications.")
 
@@ -72,88 +72,88 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Building the process
 
-(defun haskell-process-compute-process-log-and-command (session hptype)
+(defun haskell-session-compute-process-log-and-command (session hptype)
   "Compute the log and process to start command for the SESSION from the HPTYPE.
 Do not actually start any process.
-HPTYPE is the result of calling `'haskell-process-type`' function."
+HPTYPE is the result of calling `'haskell-session-type`' function."
   (let ((session-name (haskell-session-name session)))
     (cl-ecase hptype
       ('ghci
        (append (list (format "Starting inferior GHCi process %s ..."
-                             haskell-process-path-ghci)
+                             haskell-session-path-ghci)
                      session-name
                      nil)
-               (apply haskell-process-wrapper-function
+               (apply haskell-session-wrapper-function
                       (list
-                       (cons haskell-process-path-ghci haskell-process-args-ghci)))))
+                       (cons haskell-session-path-ghci haskell-session-args-ghci)))))
       ('cabal-repl
        (append (list (format "Starting inferior `cabal repl' process using %s ..."
-                             haskell-process-path-cabal)
+                             haskell-session-path-cabal)
                      session-name
                      nil)
-               (apply haskell-process-wrapper-function
+               (apply haskell-session-wrapper-function
                       (list
                        (append
-                        (list haskell-process-path-cabal "repl")
-                        haskell-process-args-cabal-repl
+                        (list haskell-session-path-cabal "repl")
+                        haskell-session-args-cabal-repl
                         (let ((target (haskell-session-target session)))
                           (if target (list target) nil)))))))
       ('stack-ghci
-       (append (list (format "Starting inferior stack GHCi process using %s" haskell-process-path-stack)
+       (append (list (format "Starting inferior stack GHCi process using %s" haskell-session-path-stack)
                      session-name
                      nil)
-               (apply haskell-process-wrapper-function
+               (apply haskell-session-wrapper-function
                       (list
                        (append
-                        (list haskell-process-path-stack "ghci")
+                        (list haskell-session-path-stack "ghci")
                         (let ((target (haskell-session-target session)))
                           (if target (list target) nil))
-                        haskell-process-args-stack-ghci))))))))
+                        haskell-session-args-stack-ghci))))))))
 
-(defun haskell-process-make (name)
+(defun haskell-session-make (name)
   "Make an inferior Haskell process."
   (list (cons 'name name)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Process communication
 
-(defun haskell-process-sentinel (proc event)
+(defun haskell-session-sentinel (proc event)
   "The sentinel for the process pipe."
-  (let ((session (haskell-process-project-by-proc proc)))
+  (let ((session (haskell-session-project-by-proc proc)))
     (when session
       (let* ((process (haskell-session-process session)))
-        (unless (haskell-process-restarting process)
-          (haskell-process-log
+        (unless (haskell-session-restarting process)
+          (haskell-session-log
            (propertize (format "Event: %S\n" event)
                        'face '((:weight bold))))
-          (haskell-process-log
+          (haskell-session-log
            (propertize "Process reset.\n"
                        'face font-lock-comment-face))
-          (run-hook-with-args 'haskell-process-ended-hook process))))))
+          (run-hook-with-args 'haskell-session-ended-hook process))))))
 
-(defun haskell-process-filter (proc response)
+(defun haskell-session-filter (proc response)
   "The filter for the process pipe."
   (let ((i 0))
     (cl-loop for line in (split-string response "\n")
-             do (haskell-process-log
+             do (haskell-session-log
                  (concat (if (= i 0)
                              (propertize "<- " 'face font-lock-comment-face)
                            "   ")
                          (propertize line 'face 'haskell-interactive-face-compile-warning)))
              do (setq i (1+ i))))
-  (let ((session (haskell-process-project-by-proc proc)))
+  (let ((session (haskell-session-project-by-proc proc)))
     (when session
-      (if (haskell-process-cmd (haskell-session-process session))
-          (haskell-process-collect session
+      (if (haskell-session-cmd (haskell-session-process session))
+          (haskell-session-collect session
                                    response
                                    (haskell-session-process session))
-        (haskell-process-log
+        (haskell-session-log
          (replace-regexp-in-string "\4" "" response))))))
 
-(defun haskell-process-log (msg)
+(defun haskell-session-log (msg)
   "Effective append MSG to the process log (if enabled)."
-  (when haskell-process-log
-    (let* ((append-to (get-buffer-create "*haskell-process-log*"))
+  (when haskell-session-log
+    (let* ((append-to (get-buffer-create "*haskell-session-log*"))
            (windows (get-buffer-window-list append-to t t))
            move-point-in-windows)
       (with-current-buffer append-to
@@ -176,117 +176,117 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
           (set-window-point window (point-max)))
         (setq buffer-read-only t)))))
 
-(defun haskell-process-project-by-proc (proc)
+(defun haskell-session-project-by-proc (proc)
   "Find project by process."
   (cl-find-if (lambda (project)
                 (string= (haskell-session-name project)
                          (process-name proc)))
               haskell-sessions))
 
-(defun haskell-process-collect (_session response process)
+(defun haskell-session-collect (_session response process)
   "Collect input for the response until receives a prompt."
-  (haskell-process-set-response process
-                                (concat (haskell-process-response process) response))
-  (while (haskell-process-live-updates process))
-  (when (string-match haskell-process-prompt-regex
-                      (haskell-process-response process))
+  (haskell-session-set-response process
+                                (concat (haskell-session-response process) response))
+  (while (haskell-session-live-updates process))
+  (when (string-match haskell-session-prompt-regex
+                      (haskell-session-response process))
     (haskell-command-exec-complete
-     (haskell-process-cmd process)
+     (haskell-session-cmd process)
      (replace-regexp-in-string
-      haskell-process-prompt-regex
+      haskell-session-prompt-regex
       ""
-      (haskell-process-response process)))
-    (haskell-process-reset process)
-    (haskell-process-trigger-queue process)))
+      (haskell-session-response process)))
+    (haskell-session-reset process)
+    (haskell-session-trigger-queue process)))
 
-(defun haskell-process-reset (process)
+(defun haskell-session-reset (process)
   "Reset the process's state, ready for the next send/reply."
-  (progn (haskell-process-set-response-cursor process 0)
-         (haskell-process-set-response process "")
-         (haskell-process-set-cmd process nil)))
+  (progn (haskell-session-set-response-cursor process 0)
+         (haskell-session-set-response process "")
+         (haskell-session-set-cmd process nil)))
 
-(defun haskell-process-consume (process regex)
+(defun haskell-session-consume (process regex)
   "Consume a regex from the response and move the cursor along if succeed."
   (when (string-match regex
-                      (haskell-process-response process)
-                      (haskell-process-response-cursor process))
-    (haskell-process-set-response-cursor process (match-end 0))
+                      (haskell-session-response process)
+                      (haskell-session-response-cursor process))
+    (haskell-session-set-response-cursor process (match-end 0))
     t))
 
-(defun haskell-process-send-string (process string)
+(defun haskell-session-send-string (process string)
   "Try to send a string to the process's process. Ask to restart if it's not running."
-  (let ((child (haskell-process-process process)))
+  (let ((child (haskell-session-process process)))
     (if (equal 'run (process-status child))
         (let ((out (concat string "\n")))
-          (haskell-process-log
+          (haskell-session-log
            (propertize (concat (propertize "-> " 'face font-lock-comment-face)
                                (propertize string 'face font-lock-string-face))
                        'face '((:weight bold))))
           (process-send-string child out))
-      (unless (haskell-process-restarting process)
-        (run-hook-with-args 'haskell-process-ended process)))))
+      (unless (haskell-session-restarting process)
+        (run-hook-with-args 'haskell-session-ended process)))))
 
-(defun haskell-process-live-updates (process)
+(defun haskell-session-live-updates (process)
   "Process live updates."
-  (haskell-command-exec-live (haskell-process-cmd process)
-                             (haskell-process-response process)))
+  (haskell-command-exec-live (haskell-session-cmd process)
+                             (haskell-session-response process)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Making commands
 
-(defun haskell-process-queue-without-filters (process line)
+(defun haskell-session-queue-without-filters (process line)
   "Queue LINE to be sent to PROCESS without bothering to look at
 the response."
-  (haskell-process-queue-command
+  (haskell-session-queue-command
    process
    (make-haskell-command
     :state (cons process line)
     :go (lambda (state)
-          (haskell-process-send-string (car state)
+          (haskell-session-send-string (car state)
                                        (cdr state))))))
 
 
-(defun haskell-process-queue-command (process command)
+(defun haskell-session-queue-command (process command)
   "Add a command to the process command queue."
-  (haskell-process-cmd-queue-add process command)
-  (haskell-process-trigger-queue process))
+  (haskell-session-cmd-queue-add process command)
+  (haskell-session-trigger-queue process))
 
-(defun haskell-process-trigger-queue (process)
+(defun haskell-session-trigger-queue (process)
   "Trigger the next command in the queue to be ran if there is no current command."
-  (if (and (haskell-process-process process)
-           (process-live-p (haskell-process-process process)))
-      (unless (haskell-process-cmd process)
-        (let ((cmd (haskell-process-cmd-queue-pop process)))
+  (if (and (haskell-session-process process)
+           (process-live-p (haskell-session-process process)))
+      (unless (haskell-session-cmd process)
+        (let ((cmd (haskell-session-cmd-queue-pop process)))
           (when cmd
-            (haskell-process-set-cmd process cmd)
+            (haskell-session-set-cmd process cmd)
             (haskell-command-exec-go cmd))))
-    (progn (haskell-process-reset process)
-           (haskell-process-set process 'command-queue nil)
-           (run-hook-with-args 'haskell-process-ended process))))
+    (progn (haskell-session-reset process)
+           (haskell-session-set process 'command-queue nil)
+           (run-hook-with-args 'haskell-session-ended process))))
 
-(defun haskell-process-queue-flushed-p (process)
+(defun haskell-session-queue-flushed-p (process)
   "Return t if command queue has been completely processed."
-  (not (or (haskell-process-cmd-queue process)
-           (haskell-process-cmd process))))
+  (not (or (haskell-session-cmd-queue process)
+           (haskell-session-cmd process))))
 
-(defun haskell-process-queue-flush (process)
+(defun haskell-session-queue-flush (process)
   "Block till PROCESS' command queue has been completely processed.
 This uses `accept-process-output' internally."
-  (while (not (haskell-process-queue-flushed-p process))
-    (haskell-process-trigger-queue process)
-    (accept-process-output (haskell-process-process process) 1)))
+  (while (not (haskell-session-queue-flushed-p process))
+    (haskell-session-trigger-queue process)
+    (accept-process-output (haskell-session-process process) 1)))
 
-(defun haskell-process-queue-sync-request (process reqstr)
+(defun haskell-session-queue-sync-request (process reqstr)
   "Queue submitting REQSTR to PROCESS and return response blockingly."
   (let ((cmd (make-haskell-command
               :state (cons nil process)
-              :go `(lambda (s) (haskell-process-send-string (cdr s) ,reqstr))
+              :go `(lambda (s) (haskell-session-send-string (cdr s) ,reqstr))
               :complete 'setcar)))
-    (haskell-process-queue-command process cmd)
-    (haskell-process-queue-flush process)
+    (haskell-session-queue-command process cmd)
+    (haskell-session-queue-flush process)
     (car-safe (haskell-command-state cmd))))
 
-(defun haskell-process-get-repl-completions (process inputstr &optional limit)
+(defun haskell-session-get-repl-completions (process inputstr &optional limit)
   "Perform `:complete repl ...' query for INPUTSTR using PROCESS.
 Give optional LIMIT arg to limit completion candidates count,
 zero, negative values, and nil means all possible completions.
@@ -297,7 +297,7 @@ Returns NIL when no completions found."
          (reqstr (concat ":complete repl"
                          mlimit
                          (haskell-string-literal-encode inputstr)))
-         (rawstr (haskell-process-queue-sync-request process reqstr)))
+         (rawstr (haskell-session-queue-sync-request process reqstr)))
     ;; TODO use haskell-utils-parse-repl-response
     (if (string-prefix-p "unknown command " rawstr)
         (error "GHCi lacks `:complete' support (try installing 7.8 or ghci-ng)")
@@ -315,12 +315,12 @@ Returns NIL when no completions found."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessing the process
 
-(defun haskell-process-get (process key)
+(defun haskell-session-get (process key)
   "Get the PROCESS's KEY value.
 Returns nil if KEY not set."
   (cdr (assq key process)))
 
-(defun haskell-process-set (process key value)
+(defun haskell-session-set (process key value)
   "Set the PROCESS's KEY to VALUE.
 Returns newly set VALUE."
   (if process
@@ -330,114 +330,114 @@ Returns newly set VALUE."
           (setcdr process (cons (cons key value) (cdr process))) ; new cell
           value))
     (display-warning 'haskell-interactive
-                     "`haskell-process-set' called with nil process")))
+                     "`haskell-session-set' called with nil process")))
 
-;; Wrappers using haskell-process-{get,set}
+;; Wrappers using haskell-session-{get,set}
 
-(defun haskell-process-set-sent-stdin (p v)
+(defun haskell-session-set-sent-stdin (p v)
   "We've sent stdin, so let's not clear the output at the end."
-  (haskell-process-set p 'sent-stdin v))
+  (haskell-session-set p 'sent-stdin v))
 
-(defun haskell-process-sent-stdin-p (p)
+(defun haskell-session-sent-stdin-p (p)
   "Did we send any stdin to the process during evaluation?"
-  (haskell-process-get p 'sent-stdin))
+  (haskell-session-get p 'sent-stdin))
 
-(defun haskell-process-set-suggested-imports (p v)
+(defun haskell-session-set-suggested-imports (p v)
   "Remember what imports have been suggested, to avoid
 re-asking about the same imports."
-  (haskell-process-set p 'suggested-imported v))
+  (haskell-session-set p 'suggested-imported v))
 
-(defun haskell-process-suggested-imports (p)
+(defun haskell-session-suggested-imports (p)
   "Get what modules have already been suggested and accepted."
-  (haskell-process-get p 'suggested-imported))
+  (haskell-session-get p 'suggested-imported))
 
-(defun haskell-process-set-evaluating (p v)
+(defun haskell-session-set-evaluating (p v)
   "Set status of evaluating to be on/off."
-  (haskell-process-set p 'evaluating v))
+  (haskell-session-set p 'evaluating v))
 
-(defun haskell-process-evaluating-p (p)
+(defun haskell-session-evaluating-p (p)
   "Set status of evaluating to be on/off."
-  (haskell-process-get p 'evaluating))
+  (haskell-session-get p 'evaluating))
 
-(defun haskell-process-set-process (p v)
+(defun haskell-session-set-process (p v)
   "Set the process's inferior process."
-  (haskell-process-set p 'inferior-process v))
+  (haskell-session-set p 'inferior-process v))
 
-(defun haskell-process-process (p)
+(defun haskell-session-process (p)
   "Get the process child."
-  (haskell-process-get p 'inferior-process))
+  (haskell-session-get p 'inferior-process))
 
-(defun haskell-process-name (p)
+(defun haskell-session-name (p)
   "Get the process name."
-  (haskell-process-get p 'name))
+  (haskell-session-get p 'name))
 
-(defun haskell-process-cmd (p)
+(defun haskell-session-cmd (p)
   "Get the process's current command.
 Return nil if no current command."
-  (haskell-process-get p 'current-command))
+  (haskell-session-get p 'current-command))
 
-(defun haskell-process-set-cmd (p v)
+(defun haskell-session-set-cmd (p v)
   "Set the process's current command."
-  (haskell-process-set-evaluating p nil)
-  (haskell-process-set-sent-stdin p nil)
-  (haskell-process-set-suggested-imports p nil)
-  (haskell-process-set p 'current-command v))
+  (haskell-session-set-evaluating p nil)
+  (haskell-session-set-sent-stdin p nil)
+  (haskell-session-set-suggested-imports p nil)
+  (haskell-session-set p 'current-command v))
 
-(defun haskell-process-response (p)
+(defun haskell-session-response (p)
   "Get the process's current response."
-  (haskell-process-get p 'current-response))
+  (haskell-session-get p 'current-response))
 
-(defun haskell-process-session (p)
+(defun haskell-session-session (p)
   "Get the process's current session."
-  (haskell-process-get p 'session))
+  (haskell-session-get p 'session))
 
-(defun haskell-process-set-response (p v)
+(defun haskell-session-set-response (p v)
   "Set the process's current response."
-  (haskell-process-set p 'current-response v))
+  (haskell-session-set p 'current-response v))
 
-(defun haskell-process-set-session (p v)
+(defun haskell-session-set-session (p v)
   "Set the process's current session."
-  (haskell-process-set p 'session v))
+  (haskell-session-set p 'session v))
 
-(defun haskell-process-response-cursor (p)
+(defun haskell-session-response-cursor (p)
   "Get the process's current response cursor."
-  (haskell-process-get p 'current-response-cursor))
+  (haskell-session-get p 'current-response-cursor))
 
-(defun haskell-process-set-response-cursor (p v)
+(defun haskell-session-set-response-cursor (p v)
   "Set the process's response cursor."
-  (haskell-process-set p 'current-response-cursor v))
+  (haskell-session-set p 'current-response-cursor v))
 
 ;; low-level command queue operations
 
-(defun haskell-process-restarting (process)
+(defun haskell-session-restarting (process)
   "Is the PROCESS restarting?"
-  (haskell-process-get process 'is-restarting))
+  (haskell-session-get process 'is-restarting))
 
-(defun haskell-process-cmd-queue (process)
+(defun haskell-session-cmd-queue (process)
   "Get the PROCESS' command queue.
 New entries get added to the end of the list. Use
-`haskell-process-cmd-queue-add' and
-`haskell-process-cmd-queue-pop' to modify the command queue."
-  (haskell-process-get process 'command-queue))
+`haskell-session-cmd-queue-add' and
+`haskell-session-cmd-queue-pop' to modify the command queue."
+  (haskell-session-get process 'command-queue))
 
-(defun haskell-process-cmd-queue-add (process cmd)
+(defun haskell-session-cmd-queue-add (process cmd)
   "Add CMD to end of PROCESS's command queue."
   (cl-check-type cmd haskell-command)
-  (haskell-process-set process
+  (haskell-session-set process
                        'command-queue
-                       (append (haskell-process-cmd-queue process)
+                       (append (haskell-session-cmd-queue process)
                                (list cmd))))
 
-(defun haskell-process-cmd-queue-pop (process)
+(defun haskell-session-cmd-queue-pop (process)
   "Pop the PROCESS' next entry from command queue.
 Returns nil if queue is empty."
-  (let ((queue (haskell-process-cmd-queue process)))
+  (let ((queue (haskell-session-cmd-queue process)))
     (when queue
-      (haskell-process-set process 'command-queue (cdr queue))
+      (haskell-session-set process 'command-queue (cdr queue))
       (car queue))))
 
 
-(defun haskell-process-unignore-file (session file)
+(defun haskell-session-unignore-file (session file)
   "
 
 Note to Windows Emacs hackers:
@@ -492,4 +492,4 @@ function and remove this comment.
 
 (provide 'haskell-process)
 
-;;; haskell-process.el ends here
+;;; haskell-session.el ends here

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -117,15 +117,14 @@ HPTYPE is the result of calling `'haskell-session-type`' function."
   "The sentinel for the process pipe."
   (let ((session (haskell-session-project-by-proc proc)))
     (when session
-      (let* ((process (haskell-session-process session)))
-        (unless (haskell-session-restarting process)
-          (haskell-session-log
-           (propertize (format "Event: %S\n" event)
-                       'face '((:weight bold))))
-          (haskell-session-log
-           (propertize "Process reset.\n"
-                       'face font-lock-comment-face))
-          (run-hook-with-args 'haskell-session-ended-hook process))))))
+      (unless (haskell-session-restarting session)
+	(haskell-session-log
+	 (propertize (format "Event: %S\n" event)
+		     'face '((:weight bold))))
+	(haskell-session-log
+	 (propertize "Process reset.\n"
+		     'face font-lock-comment-face))
+	(run-hook-with-args 'haskell-session-ended-hook session)))))
 
 (defun haskell-session-filter (proc response)
   "The filter for the process pipe."
@@ -139,10 +138,10 @@ HPTYPE is the result of calling `'haskell-session-type`' function."
              do (setq i (1+ i))))
   (let ((session (haskell-session-project-by-proc proc)))
     (when session
-      (if (haskell-session-cmd (haskell-session-process session))
+      (if (haskell-session-cmd session)
           (haskell-session-collect session
                                    response
-                                   (haskell-session-process session))
+                                   session)
         (haskell-session-log
          (replace-regexp-in-string "\4" "" response))))))
 

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -358,17 +358,9 @@ Return nil if no current command."
   "Get the process's current response."
   (haskell-session-get p 'current-response))
 
-(defun haskell-session-session (p)
-  "Get the process's current session."
-  (haskell-session-get p 'session))
-
 (defun haskell-session-set-response (p v)
   "Set the process's current response."
   (haskell-session-set p 'current-response v))
-
-(defun haskell-session-set-session (p v)
-  "Set the process's current session."
-  (haskell-session-set p 'session v))
 
 (defun haskell-session-response-cursor (p)
   "Get the process's current response cursor."

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -342,10 +342,6 @@ re-asking about the same imports."
   "Get the process child."
   (haskell-session-get p 'inferior-process))
 
-(defun haskell-session-name (p)
-  "Get the process name."
-  (haskell-session-get p 'name))
-
 (defun haskell-session-cmd (p)
   "Get the process's current command.
 Return nil if no current command."

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -110,10 +110,6 @@ HPTYPE is the result of calling `'haskell-session-type`' function."
                           (if target (list target) nil))
                         haskell-session-args-stack-ghci))))))))
 
-(defun haskell-session-make (name)
-  "Make an inferior Haskell process."
-  (list (cons 'name name)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Process communication
 

--- a/haskell-repl.el
+++ b/haskell-repl.el
@@ -29,7 +29,7 @@
          ;; If already evaluating, then the user is trying to send
          ;; input to the REPL during evaluation. Most likely in
          ;; response to a getLine-like function.
-         ((and (haskell-process-evaluating-p (haskell-interactive-process))
+         ((and (haskell-session-evaluating-p (haskell-interactive-process))
                (= (line-end-position) (point-max)))
           (goto-char (point-max))
           (let ((process (haskell-interactive-process))
@@ -43,8 +43,8 @@
             ;; Bring the marker forward
             (setq haskell-interactive-mode-result-end
                   (point-max))
-            (haskell-process-set-sent-stdin process t)
-            (haskell-process-send-string process string)))
+            (haskell-session-set-sent-stdin process t)
+            (haskell-session-send-string process string)))
          ;; Otherwise we start a normal evaluation call.
          (t (setq haskell-interactive-mode-old-prompt-start
                   (copy-marker haskell-interactive-mode-prompt-start))
@@ -63,7 +63,7 @@
   "Run the given expression."
   (let ((session (haskell-interactive-session))
         (process (haskell-interactive-process)))
-    (haskell-process-queue-command
+    (haskell-session-queue-command
      process
      (make-haskell-command
       :state (list session process expr 0)
@@ -72,15 +72,15 @@
             (insert "\n")
             (setq haskell-interactive-mode-result-end
                   (point-max))
-            (haskell-process-send-string (cadr state)
+            (haskell-session-send-string (cadr state)
                                          (haskell-interactive-mode-multi-line (cl-caddr state)))
-            (haskell-process-set-evaluating (cadr state) t))
+            (haskell-session-set-evaluating (cadr state) t))
       :live (lambda (state buffer)
               (unless (and (string-prefix-p ":q" (cl-caddr state))
                            (string-prefix-p (cl-caddr state) ":quit"))
                 (let* ((cursor (cl-cadddr state))
                        (next (replace-regexp-in-string
-                              haskell-process-prompt-regex
+                              haskell-session-prompt-regex
                               ""
                               (substring buffer cursor))))
                   (haskell-interactive-mode-eval-result (car state) next)
@@ -88,7 +88,7 @@
                   nil)))
       :complete
       (lambda (state response)
-        (haskell-process-set-evaluating (cadr state) nil)
+        (haskell-session-set-evaluating (cadr state) nil)
         (unless (haskell-interactive-mode-trigger-compile-error state response)
           (haskell-interactive-mode-expr-result state response)))))))
 
@@ -101,7 +101,7 @@
            (haskell-interactive-mode-handle-h)
            (buffer-string))))
     (when haskell-interactive-mode-eval-mode
-      (unless (haskell-process-sent-stdin-p (cadr state))
+      (unless (haskell-session-sent-stdin-p (cadr state))
         (haskell-interactive-mode-eval-as-mode (car state) response))))
   (haskell-interactive-mode-prompt (car state)))
 

--- a/haskell-repl.el
+++ b/haskell-repl.el
@@ -29,10 +29,10 @@
          ;; If already evaluating, then the user is trying to send
          ;; input to the REPL during evaluation. Most likely in
          ;; response to a getLine-like function.
-         ((and (haskell-session-evaluating-p (haskell-interactive-process))
+         ((and (haskell-session-evaluating-p (haskell-interactive-session))
                (= (line-end-position) (point-max)))
           (goto-char (point-max))
-          (let ((process (haskell-interactive-process))
+          (let ((process (haskell-interactive-session))
                 (string (buffer-substring-no-properties
                          haskell-interactive-mode-result-end
                          (point))))
@@ -62,7 +62,7 @@
 (defun haskell-interactive-mode-run-expr (expr)
   "Run the given expression."
   (let ((session (haskell-interactive-session))
-        (process (haskell-interactive-process)))
+        (process (haskell-interactive-session)))
     (haskell-session-queue-command
      process
      (make-haskell-command

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -110,10 +110,6 @@ with all relevant buffers)."
                                 haskell-sessions)))
       session)))
 
-(defun haskell-session-clear ()
-  "Clear the buffer of any Haskell session choice."
-  (set (make-local-variable 'haskell-session) nil))
-
 (defun haskell-session-lookup (name)
   "Get the session by name."
   (cl-remove-if-not (lambda (s)

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -215,11 +215,14 @@ Returns nil if KEY not set."
 (defun haskell-session-set (session key value)
   "Set the SESSION's KEY to VALUE.
 Returns newly set VALUE."
-  (let ((cell (assq key session)))
-    (if cell
-        (setcdr cell value) ; modify cell in-place
-      (setcdr session (cons (cons key value) (cdr session))) ; new cell
-      value)))
+  (if session
+      (let ((cell (assq key session)))
+	(if cell
+	    (setcdr cell value)		; modify cell in-place
+	    (setcdr session (cons (cons key value) (cdr session))) ; new cell
+	    value))
+      (display-warning 'haskell-interactive
+		       "`haskell-session-set' called with nil session")))
 
 (provide 'haskell-session)
 

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -151,11 +151,11 @@ with all relevant buffers)."
 
 (defun haskell-session-target (s)
   "Get the session build target.
-If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
+If `haskell-session-load-or-reload-prompt' is nil, accept `default'."
   (let* ((maybe-target (haskell-session-get s 'target))
          (target (if maybe-target maybe-target
                    (let ((new-target
-			  (if haskell-process-load-or-reload-prompt
+			  (if haskell-session-load-or-reload-prompt
 			      (read-string "build target (empty for default):")
 			    "")))
                      (haskell-session-set-target s new-target)))))
@@ -197,7 +197,7 @@ If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
 (defun haskell-session-cabal-dir (s)
   "Get the session cabal-dir."
   (or (haskell-session-get s 'cabal-dir)
-      (let ((set-dir (haskell-cabal-get-dir (not haskell-process-load-or-reload-prompt))))
+      (let ((set-dir (haskell-cabal-get-dir (not haskell-session-load-or-reload-prompt))))
 	(if set-dir
 	    (progn (haskell-session-set-cabal-dir s set-dir)
 		   set-dir)

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -165,15 +165,6 @@ If `haskell-session-load-or-reload-prompt' is nil, accept `default'."
   "Set the session interactive buffer."
   (haskell-session-set s 'interactive-buffer v))
 
-(defun haskell-session-set-process (s v)
-  "Set the session process."
-  (haskell-session-set s 'process v))
-
-;;;###autoload
-(defun haskell-session-process (s)
-  "Get the session process."
-  (haskell-session-get s 'process))
-
 (defun haskell-session-set-cabal-dir (s v)
   "Set the session cabal-dir."
   (let ((true-path (file-truename v)))

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -47,7 +47,7 @@
 (defun haskell-utils-read-directory-name (prompt default)
   "Read directory name and normalize to true absolute path.
 Refer to `read-directory-name' for the meaning of PROMPT and
-DEFAULT. If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
+DEFAULT. If `haskell-session-load-or-reload-prompt' is nil, accept `default'."
   (let ((filename (file-truename (read-directory-name prompt default default))))
     (concat (replace-regexp-in-string "/$" "" filename) "/")))
 

--- a/haskell.el
+++ b/haskell.el
@@ -273,7 +273,7 @@ If `haskell-session-load-or-reload-prompt' is nil, accept `default'."
          (existing-process (get-process (haskell-session-name session))))
     (when (processp existing-process)
       (haskell-interactive-mode-echo session "Killing process ...")
-      (haskell-session-set (haskell-session-process session) 'is-restarting t)
+      (haskell-session-set session 'is-restarting t)
       (delete-process existing-process))))
 
 ;;;###autoload

--- a/haskell.el
+++ b/haskell.el
@@ -261,10 +261,6 @@ If `haskell-session-load-or-reload-prompt' is nil, accept `default'."
       (message (format "The Haskell process `%s' is dearly departed."
                        process-name)))))
 
-(defun haskell-session ()
-  "Get the current process from the current session."
-  (haskell-session-process (haskell-session)))
-
 (defun haskell-interactive-buffer ()
   "Get the interactive buffer of the session."
   (haskell-session-interactive-buffer (haskell-session)))

--- a/haskell.el
+++ b/haskell.el
@@ -236,7 +236,7 @@ If `haskell-session-load-or-reload-prompt' is nil, accept `default'."
                             "Cabal said:\n\n"
                             (propertize (haskell-session-response process)
                                         'face 'font-lock-comment-face)))
-            (?y (let ((default-directory (haskell-session-cabal-dir (haskell-session-session process))))
+            (?y (let ((default-directory (haskell-session-cabal-dir process)))
                   (message "%s" (shell-command-to-string "cabal configure"))))
             (?l (let* ((response (haskell-session-response process))
                        (buffer (get-buffer "*haskell-session-log*")))
@@ -250,7 +250,7 @@ If `haskell-session-load-or-reload-prompt' is nil, accept `default'."
                     (propertize (format "The Haskell process `%s' has died. Restart? (y, n, l: show process log)"
                                         process-name)
                                 'face 'minibuffer-prompt))
-            (?y (haskell-session-start (haskell-session-session process)))
+            (?y (haskell-session-start process))
             (?l (let* ((response (haskell-session-response process))
                        (buffer (get-buffer "*haskell-session-log*")))
                   (if buffer

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -189,14 +189,14 @@ setting up the inferior-haskell buffer."
     (inferior-haskell-mode)
     (run-hooks 'inferior-haskell-hook)))
 
-(defun inferior-haskell-process (&optional arg)
+(defun inferior-haskell-session (&optional arg)
   (or (if (buffer-live-p inferior-haskell-buffer)
           (get-buffer-process inferior-haskell-buffer))
       (progn
         (let ((current-prefix-arg arg))
           (call-interactively 'inferior-haskell-start-process))
         ;; Try again.
-        (inferior-haskell-process arg))))
+        (inferior-haskell-session arg))))
 
 ;;;###autoload
 (defalias 'run-haskell 'switch-to-haskell)
@@ -204,7 +204,7 @@ setting up the inferior-haskell buffer."
 (defun switch-to-haskell (&optional arg)
   "Show the inferior-haskell buffer.  Start the process if needed."
   (interactive "P")
-  (let ((proc (inferior-haskell-process arg)))
+  (let ((proc (inferior-haskell-session arg)))
     (pop-to-buffer (process-buffer proc))))
 
 ;;;###autoload
@@ -328,7 +328,7 @@ If prefix arg \\[universal-argument] is given, just reload the previous file."
   (save-buffer)
   (let ((buf (current-buffer))
         (file buffer-file-name)
-        (proc (inferior-haskell-process)))
+        (proc (inferior-haskell-session)))
     (if file
         (with-current-buffer (process-buffer proc)
           (compilation-forget-errors)
@@ -389,7 +389,7 @@ If prefix arg \\[universal-argument] is given, just reload the previous file."
           (inferior-haskell-load-file))
       (remove-hook 'next-error-hook neh))
     (unless inferior-haskell-errors
-      (inferior-haskell-send-command (inferior-haskell-process) command)
+      (inferior-haskell-send-command (inferior-haskell-session) command)
       (switch-to-haskell))))
 
 (defun inferior-haskell-send-command (proc str)
@@ -447,7 +447,7 @@ If prefix arg \\[universal-argument] is given, just reload the previous file."
   (interactive)
   (save-excursion
     (goto-char (1+ (point)))
-    (let* ((proc (inferior-haskell-process))
+    (let* ((proc (inferior-haskell-session))
            (start (or (haskell-ds-backward-decl) (point-min)))
            (end (or (haskell-ds-forward-decl) (point-max)))
            (raw-decl (buffer-substring start end)))
@@ -470,7 +470,7 @@ If prefix arg \\[universal-argument] is given, just reload the previous file."
 
 (defun inferior-haskell-get-result (inf-expr)
   "Submit the expression `inf-expr' to ghci and read the result."
-  (let ((proc (inferior-haskell-process)))
+  (let ((proc (inferior-haskell-session)))
     (with-current-buffer (process-buffer proc)
       (let ((parsing-end                ; Remember previous spot.
              (marker-position (process-mark proc))))
@@ -569,7 +569,7 @@ The returned info is cached for reuse by `haskell-doc-mode'."
             (col (string-to-number
                   (match-string-no-properties 3 info))))
         (when file
-          (with-current-buffer (process-buffer (inferior-haskell-process))
+          (with-current-buffer (process-buffer (inferior-haskell-session))
             ;; The file name is relative to the process's cwd.
             (setq file (expand-file-name file)))
           ;; Push current location marker on the ring used by `find-tag'

--- a/tests/haskell-process-tests.el
+++ b/tests/haskell-process-tests.el
@@ -7,59 +7,59 @@
 
 (require 'haskell-process)
 
-(ert-deftest haskell-process-wrapper-command-function-identity ()
+(ert-deftest haskell-session-wrapper-command-function-identity ()
   "No wrapper, return directly the command."
   (should (equal '("ghci")
                  (progn
-                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
-                   (apply haskell-process-wrapper-function (list '("ghci")))))))
+                   (custom-set-variables '(haskell-session-wrapper-function #'identity))
+                   (apply haskell-session-wrapper-function (list '("ghci")))))))
 
-(ert-deftest haskell-process-wrapper-function-non-identity ()
+(ert-deftest haskell-session-wrapper-function-non-identity ()
   "Wrapper as a string, return the wrapping command as a string."
   (should (equal '("nix-shell" "default.nix" "--command" "cabal\\ run")
                  (progn
-                   (custom-set-variables '(haskell-process-wrapper-function (lambda (argv)
+                   (custom-set-variables '(haskell-session-wrapper-function (lambda (argv)
                                                                               (append '("nix-shell" "default.nix" "--command")
                                                                                       (list (shell-quote-argument argv))))))
-                   (apply haskell-process-wrapper-function (list "cabal run"))))))
+                   (apply haskell-session-wrapper-function (list "cabal run"))))))
 
-(ert-deftest test-haskell-process--compute-process-log-and-command-ghci ()
+(ert-deftest test-haskell-session--compute-process-log-and-command-ghci ()
   (should (equal '("Starting inferior GHCi process ghci ..." "dumses1" nil "ghci" "-ferror-spans")
-                 (let ((haskell-process-path-ghci "ghci")
-                       (haskell-process-args-ghci '("-ferror-spans")))
-                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
+                 (let ((haskell-session-path-ghci "ghci")
+                       (haskell-session-args-ghci '("-ferror-spans")))
+                   (custom-set-variables '(haskell-session-wrapper-function #'identity))
                    (mocklet (((haskell-session-name "dummy-session") => "dumses1"))
-                     (haskell-process-compute-process-log-and-command "dummy-session" 'ghci))))))
+                     (haskell-session-compute-process-log-and-command "dummy-session" 'ghci))))))
 
-(ert-deftest test-haskell-process--with-wrapper-compute-process-log-and-command-ghci ()
+(ert-deftest test-haskell-session--with-wrapper-compute-process-log-and-command-ghci ()
   (should (equal '("Starting inferior GHCi process ghci ..." "dumses1" nil "nix-shell" "default.nix" "--command" "ghci\\ -ferror-spans")
-                 (let ((haskell-process-path-ghci "ghci")
-                       (haskell-process-args-ghci '("-ferror-spans")))
-                   (custom-set-variables '(haskell-process-wrapper-function
+                 (let ((haskell-session-path-ghci "ghci")
+                       (haskell-session-args-ghci '("-ferror-spans")))
+                   (custom-set-variables '(haskell-session-wrapper-function
                                            (lambda (argv) (append (list "nix-shell" "default.nix" "--command" )
                                                              (list (shell-quote-argument (mapconcat 'identity argv " ")))))))
                    (mocklet (((haskell-session-name "dummy-session") => "dumses1"))
-                     (haskell-process-compute-process-log-and-command "dummy-session" 'ghci))))))
+                     (haskell-session-compute-process-log-and-command "dummy-session" 'ghci))))))
 
-(ert-deftest test-haskell-process--compute-process-log-and-command-cabal-repl ()
+(ert-deftest test-haskell-session--compute-process-log-and-command-cabal-repl ()
   (should (equal '("Starting inferior `cabal repl' process using cabal ..." "dumses2" nil "cabal" "repl" "--ghc-option=-ferror-spans" "dumdum-session")
-                 (let ((haskell-process-path-cabal      "cabal")
-                       (haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans")))
-                   (custom-set-variables '(haskell-process-wrapper-function #'identity))
+                 (let ((haskell-session-path-cabal      "cabal")
+                       (haskell-session-args-cabal-repl '("--ghc-option=-ferror-spans")))
+                   (custom-set-variables '(haskell-session-wrapper-function #'identity))
                    (mocklet (((haskell-session-name "dummy-session2") => "dumses2")
                              ((haskell-session-target "dummy-session2") => "dumdum-session"))
-                     (haskell-process-compute-process-log-and-command "dummy-session2" 'cabal-repl))))))
+                     (haskell-session-compute-process-log-and-command "dummy-session2" 'cabal-repl))))))
 
-(ert-deftest test-haskell-process--with-wrapper-compute-process-log-and-command-cabal-repl ()
+(ert-deftest test-haskell-session--with-wrapper-compute-process-log-and-command-cabal-repl ()
   (should (equal '("Starting inferior `cabal repl' process using cabal ..." "dumses2" nil "nix-shell" "default.nix" "--command" "cabal\\ repl\\ --ghc-option\\=-ferror-spans\\ dumdum-session")
-                 (let ((haskell-process-path-cabal      "cabal")
-                       (haskell-process-args-cabal-repl '("--ghc-option=-ferror-spans")))
-                   (custom-set-variables '(haskell-process-wrapper-function
+                 (let ((haskell-session-path-cabal      "cabal")
+                       (haskell-session-args-cabal-repl '("--ghc-option=-ferror-spans")))
+                   (custom-set-variables '(haskell-session-wrapper-function
                                            (lambda (argv) (append (list "nix-shell" "default.nix" "--command" )
                                                              (list (shell-quote-argument (mapconcat 'identity argv " ")))))))
                    (mocklet (((haskell-session-name "dummy-session2") => "dumses2")
                              ((haskell-session-target "dummy-session2") => "dumdum-session"))
-                     (haskell-process-compute-process-log-and-command "dummy-session2" 'cabal-repl))))))
+                     (haskell-session-compute-process-log-and-command "dummy-session2" 'cabal-repl))))))
 
 
 ;;; haskell-process-tests.el ends here


### PR DESCRIPTION
`haskell-session` <- `haskell-process`

What works:
1. Loading a module and seeing the error overlays -- provided that the ~/.emacs has `s/haskell-process/haskell-session/g` applied.

Problems:
1. This is the purely mechanical phase of the merge.  The bulk of normalization will come later.
2. This changes the `defcustom` names.