### PR TITLE
Add unused string in completions as well.

### DIFF
--- a/haskell-process.el
+++ b/haskell-process.el
@@ -306,10 +306,11 @@ Returns NIL when no completions found."
              (h0 (car s1))) ;; "<limit count> <all count> <unused string>"
         (unless (string-match "\\`\\([0-9]+\\) \\([0-9]+\\) \\(\".*\"\\)\\'" h0)
           (error "Invalid `:complete' response"))
-        (let ((cnt1 (match-string 1 h0)))
+        (let ((cnt1 (match-string 1 h0))
+              (h1 (haskell-string-literal-decode (match-string 3 h0))))
           (unless (= (string-to-number cnt1) (length cs))
             (error "Lengths inconsistent in `:complete' reponse"))
-          cs)))))
+          (cons h1 cs))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessing the process


### PR DESCRIPTION
It seems that the issue #787 might be due to the "unused string" (h1) being not in completions list (cs). This commit reverts part of the commit f0466a2 back to the earlier version, where the unused string (h1) is placed at beginning of the completions list (cs). 
