### PR TITLE
Suppress byte-compile warning

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -64,8 +64,8 @@
             nil
             t))
 
-(make-obsolete #'haskell-process-completions-at-point
-               #'haskell-completions-sync-completions-at-point
+(make-obsolete 'haskell-process-completions-at-point
+               'haskell-completions-sync-completions-at-point
                "June 19, 2015")
 (defun haskell-process-completions-at-point ()
   "A completion-at-point function using the current haskell process."


### PR DESCRIPTION
`'` should be used rather than `#'` in `make-obsolete` and `#'` causes byte-compile warning.  You can get following warning by following steps.
1. byte-compile `haskell.el`
2. load `haskell.elc`
3. byte-compile `haskell.el`

```
haskell.el:67:2:Warning: `haskell-process-completions-at-point' is an obsolete
    function (as of June 19, 2015); use
    `haskell-completions-sync-completions-at-point' instead.
```
