### PR TITLE
haskell-load: add haskell-goto-first-error

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -345,6 +345,12 @@ correspondingly-named overlay properties of OVL."
 	(t
 	 (message "No further notes from Haskell compiler."))))
 
+(defun haskell-goto-first-error ()
+  (interactive)
+  (haskell-goto-error-overlay
+   (first-overlay-in-if 'haskell-check-overlay-p
+			(buffer-end 0) (buffer-end 1))))
+
 (defun haskell-goto-prev-error ()
   (interactive)
   (haskell-goto-error-overlay

--- a/haskell.el
+++ b/haskell.el
@@ -51,6 +51,7 @@
     (define-key map [?\C-c ?\C-z] 'haskell-interactive-switch)
     (define-key map (kbd "M-n") 'haskell-goto-next-error)
     (define-key map (kbd "M-p") 'haskell-goto-prev-error)
+    (define-key map (kbd "C-c M-p") 'haskell-goto-first-error)
     map)
   "Keymap for using haskell-interactive-mode.")
 


### PR DESCRIPTION
I usually start to fix stuff from top to bottom. This helps finding the first error.