### PR TITLE
Choose a REPL session target from list

### DIFF
--- a/doc/haskell-mode.texi
+++ b/doc/haskell-mode.texi
@@ -601,32 +601,24 @@ TODO/WRITEME
 @findex haskell-session-change-target
 @vindex haskell-interactive-mode-hook
 
-With @code{haskell-session-change-target} you can change the section
-(defined in project's @file{.cabal} file) the interactive REPL session is
-started with.
+With @code{haskell-session-change-target} you can change the target for
+REPL session.
 
-After the session is started, you can switch the target for
+
+After REPL session started, in @code{haskell-interactive-mode} buffer invoke the
+@code{haskell-session-change-target} and select from available targets for
 
 @cindex testing
 - Testing
 
-In @code{haskell-interactive-mode} buffer invoke the
-@code{haskell-session-change-target} and enter the name of the test you
-wish to perform, i.e. ``test''.
-Answer ``yes'' to restart the session.
-
 @cindex benchmarking
 - Benchmark
 
-In @code{haskell-interactive-mode} buffer invoke the  @code{haskell-session-change-target}
-and enter the name of the benchmark you wish to perform, i.e. ``bench''.
-Answer ``yes'' to restart the session.
-
 - Executable
 
-In @code{haskell-interactive-mode} buffer invoke the  @code{haskell-session-change-target}
-and enter the name of the executable you wish to work with.
-Answer ``yes'' to restart the session.
+- Library
+
+Answer ``yes'' to restart the session and run your tests, benchmarks, executables.
 
 
 TODO/WRITEME

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -444,6 +444,21 @@ OTHER-WINDOW use `find-file-other-window'."
 (defun haskell-cabal-section-data-start-column (section)
   (plist-get section :data-start-column))
 
+(defun haskell-cabal-enum-targets ()
+  "Enumerate .cabal targets."
+  (let ((cabal-file (haskell-cabal-find-file)))
+    (when (and cabal-file (file-readable-p cabal-file))
+      (with-temp-buffer
+	(insert-file-contents cabal-file)
+	(haskell-cabal-mode)
+	(let (matches)
+	  (goto-char (point-min))
+	  (haskell-cabal-next-section)
+	  (while (not (eobp))
+	    (push (haskell-cabal-section-value (haskell-cabal-section)) matches)
+	    (haskell-cabal-next-section))
+	  (reverse matches))))))
+
 (defmacro haskell-cabal-with-subsection (subsection replace &rest funs)
   "Copy subsection data into a temporary buffer, save indentation
 and execute FORMS

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -777,8 +777,8 @@ inferior GHCi process."
   "Set the build TARGET for cabal REPL."
   (interactive
    (list
-     (completing-read "New build target:" (haskell-cabal-enum-targets)
-		      nil nil nil haskell-cabal-targets-history)))
+     (completing-read "New build target: " (haskell-cabal-enum-targets)
+		      nil nil nil 'haskell-cabal-targets-history)))
   (let* ((session haskell-session)
          (old-target (haskell-session-get session 'target)))
     (when session

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -773,7 +773,8 @@ inferior GHCi process."
 ;;;###autoload
 (defun haskell-session-change-target (target)
   "Set the build TARGET for cabal REPL."
-  (interactive "sNew build target:")
+  (interactive
+   (list (completing-read "New build target:" (haskell-cabal-enum-targets))))
   (let* ((session haskell-session)
          (old-target (haskell-session-get session 'target)))
     (when session

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -169,6 +169,8 @@ Use to update mtime on BUFFER's file."
 
 (defvar url-http-response-status)
 (defvar url-http-end-of-headers)
+(defvar haskell-cabal-targets-history nil
+  "History list for session targets.")
 
 (defun haskell-process-hayoo-ident (ident)
   ;; FIXME Obsolete doc string, CALLBACK is not used.
@@ -774,7 +776,9 @@ inferior GHCi process."
 (defun haskell-session-change-target (target)
   "Set the build TARGET for cabal REPL."
   (interactive
-   (list (completing-read "New build target:" (haskell-cabal-enum-targets))))
+   (list
+     (completing-read "New build target:" (haskell-cabal-enum-targets)
+		      nil nil nil haskell-cabal-targets-history)))
   (let* ((session haskell-session)
          (old-target (haskell-session-get session 'target)))
     (when session


### PR DESCRIPTION
New function `haskell-session-choose-target` enables choosing from available targets list from `.cabal` file.
It is just a wrapper around `haskell-session-change-target` which can still be used to select a target directly, by specifying it as an arg.