### PR TITLE
Prevent the unused variable warning

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -421,9 +421,10 @@ indentation points to the right, we switch going to the left."
   "Makes sure that haskell-indentation-dyn-overlays contains at least N overlays."
   (let* ((clen (length haskell-indentation-dyn-overlays))
          (needed (- n clen)))
-    (dotimes (n needed haskell-indentation-dyn-overlays)
+    (dotimes (_n needed)
       (setq haskell-indentation-dyn-overlays
-            (cons (make-overlay 1 1) haskell-indentation-dyn-overlays)))))
+            (cons (make-overlay 1 1) haskell-indentation-dyn-overlays)))
+    haskell-indentation-dyn-overlays))
 
 (defun haskell-indentation-unshow-overlays ()
   "Unshows all the overlays."


### PR DESCRIPTION
The warning report system of the byte-compiler is not perfect.
It generates the warning if the third argument of `dotimes` is used.
Also, it does so if the first argument is not explicitly used in its body.
As workaround, this patch removes the third argument and put "_" to
the first argument.

Relating to #815 and #827.