### PR TITLE
Fix hoogle lookup from local servers

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -859,27 +859,33 @@ is asked to show extra info for the items matching QUERY.."
 (defvar hoogle-server-process-name "emacs-local-hoogle")
 (defvar hoogle-server-buffer-name (format "*%s*" hoogle-server-process-name))
 (defvar hoogle-port-number 49513 "Port number.")
+(defvar hoogle-server-process nil "The process handle of the local hoogle server.")
 
 (defun hoogle-start-server ()
   "Start hoogle local server."
   (interactive)
-  (unless (hoogle-server-live-p)
-    (start-process
-     hoogle-server-process-name
-     (get-buffer-create hoogle-server-buffer-name) "/bin/sh" "-c"
-     (format "hoogle server -p %i" hoogle-port-number))))
+  (if (executable-find "hoogle")
+        (unless (hoogle-server-live-p)
+          (set 'hoogle-server-process
+            (start-process
+               hoogle-server-process-name
+               (get-buffer-create hoogle-server-buffer-name)
+               "/bin/sh" "-c"
+               (format "hoogle server -p %i" hoogle-port-number))))
+    (error "hoogle executable not found")))
 
 (defun hoogle-server-live-p ()
-  "Whether hoogle server is live or not."
+  "Whether the hoogle server process is live."
   (condition-case _err
-      (process-live-p (get-buffer-create hoogle-server-buffer-name))
+      (process-live-p hoogle-server-process)
     (error nil)))
 
 (defun hoogle-kill-server ()
-  "Kill hoogle server if it is live."
+  "Kill the hoogle server if it is live."
   (interactive)
   (when (hoogle-server-live-p)
-    (kill-process (get-buffer-create hoogle-server-buffer-name))))
+    (kill-process (get-buffer-create hoogle-server-buffer-name))
+    (set 'hoogle-server-process nil)))
 
 ;;;###autoload
 (defun hoogle-lookup-from-local ()
@@ -890,10 +896,8 @@ is asked to show extra info for the items matching QUERY.."
                           hoogle-port-number
                           (read-string "hoogle: " (haskell-ident-at-point))))
     (when (y-or-n-p
-           "hoogle server not found, start hoogle server?")
-      (if (executable-find "hoogle")
-          (hoogle-start-server)
-        (error "hoogle is not installed")))))
+           "hoogle server not running, start hoogle server?")
+      (hoogle-start-server))))
 
 ;;;###autoload
 (defcustom haskell-hayoo-url "http://hayoo.fh-wedel.de/?query=%s"

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -870,8 +870,7 @@ is asked to show extra info for the items matching QUERY.."
             (start-process
                hoogle-server-process-name
                (get-buffer-create hoogle-server-buffer-name)
-               "/bin/sh" "-c"
-               (format "hoogle server -p %i" hoogle-port-number))))
+               "hoogle" "server" "-p" (number-to-string hoogle-port-number))))
     (error "hoogle executable not found")))
 
 (defun hoogle-server-live-p ()


### PR DESCRIPTION
Use a better way to check if the hoogle process is alive: Instead of
checking if the corresponding buffer-name is an alive process, store the
process handle in a global variable and check that.

The problem is that when using 'hoogle-lookup-from-local' without any
hoogle server running, a new local hoogle server is started, but the
code fails to recognize that server is running and instead repeatedly
reports that the server is not running offering to start it.