### PR TITLE
Skip space prefixes in error-messages

### DIFF
--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -68,7 +68,7 @@ The `%s' placeholder is replaced by the current buffer's filename."
 
 (defconst haskell-compilation-error-regexp-alist
   `((,(concat
-       "^\\(?1:[^ \t\r\n]+?\\):"
+       "^ *\\(?1:[^ \t\r\n]+?\\):"
        "\\(?:"
        "\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)\\(?:-\\(?5:[0-9]+\\)\\)?" ;; "121:1" & "12:3-5"
        "\\|"
@@ -97,7 +97,7 @@ This is a child of `compilation-mode-map'.")
   "Local `compilation-filter-hook' for `haskell-compilation-mode'."
 
   (when haskell-compile-ghc-filter-linker-messages
-    (delete-matching-lines "^Loading package [^ \t\r\n]+ [.]+ linking [.]+ done\\.$"
+    (delete-matching-lines "^ *Loading package [^ \t\r\n]+ [.]+ linking [.]+ done\\.$"
                            (if (boundp 'compilation-filter-start) ;; available since Emacs 24.2
                                (save-excursion (goto-char compilation-filter-start)
                                                (line-beginning-position))


### PR DESCRIPTION
Useful for stack tool, which renders dependency-errors indented

Resolves #764