### PR TITLE
Disable layout rule only inside parentheses

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -894,11 +894,14 @@ After a lambda (backslash) there are two possible cases:
   "Parse a list, pair or other expression containing multiple
 items parsed by PARSER, separated by SEP or STMT-SEP, and ending
 with END."
-  (let (implicit-layout-active)
-    (haskell-indentation-with-starter
-     (apply-partially #'haskell-indentation-separated
-                      parser sep stmt-sep)
-     end)))
+  ;; note that we use macro expansion here to preserver Emacs 23
+  ;; compatibility and its lack of lexical binding
+  (haskell-indentation-with-starter
+   `(lambda ()
+      (let ((implicit-layout-active nil))
+        (haskell-indentation-separated
+         #',parser ,sep ,stmt-sep)))
+   end))
 
 (defun haskell-indentation-with-starter (parser &optional end where-expr?)
   "Parse an expression starting with a keyword or parenthesis.

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -506,4 +506,16 @@ let foo = Foo {
   ((5 0) 12)
   ((6 0) 12))
 
+(hindent-test "22 should obey layout only outside parentheses" "
+func = 1234
+  where
+    foo :: Ivory eff ()
+    foo = do
+      return ()"
+  ((1 0) 0)
+  ((2 0) 2)
+  ((3 0) 4)
+  ((4 0) 0 4 11)
+  ((5 0) 6))
+
 ;;; haskell-indentation-tests.el ends here


### PR DESCRIPTION
Fixes #844, fixes #835.