### PR TITLE
Use customize-variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install `haskell-mode` you need to add a package archive repository that dist
 `haskell-mode`. Execute
 
 ```
-M-x customize-option RET package-archives
+M-x customize-variable RET package-archives
 ```
 
 and add


### PR DESCRIPTION
`customize-option` doesn't work, since you also need to add `(require 'package)` to your `~/.emacs`, and requiring users to do so makes these instructions too complex, so usage of `customize-variable` looks best.

Resolves #857