### PR TITLE
Don't spuriously set mark on xref push

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -364,12 +364,7 @@ position with `xref-pop-marker-stack'."
         (haskell-mode-handle-generic-loc loc)
       (call-interactively 'haskell-mode-tag-find))
     (unless (equal initial-loc (point-marker))
-      (with-current-buffer (marker-buffer initial-loc)
-        (save-excursion
-          (goto-char initial-loc)
-          (set-mark-command nil)
-          ;; Store position for return with `xref-pop-marker-stack'
-          (xref-push-marker-stack))))))
+      (xref-push-marker-stack initial-loc))))
 
 ;;;###autoload
 (defun haskell-mode-goto-loc ()

--- a/haskell-compat.el
+++ b/haskell-compat.el
@@ -43,9 +43,9 @@ A process is considered alive if its status is `run', `open',
 (unless (fboundp 'xref-push-marker-stack)
   (defalias 'xref-pop-marker-stack 'pop-tag-mark)
 
-  (defun xref-push-marker-stack ()
+  (defun xref-push-marker-stack (&optional m)
     "Add point to the marker stack."
-    (ring-insert find-tag-marker-ring (point-marker))))
+    (ring-insert find-tag-marker-ring (or m (point-marker)))))
 
 (unless (fboundp 'outline-hide-sublevels)
   (defalias 'outline-hide-sublevels 'hide-sublevels))


### PR DESCRIPTION
This fixes #863, whereby jumping to the definition of a symbol in the
same file was incorrectly activating the mark and region. This commit
also simplifies the original code, since the initial position marker can
simply be passed to xref-push-marker-stack. (The haskell-compat shim for
that function is also fixed here accordingly.)