### PR TITLE
Keyword do is not open expression for indentation

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -1041,7 +1041,7 @@ parser.  If parsing ends here, set indentation to left-indent."
                 (haskell-indentation-add-layout-indent)
                 (throw 'parse-end nil))
               ;; after an 'open' expression such as 'if', exit
-              (unless (member (car parser) '("(" "[" "{" "do" "case"))
+              (unless (member (car parser) '("(" "[" "{" "case"))
                 (throw 'return nil)))))))))
 
 (defun haskell-indentation-test-indentations ()

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -254,7 +254,7 @@ fun = do { putStrLn \"X\";
          }"
   ((1 0) 0)
   ((2 0) 9 11)
-  ((3 0) 0 6))
+  ((3 0) 0))
 
 (hindent-test "13* Don't indent after deriving""
 data X = X


### PR DESCRIPTION
This is not syntactically legal Haskell:

    main =
       do putStrLn "X"
       do putStrLn "X"

where this is:

    main =
       (do putStrLn "X")
       (do putStrLn "X")

It parses but does not type check. Indentation should not propose the first case.