### PR TITLE
Support scoped types in indentation

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -740,10 +740,7 @@ the current buffer."
     ("where"   .
      ,(apply-partially 'haskell-indentation-with-starter
                        'haskell-indentation-declaration-layout nil t))
-    ("::"      .
-     ,(apply-partially 'haskell-indentation-with-starter
-                       (apply-partially #'haskell-indentation-separated
-                                        #'haskell-indentation-type "->")))
+    ("::"      .        haskell-indentation-scoped-type)
     ("="       .
      ,(apply-partially 'haskell-indentation-statement-right
                        'haskell-indentation-expression))
@@ -833,6 +830,17 @@ After a lambda (backslash) there are two possible cases:
               (if (not parser)
                   (throw 'return nil)
                 (funcall (cdr parser))))))))))
+
+(defun haskell-indentation-scoped-type ()
+  "Parse scoped type declaration.
+
+For example
+   let x :: Int = 12
+   do x :: Int <- return 12"
+  (haskell-indentation-with-starter
+   (apply-partially #'haskell-indentation-separated #'haskell-indentation-type "->"))
+  (when (member current-token '("<-" "="))
+    (haskell-indentation-statement-right #'haskell-indentation-expression)))
 
 (defun haskell-indentation-data ()
   "Parse data or type declaration."

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -524,15 +524,37 @@ func = 1234
 -}"
   ((3 2) 0))
 
-(hindent-test "24* should parse inline type signatures properly" "
+(hindent-test "24 should parse inline type signatures properly" "
 foo = do
   _ :: String <- undefined
   _ :: String <- undefined
   return ()"
               ((1 0) 0)
               ((2 0) 2)
-              ((3 0) 2 17)
-              ((4 0) 2 17))
+              ((3 0) 0 2 17)
+              ((4 0) 0 2 17))
+
+(hindent-test "25a* support scoped type declarations" "
+foo = do
+  bar :: String
+      -> String
+    <- undefined"
+              ((1 0) 0)
+              ((2 0) 2)
+              ((3 0) 6 9)
+              ;; here it brakes, it would like to put '<-' on same line with 'bar'
+              ;; the culprit is the 'do' keyword
+              ((4 0) 4))
+
+(hindent-test "25b support scoped type declarations" "
+foo = let
+  bar :: String
+      -> String
+    = undefined"
+              ((1 0) 0)
+              ((2 0) 2)
+              ((3 0) 6 9)
+              ((4 0) 4))
 
 
 ;;; haskell-indentation-tests.el ends here


### PR DESCRIPTION
Fixes #862. That is

    let foo :: Int = 42

and

    do foo :: Int <- return 42
