### PR TITLE
Ensure file reload when using -fbytecode

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -143,29 +143,17 @@ If I break, you can:
 Restores -fobject-code after reload finished.
 MODULE-BUFFER is the actual Emacs buffer of the module being loaded."
   (haskell-process-queue-without-filters process ":set -fbyte-code")
-  (haskell-process-touch-buffer process module-buffer)
-  (haskell-process-queue-without-filters process ":reload")
-  (haskell-process-queue-without-filters process ":set -fobject-code"))
-
-;;;###autoload
-(defun haskell-process-touch-buffer (process buffer)
-  "Query PROCESS to `:!touch` BUFFER's file.
-Use to update mtime on BUFFER's file."
-  (interactive)
-  (haskell-process-queue-command
+  ;; We prefix the module's filename with a "*", which asks ghci to
+  ;; ignore any existing object file and interpret the module.
+  ;; Dependencies will still use their object files as usual.
+  (haskell-process-queue-without-filters
    process
-   (make-haskell-command
-    :state (cons process buffer)
-    :go (lambda (state)
-          (haskell-process-send-string
-           (car state)
-           (format ":!%s %s"
-                   "touch"
-                   (shell-quote-argument (buffer-file-name
-                                          (cdr state))))))
-    :complete (lambda (state _)
-                (with-current-buffer (cdr state)
-                  (clear-visited-file-modtime))))))
+   (format ":load \"*%s\""
+           (replace-regexp-in-string
+            "\""
+            "\\\\\""
+            (buffer-file-name module-buffer))))
+  (haskell-process-queue-without-filters process ":set -fobject-code"))
 
 (defvar url-http-response-status)
 (defvar url-http-end-of-headers)


### PR DESCRIPTION
With `haskell-process-reload-with-fbytecode` set to `t`, we first compile with object code, then switch to bytecode, touch the file and issue a `:reload`. However, if the `.o` file generated in the first compilation is still considered fresh -- because it has the same timestamp as the just-touched source file -- the reload doesn't do anything.

This patch makes the touch move the source code's timestamp into the near future, so that it's always newer than the object code. This way the reload will always recompile it. The mechanism is pretty ugly and a bit of a hack, but seems to work on Linux and OS X.