### PR TITLE
Fix out-of-order session startup.

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -87,9 +87,11 @@ You can create new session using function `haskell-session-make'."
     :state process
 
     :go (lambda (process)
-          (haskell-process-send-string process ":set prompt \"\\4\"")
+          ;; We must set the prompt last, so that this command as a
+          ;; whole produces only one prompt marker as a response.
           (haskell-process-send-string process "Prelude.putStrLn \"\"")
-          (haskell-process-send-string process ":set -v1"))
+          (haskell-process-send-string process ":set -v1")
+          (haskell-process-send-string process ":set prompt \"\\4\""))
 
     :live (lambda (process buffer)
             (when (haskell-process-consume


### PR DESCRIPTION
Previously the responses to the startup commands could be delayed,
arriving so late that they appeared to be in response to later
commands (e.g. a :load).  By setting the prompt last, only one prompt
marker will be sent for the whole startup procedure.

Should fix issue #882.