### PR TITLE
some simple commands to send arbitrary text to a haskell process.

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -201,6 +201,7 @@ be set to the preferred literate style."
     (define-key map (kbd "C-c C-v") 'haskell-mode-enable-process-minor-mode)
     (define-key map (kbd "C-c C-t") 'haskell-mode-enable-process-minor-mode)
     (define-key map (kbd "C-c C-i") 'haskell-mode-enable-process-minor-mode)
+    (define-key map (kbd "C-c C-n") 'inferior-haskell-send-paragraph)
     map)
   "Keymap used in Haskell mode.")
 

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -402,6 +402,36 @@ If prefix arg \\[universal-argument] is given, just reload the previous file."
     (setq inferior-haskell-seen-prompt nil)
     (comint-send-string proc str)))
 
+(defun inferior-haskell-send-region ()
+  "Send an arbitrary region to an existing inferior haskell."
+  (interactive "*")
+  (save-excursion
+    (let ((haskell-proc (inferior-haskell-process))
+          (region-string (buffer-substring (region-beginning) (region-end))))
+      (inferior-haskell-send-command haskell-proc region-string))))
+
+(defun inferior-haskell-send-paragraph ()
+  "Send the current paragraph to a running inferior haskell."
+  (interactive "*")
+  (save-excursion
+    (let ((haskell-proc (inferior-haskell-process)))
+      (forward-paragraph)
+      (setq region-end (point))
+      (backward-paragraph)
+      (setq region-start (point))
+      (setq region-string (buffer-substring region-start region-end))
+      (inferior-haskell-send-command haskell-proc region-string))))
+
+(defun inferior-haskell-send-line ()
+  "Send the current line to a running haskell process."
+  (interactive "*")
+  (save-excursion
+    (let ((haskell-proc (inferior-haskell-process)))
+      (end-of-line)
+      (set-mark (line-beginning-position))
+      (setq region-string (buffer-substring (region-beginning) (region-end)))
+      (inferior-haskell-send-command haskell-proc region-string))))
+
 (defun inferior-haskell-reload-file ()
   "Tell the inferior haskell process to reread the current buffer's file."
   (interactive)


### PR DESCRIPTION
This provides 3 small functions to send a line, region, and paragraph to a running haskell.
My commit follows:

Also a keybinding similar to ESS's for sending a paragraph (C-c C-n) which
I don't think conflicts with anything existing unless you get your lines crossed with haskell-interactive-mode in which case it would conflict with
'haskell-interactive-mode-prompt-next.

I have so far tested it out only on my simple playing around scripts, but it seems to work as advertised and evaluate arbitrary code from my emacs buffer.
The current workflow I am using to play in haskell is:
1.  Open my .hs file
2    meta-x run-haskell
3.   :l file.hs
4.  Make some changes and hit ^C^N
5.  Watch the haskell prompt to see what I did right/wrong.