### PR TITLE
Support `where` keyword after any expression

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -987,7 +987,10 @@ parser.  If parsing ends here, set indentation to left-indent."
     (haskell-indentation-add-indentation current-indent)
     (throw 'parse-end nil))
   (let ((current-indent (current-column)))
-    (funcall parser)))
+    (funcall parser)
+    (when (equal current-token "where")
+      (haskell-indentation-with-starter
+       #'haskell-indentation-expression-layout nil))))
 
 (defun haskell-indentation-guard ()
   "Parse \"guard\" statement."

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -556,7 +556,7 @@ foo = let
               ((3 0) 6 9)
               ((4 0) 4))
 
-(hindent-test "26* should parse unindented where-clause properly" "
+(hindent-test "26 should parse unindented where-clause properly" "
 foo = do
     return ()
   where


### PR DESCRIPTION
Fixes #883.