### PR TITLE
Fix switching to the presentation buffer

### DIFF
--- a/haskell-presentation-mode.el
+++ b/haskell-presentation-mode.el
@@ -92,11 +92,11 @@ buffer before presenting message."
         (let ((buffer-read-only nil))
           (goto-char (point-min))
           (forward-line 2)
-          (insert code "\n\n")))
+          (insert code "\n\n"))))
 
-      (if (eq major-mode 'haskell-presentation-mode)
-          (switch-to-buffer buffer)
-        (pop-to-buffer buffer)))))
+    (if (eq major-mode 'haskell-presentation-mode)
+        (switch-to-buffer buffer)
+      (pop-to-buffer buffer))))
 
 (provide 'haskell-presentation-mode)
 


### PR DESCRIPTION
This fixes a regression. `haskell-presentation-present` is supposed to pop-to-buffer when there is none and we're not in the buffer, and if we are inside the buffer it's supposed to re-use this same buffer. This fixes it. `(with-current-buffer ...)` confuses the value of `major-mode`.