### PR TITLE
Toplevel indentation bugfixes for data, newtype, instance

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -679,15 +679,9 @@ the current buffer."
 
 (defconst haskell-indentation-toplevel-list
   `(("module"   . haskell-indentation-module)
-    ("data"     .
-     ,(apply-partially 'haskell-indentation-statement-right
-                       'haskell-indentation-data))
-    ("type"     .
-     ,(apply-partially 'haskell-indentation-statement-right
-                       'haskell-indentation-data))
-    ("newtype"  .
-     ,(apply-partially 'haskell-indentation-statement-right
-                       'haskell-indentation-data))
+    ("data"     . haskell-indentation-data)
+    ("type"     . haskell-indentation-data)
+    ("newtype"  .   haskell-indentation-data)
     ("class"    . haskell-indentation-class-declaration)
     ("instance" . haskell-indentation-class-declaration))
   "Alist of toplevel keywords with associated parsers.")

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -613,7 +613,7 @@ class Foo a where
 instance Bar Int
 "
 	      ((2 0) 0))
-(hindent-test "32* allow type operators" "
+(hindent-test "32 allow type operators" "
 data (:.) a b = a :. b
 "
 	      ((2 0) 0 16))


### PR DESCRIPTION
Reference #916. One of those is fixed.