### PR TITLE
Reloading: haskell-process-file-loadish needs the current buffer as an argument

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -398,7 +398,7 @@ If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
   (interactive)
   (save-buffer)
   (haskell-interactive-mode-reset-error (haskell-session))
-  (haskell-process-file-loadish "reload" t nil))
+  (haskell-process-file-loadish "reload" t (current-buffer)))
 
 ;;;###autoload
 (defun haskell-process-load-or-reload (&optional toggle)


### PR DESCRIPTION
Currently nil is the argument for the buffer called in haskell-process-reload-file such that I always get "Haskell process command errored with: (wrong-type-argument stringp nil)" in the mini buffer.