### PR TITLE
Add ido/helm interface for haskell-interactive-mode-history

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -38,6 +38,7 @@
 (require 'ansi-color)
 (require 'cl-lib)
 (require 'etags)
+(require 'helm)
 
 (defvar haskell-interactive-mode-history-index)
 (make-variable-buffer-local 'haskell-interactive-mode-history-index)
@@ -973,6 +974,18 @@ don't care when the thing completes as long as it's soonish."
            (and (search-backward-regexp (haskell-interactive-prompt-regex) nil t)
                 (match-end 0)))))
     (when prev-prompt-pos (goto-char prev-prompt-pos))))
+
+(defun haskell-interactive-ido-history ()
+  (interactive)
+  (insert (ido-completing-read "history:" haskell-interactive-mode-history)))
+
+(defun haskell-interactive-helm-history ()
+  (interactive)
+  (helm
+   :sources `((
+	       (name . "history")
+	       (candidates . ,haskell-interactive-mode-history)
+	       (action . insert)))))
 
 (defun haskell-interactive-mode-prompt-next ()
   "Jump to the next prompt."

--- a/haskell-mode-pkg.el
+++ b/haskell-mode-pkg.el
@@ -1,5 +1,6 @@
 (define-package "haskell-mode" "20150822.1728" "A Haskell editing mode"
-		'((cl-lib "0.5")))
+		'((cl-lib "0.5")
+		  (helm "20151013.958")))
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:


### PR DESCRIPTION
Hello.

`haskell-interactive-mode-history-next/previous` requires too many key-pushes when the user wants to trace an old history.
I think it would be better if these kind of functions are provided as options.

Thanks.
