### PR TITLE
Make hasktags command customizable

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -33,6 +33,7 @@
 (require 'haskell-presentation-mode)
 (require 'haskell-utils)
 (require 'highlight-uses-mode)
+(require 'haskell-customize)
 
 ;;;###autoload
 (defun haskell-process-restart ()
@@ -702,11 +703,11 @@ function `xref-find-definitions' after new table was generated."
                             (haskell-session-cabal-dir (haskell-process-session (car state)))))
               (haskell-process-send-string
                (car state)
-               (format ":!cd %s && %s | %s"
+               (format ":!cd %s && %s"
                        (haskell-session-cabal-dir
                         (haskell-process-session (car state)))
-                       "find . -type f \\( -name '*.hs' -or -name '*.lhs' -or -name '*.hsc' \\) -not \\( -name '#*' -or -name '.*' \\) -print0"
-                       "xargs -0 hasktags -e -x"))))
+                       haskell-tags-command
+                       ))))
       :complete (lambda (state _response)
                   (when (cdr state)
                     (let ((session-tags

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -404,6 +404,13 @@ same vein as `haskell-indent-spaces'."
   :group 'haskell
   :type '(repeat 'string))
 
+;;;###autoload
+(defcustom haskell-tags-command
+  "find . -type f \\( -name '*.hs' -or -name '*.lhs' -or -name '*.hsc' \\) -not \\( -name '#*' -or -name '.*' \\) -print0 | xargs -0 hasktags -e -x"
+  "Command to run from the project root to find haskell files and generate a TAGS file"
+  :type 'string
+  :group 'haskell)
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessor functions


### PR DESCRIPTION
Because of some some pretty odd reasons in my setup, I found myself needing to customize the find/hasktags command that haskell-mode runs to generate a TAGS file. Some valid reasons for this being customizable could include having different versions of either hasktags or GNU find. Went ahead and loaded this into my own editor and it appears to work fine.