### PR TITLE
Recognize top level constructs in indentation

### DIFF
--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -507,7 +507,8 @@ indentation points to the right, we switch going to the left."
   `(("module"   . haskell-indentation-module)
     ("data"     . haskell-indentation-data)
     ("type"     . haskell-indentation-data)
-    ("newtype"  .   haskell-indentation-data)
+    ("newtype"  . haskell-indentation-data)
+    ("import"   . haskell-indentation-import)
     ("class"    . haskell-indentation-class-declaration)
     ("instance" . haskell-indentation-class-declaration))
   "Alist of toplevel keywords with associated parsers.")
@@ -676,6 +677,10 @@ For example
            ((string= current-token "where")
             (haskell-indentation-with-starter
              #'haskell-indentation-expression-layout nil))))))
+
+(defun haskell-indentation-import ()
+  "Parse import declaration."
+  (haskell-indentation-with-starter #'haskell-indentation-expression))
 
 (defun haskell-indentation-class-declaration ()
   "Parse class declaration."
@@ -946,7 +951,9 @@ layout starts."
                (haskell-indentation-read-next-token))
               ((eq current-token 'end-tokens)
                (when (or (haskell-indentation-expression-token-p following-token)
-                         (string= following-token ";"))
+                         (string= following-token ";")
+                         (and (equal layout-indent 0)
+                              (member following-token (mapcar #'car haskell-indentation-toplevel-list))))
                  (haskell-indentation-add-layout-indent))
                (throw 'return nil))
               (t (throw 'return nil))))))
@@ -1132,7 +1139,7 @@ line."
 
 (defun haskell-indentation-peek-token ()
   "Return token starting at point."
-  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|rec\\|do\\|proc\\|case\\|of\\|where\\|module\\|deriving\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
+  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|rec\\|do\\|proc\\|case\\|of\\|where\\|module\\|deriving\\|import\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
          (match-string-no-properties 1))
         ((looking-at "[][(){}[,;]")
          (match-string-no-properties 0))

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -181,22 +181,21 @@ function = do
 
 (hindent-test "3 Import statememnt symbol list 1""
 import Control.Concurrent
-  ( forkIO,
-    killThread )"
+       ( forkIO,
+         killThread )"
   ((1 0) 0)
-  ((2 0) 0 2)
-  ((3 0) 4)
-  ((4 0) 0 2))
+  ((2 0) 0 7)
+  ((3 0) 9)
+  ((4 0) 0 7))
 
 (hindent-test "4 Import statememnt symbol list 2""
 import Control.Concurrent
-  ( forkIO
-  , killThread )
-"
+       ( forkIO
+       , killThread )"
   ((1 0) 0)
-  ((2 0) 0 2)
-  ((3 0) 2)
-  ((4 0) 0 2))
+  ((2 0) 0 7)
+  ((3 0) 7)
+  ((4 0) 0 7))
 
 (hindent-test "5 List comprehension""
 fun = [ x | y
@@ -234,12 +233,24 @@ fun = [ f | x ← xs
   ((4 0) 10)
   ((5 0) 0))
 
-(hindent-test "7* \"import\" after \"import\"""
+(hindent-test "7a \"data\" after \"data\"""
+data ABC = ABC
+data DEF = DEF"
+  ((1 0) 0)
+  ((2 0) 0))
+
+(hindent-test "7 \"import\" after \"import\"""
 import ABC
 import DEF"
   ((1 0) 0)
   ((2 0) 0)
-  ((3 0) 0))
+  ((3 0) 0 7))
+
+(hindent-test "7b* declaration after declaration" "
+fun1 = undefined
+fun2 = undefined"
+  ((1 0) 0)
+  ((2 0) 0))
 
 (hindent-test "8* Guards in function definition""
 resolve (amount, max) number


### PR DESCRIPTION
Keep top level constructs like 'data', 'import', 'class', 'instance' at top level.