### PR TITLE
Don't spuriously modify tags-table-list's global value

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -709,12 +709,10 @@ function `xref-find-definitions' after new table was generated."
                        "xargs -0 hasktags -e -x"))))
       :complete (lambda (state _response)
                   (when (cdr state)
-                    (let ((session-tags
-                          (haskell-session-tags-filename
-                           (haskell-process-session (car state)))))
-                      (add-to-list 'tags-table-list session-tags)
-                      (setq tags-file-name nil))
-                    (xref-find-definitions (cdr state)))
+                    (let ((tags-file-name
+                           (haskell-session-tags-filename
+                            (haskell-process-session (car state)))))
+                      (xref-find-definitions (cdr state))))
                   (haskell-mode-message-line "Tags generated."))))))
 
 (defun haskell-process-add-cabal-autogen ()


### PR DESCRIPTION
As part of #592, commit 2b4e49cf modified this code to alter the global
value of tags-table-list as a side-effect, but this change was incorrect
and causes problems elsewhere.

Specifically, consider the following scenario:

- User tries to jump to a definition with haskell-mode-jump-to-def-or-tag
- That function falls back to haskell-mode-tag-find, which then calls
  haskell-mode-jump-to-tag

This results in a call to haskell-process-generate-tags, which tries to
run hasktags, whether or not it is installed. As a side effect, the
global value of tags-table-list is set to include
"/project/root/dir/TAGS", which was probably not even created
properly (most people won't have hasktags installed).

Then, imagine we're working in an unrelated project, and use Emacs'
built-in completion-at-point functionality (or company-mode, which wraps
it). Now, the tags-completion-at-point-function (enabled by default)
sees and uses the modified value of tags-table-list, and errors noisily
when called because that file does not exist. And even if it didn't
error, the tags would not be relevant to the current project.

In other words, this code either breaks or disrupts completion
everywhere beyond the current haskell project.

So, the correct solution here is to leave tags-table-list unchanged:
users such as the author of 2b4e49cf should instead use directory-local
variables to set tags-table-list or tags-file-name locally to their
haskell project.