### PR TITLE
Add an additional trigger for pragma suggestions

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -139,6 +139,7 @@ actual Emacs buffer of the module being loaded."
                     (not (string-match "\\([A-Z][A-Za-z]+\\) is deprecated" msg)))
                (string-match "Use \\([A-Z][A-Za-z]+\\) to permit this" msg)
                (string-match "Use \\([A-Z][A-Za-z]+\\) to allow" msg)
+               (string-match "Use \\([A-Z][A-Za-z]+\\) if you want to disable this" msg)
                (string-match "use \\([A-Z][A-Za-z]+\\)" msg)
                (string-match "You need \\([A-Z][A-Za-z]+\\)" msg)))
          (when haskell-process-suggest-language-pragmas


### PR DESCRIPTION
An example of an error message that gets triggered by this is the following
```
      (All instance types must be of the form (T a1 ... an)
       where a1 ... an are *distinct type variables*,
       and each type variable appears at most once in the instance head.
       Use FlexibleInstances if you want to disable this.)
```