### PR TITLE
Clean up SCC code

### DIFF
--- a/doc/haskell-mode.texi
+++ b/doc/haskell-mode.texi
@@ -278,6 +278,15 @@ and available packages.
 @image{anim/company-mode-import-statement}
 @end ifhtml
 
+@section Profiling and Debugging support
+
+When profiling code with GHC, it is often useful to add
+@uref{https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/profiling.html#cost-centres,
+cost centres} by hand.  These allow finer-grained information about
+program behavior.  @code{haskell-mode} provides the function
+@code{haskell-mode-toggle-scc-at-point} to make this more convenient.
+It will remove an SCC annotation at point if one is present, or add
+one if point is over whitespace.  By default it is bound to @kbd{C-c C-s}.
 
 @node Unicode support
 @chapter Unicode support

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -202,6 +202,7 @@ be set to the preferred literate style."
     (define-key map (kbd "C-c C-v") 'haskell-mode-enable-process-minor-mode)
     (define-key map (kbd "C-c C-t") 'haskell-mode-enable-process-minor-mode)
     (define-key map (kbd "C-c C-i") 'haskell-mode-enable-process-minor-mode)
+    (define-key map (kbd "C-c C-s") 'haskell-mode-toggle-scc-at-point)
     map)
   "Keymap used in Haskell mode.")
 

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -918,6 +918,10 @@ successful, nil otherwise."
   (if (not (haskell-mode-try-insert-scc-at-point))
       (error "Not over an area of whitespace")))
 
+(make-obsolete
+ 'haskell-mode-insert-scc-at-point
+ 'haskell-mode-toggle-scc-at-point)
+
 (defun haskell-mode-try-kill-scc-at-point ()
   "Try to kill an SCC annotation at point.  Return true if
 successful, nil otherwise."
@@ -938,6 +942,10 @@ successful, nil otherwise."
   (interactive)
   (if (not (haskell-mode-try-kill-scc-at-point))
       (error "No SCC at point")))
+
+(make-obsolete
+ 'haskell-mode-kill-scc-at-point
+ 'haskell-mode-toggle-scc-at-point)
 
 (defun haskell-mode-toggle-scc-at-point ()
   "If point is in an SCC annotation, kill the annotation.  Otherwise, try to insert a new annotation."

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -920,7 +920,8 @@ successful, nil otherwise."
 
 (make-obsolete
  'haskell-mode-insert-scc-at-point
- 'haskell-mode-toggle-scc-at-point)
+ 'haskell-mode-toggle-scc-at-point
+ "2015-11-11")
 
 (defun haskell-mode-try-kill-scc-at-point ()
   "Try to kill an SCC annotation at point.  Return true if
@@ -945,7 +946,8 @@ successful, nil otherwise."
 
 (make-obsolete
  'haskell-mode-kill-scc-at-point
- 'haskell-mode-toggle-scc-at-point)
+ 'haskell-mode-toggle-scc-at-point
+ "2015-11-11")
 
 (defun haskell-mode-toggle-scc-at-point ()
   "If point is in an SCC annotation, kill the annotation.  Otherwise, try to insert a new annotation."

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -895,10 +895,12 @@ LOC = (list FILE LINE COL)"
 (defun haskell-mode-try-insert-scc-at-point ()
   "Try to insert an SCC annotation at point.  Return true if
 successful, nil otherwise."
-  (if (or (looking-at "\\b\\|[ \t]\\|$") (and (not (bolp))
-                                              (save-excursion
-                                                (forward-char -1)
-                                                (looking-at "\\b\\|[ \t]"))))
+  (if (or (looking-at "\\b\\|[ \t]\\|$")
+          ;; Allow SCC if point is on a non-letter with whitespace to the left
+          (and (not (bolp))
+               (save-excursion
+                 (forward-char -1)
+                 (looking-at "[ \t]"))))
       (let ((space-at-point (looking-at "[ \t]")))
         (unless (and (not (bolp)) (save-excursion
                                     (forward-char -1)

--- a/tests/haskell-mode-tests.el
+++ b/tests/haskell-mode-tests.el
@@ -170,7 +170,7 @@
   (should (with-temp-buffer
             (haskell-mode)
             (insert "Äöèąċōïá")
-            (string= "Äöèąċōïá" (haskell-ident-at-point)))))            
+            (string= "Äöèąċōïá" (haskell-ident-at-point)))))
 
 (ert-deftest unicode-pos ()
   (should (with-temp-buffer
@@ -384,5 +384,32 @@ Also should respect 10 column fill."
                 "-- d e")
 	      '("-- @| a b c d"
                 "-- e")))
+
+(ert-deftest insert-scc-feasible ()
+  "insert an SCC where it's possible to do so"
+  (should (with-temp-buffer
+            (insert "hello world")
+            (goto-char 6)
+            (haskell-mode-toggle-scc-at-point)
+            (string= "hello {-# SCC \"\" #-} world"
+                     (buffer-substring 1 (point-max))))))
+
+(ert-deftest insert-scc-infeasible ()
+  "insert an SCC where it's not possible to do so"
+  (should-error (with-temp-buffer
+            (insert "hello world")
+            (goto-char 3)
+            (haskell-mode-toggle-scc-at-point)
+            (string= "hello world"
+                     (buffer-substring 1 (point-max))))))
+
+(ert-deftest remove-scc ()
+  "insert an SCC where it's possible to do so"
+  (should (with-temp-buffer
+            (insert "hello {-# SCC \"\" #-} world")
+            (goto-char 10)
+            (haskell-mode-toggle-scc-at-point)
+            (string= "hello world"
+                     (buffer-substring 1 (point-max))))))
 
 (provide 'haskell-mode-tests)

--- a/tests/haskell-mode-tests.el
+++ b/tests/haskell-mode-tests.el
@@ -398,7 +398,7 @@ Also should respect 10 column fill."
   "insert an SCC where it's not possible to do so"
   (should-error (with-temp-buffer
             (insert "hello world")
-            (goto-char 3)
+            (goto-char 2)
             (haskell-mode-toggle-scc-at-point)
             (string= "hello world"
                      (buffer-substring 1 (point-max))))))


### PR DESCRIPTION
Following discussion at https://github.com/haskell/haskell-mode/pull/961, I've tried to make the SCC functions (which I use) more pleasant to use and to maintain.  Please let me know if you want things done differently.

I wrote a new function to toggle SCC's, so only one keybinding is necessary.  I refactored the existing code to avoid spurious errors about "can't remove SCC" when adding an SCC.  I kept the old functions around for backwards compatibility, but I don't really care if they go away.

Along the way I found a bug, which I think I've fixed and adequately described in the commit messages.