### PR TITLE
Truncate multi-line messages less aggressively

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -412,13 +412,15 @@ SESSION, otherwise operate on the current buffer.
 
 (defun haskell-mode-message-line (str)
   "Message only one line, multiple lines just disturbs the programmer."
-  (let ((lines (split-string str "\n" t)))
-    (when (and (car lines) (stringp (car lines)))
-      (message "%s"
-               (concat (car lines)
-                       (if (and (cdr lines) (stringp (cadr lines)))
-                           (format " [ %s .. ]" (haskell-string-take (haskell-string-trim (cadr lines)) 10))
-                         ""))))))
+  (message (haskell-mode-one-line str (frame-width))))
+
+(defun haskell-mode-one-line (str width)
+  "Try to fit as much as possible on one line."
+  (let*
+      ((long-line (replace-regexp-in-string "\n" " " str))
+       (condensed  (replace-regexp-in-string " +" " "
+                                             (haskell-string-trim long-line))))
+    (truncate-string-to-width condensed width nil nil "…")))
 
 (defun haskell-interactive-mode-tab ()
   "Do completion if at prompt or else try collapse/expand."


### PR DESCRIPTION
When preparing multiline messages for the minibuffer, unwrap onto one line
and only truncate as much as necessary.  Previously, we showed the first
line and only a small part of the second.

closes #988

This does the right thing even with proportional fonts.  It should DTRT with wide chars and combining chars, but I haven't verified that.  

I looked at all the calls to `haskell-mode-message-line`, and I think it's reasonable to have them all use this new truncation behavior, but I'd appreciate someone double-checking that.