### PR TITLE
Remove duplicate filename in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ ELFILES = \
 	haskell-collapse.el \
 	haskell-modules.el \
 	haskell-sandbox.el \
-	haskell-cabal.el \
 	haskell-commands.el \
 	haskell-compat.el \
 	haskell-compile.el \


### PR DESCRIPTION
This duplicate filename was throwing this warning:

Makefile:114: target 'check-haskell-cabal' given more than once in the same rule