### PR TITLE
Do not sort imports twice

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -404,6 +404,13 @@ same vein as `haskell-indent-spaces'."
   :group 'haskell
   :type '(repeat 'string))
 
+;;;###autoload
+(defcustom haskell-stylish-on-save nil
+  "Whether to run stylish-haskell on the buffer before saving.
+If this is true, `haskell-add-import' will not sort or align the
+imports."
+  :group 'haskell
+  :type 'boolean)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessor functions

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -822,7 +822,9 @@ Note that negative arguments do not work so well."
 
 ;;;###autoload
 (defcustom haskell-stylish-on-save nil
-  "Whether to run stylish-haskell on the buffer before saving."
+  "Whether to run stylish-haskell on the buffer before saving.
+If this is true, `haskell-add-import' will not sort or align the
+imports."
   :group 'haskell
   :type 'boolean)
 

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -821,14 +821,6 @@ Note that negative arguments do not work so well."
                  (string :tag "Other command")))
 
 ;;;###autoload
-(defcustom haskell-stylish-on-save nil
-  "Whether to run stylish-haskell on the buffer before saving.
-If this is true, `haskell-add-import' will not sort or align the
-imports."
-  :group 'haskell
-  :type 'boolean)
-
-;;;###autoload
 (defcustom haskell-tags-on-save nil
   "Generate tags via hasktags after saving."
   :group 'haskell

--- a/haskell-modules.el
+++ b/haskell-modules.el
@@ -25,7 +25,9 @@
 (require 'haskell-sandbox)
 
 (defun haskell-add-import (&optional module)
-  "Add an import to the import list."
+  "Add an import to the import list.  Sorts and aligns imports,
+unless `haskell-stylish-on-save' is set, in which case we defer
+to stylish-haskell."
   (interactive)
   (save-excursion
     (goto-char (point-max))
@@ -35,8 +37,8 @@
                  (haskell-complete-module-read
                   "Module: "
                   (haskell-session-all-modules (haskell-modules-session))))))
-    (haskell-sort-imports)
-    (haskell-align-imports)))
+    (unless haskell-stylish-on-save (haskell-sort-imports)
+            (haskell-align-imports))))
 
 (defun haskell-import-for-module (module)
   "Get import statements for the given module."

--- a/haskell-modules.el
+++ b/haskell-modules.el
@@ -23,6 +23,7 @@
 (require 'haskell-navigate-imports)
 (require 'haskell-complete-module)
 (require 'haskell-sandbox)
+(require 'haskell-customize)
 
 (defun haskell-add-import (&optional module)
   "Add an import to the import list.  Sorts and aligns imports,


### PR DESCRIPTION
reuse `haskell-stylish-on-save` to decide whether to sort & align in `haskell-add-import`.

closes https://github.com/haskell/haskell-mode/issues/914