### PR TITLE
Use vanilla buffer file name for hlint command

### DIFF
--- a/haskell-checkers.el
+++ b/haskell-checkers.el
@@ -144,7 +144,7 @@
 
 (defun haskell-lint-make-command (file)
   "Generates command line for scan"
-  (concat haskell-lint-command  " \"/" file "/\"" " " haskell-lint-options))
+  (concat haskell-lint-command  " \"" file "\"" " " haskell-lint-options))
 
 (defmacro haskell-checkers-setup (type name)
   "Performs setup of corresponding checker. Receives two arguments:


### PR DESCRIPTION
Otherwise, hlint will try checking files with names like '//home/foo/bar/Baz.hs/'.