### PR TITLE
Fix align imports for modules named "Instance"

### DIFF
--- a/haskell-align-imports.el
+++ b/haskell-align-imports.el
@@ -223,8 +223,9 @@
   "Are we after the imports list?"
   (save-excursion
     (goto-char (line-beginning-position))
-    (not (not (search-forward-regexp "\\( = \\|\\<instance\\>\\| :: \\| ∷ \\)"
-                                     (line-end-position) t 1)))))
+    (let ((case-fold-search nil))
+      (not (not (search-forward-regexp "\\( = \\|\\<instance\\>\\| :: \\| ∷ \\)"
+                                       (line-end-position) t 1))))))
 
 (provide 'haskell-align-imports)
 


### PR DESCRIPTION
If you have case-fold-search enabled and import a module named "Instance", haskell-align-imports-after-imports-p will stop looking as it  thinks it reached the end of the imports.

Changed regex to always be case sensitive.

