### PR TITLE
Add some common extensions to haskell-rgrep

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -276,7 +276,7 @@ Prompts for an arbitrary regexp given a prefix arg PROMPT."
                  (read-from-minibuffer "Look for: ")
                (haskell-ident-at-point))))
     (rgrep sym
-           "*.hs" ;; TODO: common Haskell extensions.
+           "*.hs *.lhs *.hsc *.chs *.hs-boot *.lhs-boot"
            (haskell-session-current-dir (haskell-interactive-session)))))
 
 ;;;###autoload


### PR DESCRIPTION
I added pure Haskell files and hsc2hs and c2hs files, since all of them contain mostly Haskell code.

But should Alex (\*.alex, \*.x) and/or Happy (\*.happy, \*.y, \*.ly) files be included? They always contain at least some user-defined Haskell functions, and it seems that searching for those should be possible with haskell-rgrep, but I'm not entirely sure. Any ideas?