### PR TITLE
Define url and some keywords/tags for haskell-mode

### DIFF
--- a/haskell-mode-pkg.el
+++ b/haskell-mode-pkg.el
@@ -1,5 +1,7 @@
 (define-package "haskell-mode" "13.17-git" "A Haskell editing mode"
-		'((cl-lib "0.5")))
+  '((cl-lib "0.5"))
+  :url "https://github.com/haskell/haskell-mode"
+  :keywords '("haskell" "cabal" "ghc" "repl"))
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:


### PR DESCRIPTION
This way, haskell-mode shows up in `M-x package-list-packages`  when
filtering by the `haskell` tag