### PR TITLE
Add font lock type/data family declarations

### DIFF
--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -485,7 +485,8 @@ It is probably best to manipulate this data structure with the commands
     ("where" . "exp where { decl; ...; decl [;] }") ; check that ; see also class, instance, module
     ("as" . "import [qualified] modid [as modid] [impspec]")
     ("qualified" . "import [qualified] modid [as modid] [impspec]")
-    ("hiding" . "hiding ( import1 , ... , importn [ , ] )"))
+    ("hiding" . "hiding ( import1 , ... , importn [ , ] )")
+    ("family" . "(type family type [kind] [= type_fam_equations]) | (data family type [kind])"))
   "An alist of reserved identifiers.
 Each element is of the form (ID . DOC) where both ID and DOC are strings.
 DOC should be a concise single-line string describing the construct in which

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -284,6 +284,12 @@ Returns keywords suitable for `font-lock-keywords'."
              (2 'haskell-keyword-face nil lax)
              (3 'haskell-keyword-face nil lax))
 
+            ;; Special case for `type family' and `data family'.
+            ;; `family' is only reserved in these contexts.
+            ("\\<\\(type\\|data\\)[ \t]+\\(family\\>\\)"
+             (1 'haskell-keyword-face nil lax)
+             (2 'haskell-keyword-face nil lax))
+
             ;; Toplevel Declarations.
             ;; Place them *before* generic id-and-op highlighting.
             (,topdecl-var  (1 'haskell-definition-face))


### PR DESCRIPTION
This PR rebases https://github.com/haskell/haskell-mode/pull/748 onto today's jmaster and removes the indentation changes, per discussion on that PR.