### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -211,7 +211,7 @@ Return nil if no Cabal description file could be located via
   "Search for package description file upwards starting from DIR.
 If DIR is nil, `default-directory' is used as starting point for
 directory traversal.  Upward traversal is aborted if file owner
-changes.  Uses`haskell-cabal-find-pkg-desc' internally."
+changes.  Uses `haskell-cabal-find-pkg-desc' internally."
   (let ((use-dir (or dir default-directory)))
     (while (and use-dir (not (file-directory-p use-dir)))
       (setq use-dir (file-name-directory (directory-file-name use-dir))))
@@ -373,14 +373,14 @@ OTHER-WINDOW use `find-file-other-window'."
   (goto-char (haskell-cabal-section-end)))
 
 (defun haskell-cabal-next-section ()
-  "Go to the next extion"
+  "Go to the next section"
   (interactive)
   (when (haskell-cabal-section-header-p) (forward-line))
   (while (not (or (eobp) (haskell-cabal-section-header-p)))
     (forward-line)))
 
 (defun haskell-cabal-previous-section ()
-  "Go to the next extion"
+  "Go to the next section"
   (interactive)
   (when (haskell-cabal-section-header-p) (forward-line -1))
   (while (not (or (bobp) (haskell-cabal-section-header-p)))
@@ -471,7 +471,7 @@ OTHER-WINDOW use `find-file-other-window'."
 and execute FORMS
 
 If REPLACE is non-nil the subsection data is replaced with the
-resultung buffer-content"
+resulting buffer-content"
   (let ((section (make-symbol "section"))
         (beg (make-symbol "beg"))
         (end (make-symbol "end"))
@@ -502,7 +502,7 @@ resultung buffer-content"
                  (insert ,section-data))))))))
 
 (defmacro haskell-cabal-each-line (&rest fun)
-  "Execute FOMRS on each line"
+  "Execute FORMS on each line"
   `(save-excursion
      (while (< (point) (point-max))
        ,@fun
@@ -663,7 +663,7 @@ resultung buffer-content"
   (haskell-cabal-forward-to-line-entry))
 
 (defun haskell-cabal-previous-subsection ()
-  "go to the next subsection"
+  "go to the previous subsection"
   (interactive)
   (if (haskell-cabal-header-p) (forward-line -1))
   (while (and (not (bobp))
@@ -674,7 +674,7 @@ resultung buffer-content"
 
 
 (defun haskell-cabal-find-subsection-by (section pred)
-  "Find sunsection with name NAME"
+  "Find subsection with name NAME"
   (save-excursion
     (when section (goto-char (haskell-cabal-section-start section)))
     (let* ((end (if section (haskell-cabal-section-end) (point-max)))
@@ -688,7 +688,7 @@ resultung buffer-content"
       found)))
 
 (defun haskell-cabal-find-subsection (section name)
-  "Find sunsection with name NAME"
+  "Find subsection with name NAME"
   (let ((downcase-name (downcase name)))
     (haskell-cabal-find-subsection-by
      section
@@ -747,7 +747,11 @@ resultung buffer-content"
           (marked-line (goto-char marked-line)))))
 
 (defmacro haskell-cabal-with-subsection-line (replace &rest forms)
-  "Mark line and "
+  "Mark line, copy subsection data into a temporary buffer, save indentation
+and execute FORMS at the marked line.
+
+If REPLACE is non-nil the subsection data is replaced with the
+resulting buffer-content.  Unmark line at the end."
   `(progn
      (haskell-cabal-mark)
      (unwind-protect
@@ -937,7 +941,7 @@ Source names from main-is and c-sources sections are left untouched
                      'haskell-cabal-sort-lines-key-fun)))))))
 
 (defun haskell-cabal-add-build-dependency (dependency &optional sort silent)
-  "Add a build dependencies to sections"
+  "Add the given build dependency to every section"
   (haskell-cabal-map-sections
    (lambda (section)
      (when (haskell-cabal-source-section-p section)

--- a/haskell-checkers.el
+++ b/haskell-checkers.el
@@ -136,7 +136,7 @@
   (concat haskell-scan-command " " haskell-scan-options " \"" file "\""))
 
 (defun haskell-lint-make-command (file)
-  "Generates command line for scan"
+  "Generates command line for lint"
   (concat haskell-lint-command  " \"" file "\"" " " haskell-lint-options))
 
 (defmacro haskell-checkers-setup (type name)

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -164,8 +164,7 @@ MODULE-BUFFER is the actual Emacs buffer of the module being loaded."
   "History list for session targets.")
 
 (defun haskell-process-hayoo-ident (ident)
-  ;; FIXME Obsolete doc string, CALLBACK is not used.
-  "Hayoo for IDENT, return a list of modules asyncronously through CALLBACK."
+  "Hayoo for IDENT, return a list of modules"
   ;; We need a real/simulated closure, because otherwise these
   ;; variables will be unbound when the url-retrieve callback is
   ;; called.
@@ -309,7 +308,6 @@ If PROMPT-VALUE is non-nil, request identifier via mini-buffer."
 
 ;;;###autoload
 (defun haskell-process-do-type (&optional insert-value)
-  ;; FIXME insert value functionallity seems to be missing.
   "Print the type of the given expression.
 
 Given INSERT-VALUE prefix indicates that result type signature

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -72,7 +72,7 @@ Returns t if point is either at whitespace character, or at
 punctuation, or at line end and preceeding character is not a
 whitespace or new line, otherwise returns nil.
 
-  Returns nil in presense of active region."
+  Returns nil in presence of active region."
   (when (not (region-active-p))
     (when (looking-at-p (rx (| space line-end punct)))
       (when (not (bobp))
@@ -84,7 +84,7 @@ whitespace or new line, otherwise returns nil.
   "Grab completion prefix for pragma completions.
 Returns a list of form '(prefix-start-position
 prefix-end-position prefix-value prefix-type) for pramga names
-such as WARNING, DEPRECATED, LANGUAGE and etc.  Also returns
+such as WARNING, DEPRECATED, LANGUAGE etc.  Also returns
 completion prefixes for options in case OPTIONS_GHC pragma, or
 language extensions in case of LANGUAGE pragma.  Obsolete OPTIONS
 pragma is supported also."
@@ -206,7 +206,7 @@ identifier at point depending on result of function
 Returns a list of form '(prefix-start-position
 prefix-end-position prefix-value prefix-type) depending on
 situation, e.g. is it needed to complete pragma, module name,
-arbitrary identifier, and etc.  Rerurns nil in case it is
+arbitrary identifier, etc. Returns nil in case it is
 impossible to grab prefix.
 
 If provided optional MINLEN parameter this function will return
@@ -252,7 +252,7 @@ Returns nil if no completions available."
             (list beg end lst)))))))
 
 (defun haskell-completions-sync-complete-repl (prefix &optional import)
-  "Return completion list for given PREFIX quering REPL synchronously.
+  "Return completion list for given PREFIX querying REPL synchronously.
 When optional IMPORT argument is non-nil complete PREFIX
 prepending \"import \" keyword (useful for module names).  This
 function is supposed for internal use."

--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -344,14 +344,15 @@ declaration by this function.  So, if point is within a top-level
 declaration then move it to the start of that declaration.  If point
 is already at the start of a top-level declaration, then move it to
 the start of the preceding declaration.  Returns point if point is
-left at the start of a declaration, and nil otherwise, ie. because
+left at the start of a declaration, and nil otherwise, because
 point is at the beginning of the buffer and no declaration starts
 there."
   (interactive)
   (haskell-ds-move-to-decl nil (haskell-ds-bird-p) nil))
 
 (defun haskell-ds-forward-decl ()
-  "As `haskell-ds-backward-decl' but forward."
+  "Move forward to the first character that starts a top-level
+declaration.  As `haskell-ds-backward-decl' but forward."
   (interactive)
   (haskell-ds-move-to-decl t (haskell-ds-bird-p) nil))
 

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -417,7 +417,7 @@ last input, no documentation will be printed.
 If this variable is set to 0, no idle time is required.")
 
 (defvar haskell-doc-argument-case 'identity ; 'upcase
-  "Case to display argument names of functions, as a symbol.
+  "Case in which to display argument names of functions, as a symbol.
 This has two preferred values: `upcase' or `downcase'.
 Actually, any name of a function which takes a string as an argument and
 returns another string is acceptable.")

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -182,6 +182,7 @@ its own, nor does it contain \">\" at the start of a line -- the value
 of `haskell-literate-default' is used.")
 (make-variable-buffer-local 'haskell-literate)
 (put 'haskell-literate 'safe-local-variable 'symbolp)
+
 ;; Default literate style for ambiguous literate buffers.
 (defcustom haskell-literate-default 'bird
   "Default value for `haskell-literate'.
@@ -577,7 +578,7 @@ May return a qualified name."
 (define-derived-mode haskell-mode haskell-parent-mode "Haskell"
   "Major mode for editing Haskell programs.
 
-For more information aee also Info node `(haskell-mode)Getting Started'.
+For more information see also Info node `(haskell-mode)Getting Started'.
 
 \\<haskell-mode-map>
 
@@ -621,17 +622,11 @@ example, `M-x haskell-doc-mode'. Run it again to disable it.
 To enable a mode for every haskell-mode buffer, add a hook in
 your Emacs configuration. To do that you can customize
 `haskell-mode-hook' or add lines to your .emacs file. For
-example, to enable `haskell-indent-mode' and
-`interactive-haskell-mode', use the following:
+example, to enable `interactive-haskell-mode', use the following:
 
-    (add-hook 'haskell-mode-hook 'haskell-indentation-mode)
     (add-hook 'haskell-mode-hook 'interactive-haskell-mode)
 
 For more details see Info node `(haskell-mode)haskell-mode-hook'.
-
-Warning: do not enable more than one of the above indentation
-modes. See Info node `(haskell-mode)indentation' for more
-details.
 
 Minor modes that work well with `haskell-mode':
 

--- a/haskell-navigate-imports.el
+++ b/haskell-navigate-imports.el
@@ -52,7 +52,7 @@
 
 ;;;###autoload
 (defun haskell-navigate-imports-go ()
-  "Go to the first line of a list of consequtive import lines. Cycles."
+  "Go to the first line of a list of consecutive import lines. Cycles."
   (interactive)
   (unless (or (haskell-navigate-imports-line)
               (equal (line-beginning-position) (point-min))
@@ -70,7 +70,7 @@
     (goto-char haskell-navigate-imports-start-point)))
 
 (defun haskell-navigate-imports-go-internal ()
-  "Go to the first line of a list of consequtive import lines. Cycle."
+  "Go to the first line of a list of consecutive import lines. Cycle."
   (if (haskell-navigate-imports-line)
       (progn (haskell-navigate-imports-goto-end)
              (when (haskell-navigate-imports-find-forward-line)
@@ -85,7 +85,7 @@
                    (search-forward "\n\n" nil t 1))))))))
 
 (defun haskell-navigate-imports-goto-end ()
-  "Skip a bunch of consequtive import lines."
+  "Skip a bunch of consecutive import lines."
   (while (not (or (equal (point)
                          (point-max))
                   (not (haskell-navigate-imports-line))))

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -356,7 +356,7 @@ re-asking about the same imports."
   (haskell-process-set p 'evaluating v))
 
 (defun haskell-process-evaluating-p (p)
-  "Set status of evaluating to be on/off."
+  "Get status of evaluating (on/off)."
   (haskell-process-get p 'evaluating))
 
 (defun haskell-process-set-process (p v)

--- a/haskell-sandbox.el
+++ b/haskell-sandbox.el
@@ -21,7 +21,7 @@
 (require 'haskell-session)
 
 (defun haskell-sandbox-path (session)
-  "Is there a cabal sandbox?"
+  "If there is a haskell-session, return the path to the usual sandbox location."
   (concat (haskell-session-cabal-dir session)
           "/.cabal-sandbox"))
 

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -88,8 +88,8 @@
 
 (defun haskell-session-assign (session)
   "Assing current buffer to SESSION.
-More verbose doc string for `haskell-session-assign`
-This could be helpfull for temporal or auxilar buffers such as
+
+This could be helpful for temporary or auxiliary buffers such as
 presentation mode buffers (e.g. in case when session is killed
 with all relevant buffers)."
   (set (make-local-variable 'haskell-session) session))

--- a/haskell-string.el
+++ b/haskell-string.el
@@ -58,7 +58,7 @@ Note: The implementation currently only supports ASCII
 (defun haskell-string-literal-encode (str &optional no-quotes)
   "Encode STR according Haskell escape rules using 7-bit ASCII representation.
 
-The serialization has been implement to closely match the
+The serialization has been implemented to closely match the
 behaviour of GHC's Show instance for Strings.
 
 If NO-QUOTES is non-nil, omit wrapping result in quotes.

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -79,7 +79,7 @@ This hook pushes value of variable `this-command' to flag variable
 (defun haskell-utils-async-watch-changes ()
   "Watch for triggered commands during async operation execution.
 Resets flag variable
-`haskell-utils-async-update-post-command-flag' to NIL.  By chanhges it is
+`haskell-utils-async-update-post-command-flag' to NIL.  By changes it is
 assumed that nothing happened, e.g. nothing was inserted in
 buffer, point was not moved, etc.  To collect data `post-command-hook' is used."
   (setq haskell-utils-async-post-command-flag nil)
@@ -99,18 +99,18 @@ execusion."
      'post-command-hook #'haskell-utils-async-update-post-command-flag t)))
 
 (defun haskell-utils-reduce-string (s)
-  "Remove newlines ans extra whitespace from S.
+  "Remove newlines and extra whitespace from S.
 Removes all extra whitespace at the beginning of each line leaving
-only single one.  Then removes all newlines."
+only a single space.  Then removes all newlines."
   (let ((s_ (replace-regexp-in-string "^\s+" " " s)))
     (replace-regexp-in-string "\n" "" s_)))
 
 (defun haskell-utils-parse-repl-response (r)
   "Parse response R from REPL and return special kind of result.
-The result is response string itself with speacial property
+The result is the response string itself with the special property
 response-type added.
 
-This property could be of the following:
+This property could be one of the following:
 
 + unknown-command
 + option-missing

--- a/w3m-haddock.el
+++ b/w3m-haddock.el
@@ -123,7 +123,7 @@ You can rebind this if you're using hsenv by adding it to your
         (search-forward ident)))))
 
 (defun w3m-haddock-display (_url)
-  "To be ran by w3m's display hook. This takes a normal w3m
+  "To be run by w3m's display hook. This takes a normal w3m
   buffer containing hadddock documentation and reformats it to be
   more usable and look like a dedicated documentation page."
   (when (w3m-haddock-page-p)


### PR DESCRIPTION
In a couple of places I fixed obviously outdated docstrings, as well.