### PR TITLE
Add keybinding for `haskell-cabal-visit-file`

### DIFF
--- a/doc/haskell-mode.texi
+++ b/doc/haskell-mode.texi
@@ -760,13 +760,8 @@ having a @file{.cabal} extension.
 For quickly locating and jumping to the nearest @file{.cabal} file from
 a Haskell source buffer, you can use @kbd{M-x haskell-cabal-visit-file};
 with a prefix argument (i.e. @kbd{C-u}) @code{find-file-other-window} is
-used to visit the @file{.cabal} file.  If you wish, you can bind
-@code{haskell-cabal-visit-file} to a convenient key sequence, e.g.
-
-@lisp
-(eval-after-load "haskell-mode"
-  '(define-key haskell-mode-map (kbd "C-c v c") 'haskell-cabal-visit-file))
-@end lisp
+used to visit the @file{.cabal} file.
+@code{haskell-cabal-visit-file} is bound to the key sequence @kbd{C-c v c}.
 
 TODO/WRITEME
 

--- a/haskell.el
+++ b/haskell.el
@@ -48,6 +48,7 @@
     (define-key map (kbd "M-.") 'haskell-mode-jump-to-def-or-tag)
     (define-key map (kbd "C-c C-k") 'haskell-interactive-mode-clear)
     (define-key map (kbd "C-c C-c") 'haskell-process-cabal-build)
+    (define-key map (kbd "C-c v c") 'haskell-cabal-visit-file)
     (define-key map (kbd "C-c C-x") 'haskell-process-cabal)
     (define-key map [?\C-c ?\C-b] 'haskell-interactive-switch)
     (define-key map [?\C-c ?\C-z] 'haskell-interactive-switch)


### PR DESCRIPTION
Instead of recommending this binding in the manual, provide it by
default, and document that it the manual.

This follows my understanding of https://github.com/haskell/haskell-mode/wiki/Complete-functionality

What's the recommended way to test functions that inspect the filesystem?  `el-mock`?  Some other mocking library?