### PR TITLE
Add test for 'type role' font-lock

### DIFF
--- a/tests/haskell-font-lock-tests.el
+++ b/tests/haskell-font-lock-tests.el
@@ -554,3 +554,11 @@ if all of its characters have syntax and face. See
      ("code3" t haskell-definition-face)
      ("Comment3" t haskell-literate-comment-face))
    'literate))
+
+(ert-deftest haskell-type-role ()
+  "fontify \"role\" after \"type\""
+  (check-properties
+    '("type role Ptr representational")
+    '(("type" "w" haskell-keyword-face)
+      ("role" "w" haskell-keyword-face)
+      ("Ptr" "w" haskell-constructor-face))))


### PR DESCRIPTION
Tests #1066 which fixes #1057. The test succeeds.

I tried to follow the conventions that I could find, but if you want me to move the test up in the file, rename it, or make any other change, let me know.