### PR TITLE
Define haskell-package struct's slots

### DIFF
--- a/haskell-package.el
+++ b/haskell-package.el
@@ -55,7 +55,14 @@
             name
             version))))
 
-(cl-defstruct haskell-package "Haskell package object.")
+;; Haskell package object
+(cl-defstruct haskell-package
+  name version id license copyright maintainer stability homepage
+  package-url description categories authors is-exposed
+  exposed-modules hidden-modules imports-dirs library-dirs
+  haskell-libraries extra-libraries extra-ghci-libraries include-dirs
+  includes depends hugs-options cc-options ld-options framework-dirs
+  frameworks haddock-interfaces haddock-html)
 
 (defun haskell-package-parse (text)
   "Parse a package into a package object."


### PR DESCRIPTION
`haskell-package`'s slots were not defined, and that was creating a
byte-compiler warning that the lexical variable `pkg` was unused.

I made this commit just to shut up the byte-compiler (honestly, I just started using this mode). 

As an aside, am I missing something, or is the struct not actually used? The `haskell-package-get*` functions use `haskell-package-parse` to create the struct, but nothing seems to actually use the result (I'm not sure how something could without the slots defined).