### PR TITLE
Cleanup haskell-compat.el

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,11 +109,12 @@ check-%: tests/%-tests.el
 	$(BATCH) -l "$<" -f ert-run-tests-batch-and-exit;
 
 check: $(ELCHECKS) build-$(EMACS_VERSION)
-	$(BATCH) --eval "(when (>= emacs-major-version 24)                             \
-                           (require 'undercover)                                      \
-                           (undercover \"*.el\" (:exclude \"haskell-mode-pkg.el\")))" \
-                 -L tests                                                             \
-                 $(patsubst %,-l %,$(ELCHECKS))                                       \
+	$(BATCH) --eval "(when (>= emacs-major-version 24)					\
+                           (require 'undercover)						\
+                           (undercover \"*.el\"							\
+                              (:exclude \"haskell-mode-pkg.el\" \"haskell-compat.el\")))"	\
+                 -L tests									\
+                 $(patsubst %,-l %,$(ELCHECKS))							\
                  -f ert-run-tests-batch-and-exit
 	@TAB=$$(echo "\t"); \
 	if grep -Hn "[ $${TAB}]\+\$$" *.el; then \

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -355,7 +355,9 @@ position with `xref-pop-marker-stack'."
         (haskell-mode-handle-generic-loc loc)
       (call-interactively 'haskell-mode-tag-find))
     (unless (equal initial-loc (point-marker))
-      (xref-push-marker-stack initial-loc))))
+      (save-excursion
+        (goto-char initial-loc)
+        (xref-push-marker-stack)))))
 
 ;;;###autoload
 (defun haskell-mode-goto-loc ()

--- a/haskell-compat.el
+++ b/haskell-compat.el
@@ -29,23 +29,15 @@
 (eval-when-compile
   (setq byte-compile-warnings '(not cl-functions obsolete)))
 
-;; Missing in Emacs23, stolen from Emacs24's `subr.el'
-(unless (fboundp 'process-live-p)
-  (defun process-live-p (process)
-    "Returns non-nil if PROCESS is alive.
-A process is considered alive if its status is `run', `open',
-`listen', `connect' or `stop'."
-    (memq (process-status process)
-	  '(run open listen connect stop))))
 
 ;; Cross-referencing commands have been replaced since Emacs 25.1.
 ;; These aliases are required to provide backward compatibility.
 (unless (fboundp 'xref-push-marker-stack)
   (defalias 'xref-pop-marker-stack 'pop-tag-mark)
 
-  (defun xref-push-marker-stack (&optional m)
+  (defun xref-push-marker-stack ()
     "Add point to the marker stack."
-    (ring-insert find-tag-marker-ring (or m (point-marker)))))
+    (ring-insert find-tag-marker-ring (point-marker))))
 
 (unless (fboundp 'outline-hide-sublevels)
   (defalias 'outline-hide-sublevels 'hide-sublevels))


### PR DESCRIPTION
After removing support for Emacs 23 haskell-compat.el can loose some
weight.