### PR TITLE
Remove suggested imports completely

### DIFF
--- a/tests/interactive-haskell-mode-tests.el
+++ b/tests/interactive-haskell-mode-tests.el
@@ -32,20 +32,21 @@
 (require 'ert)
 (require 'haskell-interactive-mode)
 
-(defun should-match (str)
-  (should (eq 0 (string-match-p haskell-interactive-mode-error-regexp str))))
-
 (ert-deftest haskell-interactive-error-regexp-test ()
   "Tests the regexp `haskell-interactive-mode-error-regexp'"
   (should (eq 0 (string-match-p haskell-interactive-mode-error-regexp
                                 "/home/user/Test.hs:24:30:")))
   (should (eq 0 (string-match-p haskell-interactive-mode-error-regexp
                                 "Test.hs:5:18:")))
-  (should (eq 0 (string-match-p haskell-interactive-mode-error-regexp
-                                "Test.hs:7:6: Not in scope: type constructor or class ‘Ty’")))
+  (should (eq 0 (string-match-p
+                 haskell-interactive-mode-error-regexp
+                 "Test.hs:7:6: Not in scope: type constructor or class ‘Ty’")))
   (should (eq 0 (string-match-p haskell-interactive-mode-error-regexp
                                 "Test.hs:9:5: Not in scope: ‘c’")))
   (should (eq nil (string-match-p haskell-interactive-mode-error-regexp
                                   ;; leading space
                                   " Test.hs:8:9:")))
   )
+
+(provide 'interactive-haskell-mode-tests)
+;;; interactive-haskell-mode-tests.el ends here


### PR DESCRIPTION
Do not leave blank line when removing import statement.

Now covers multiline imports properly when remove or comment out option
selected.

Will think about some test, don't merge yet.

Fixes #1109 