### PR TITLE
Add indentation tests for constructor and deriving

### DIFF
--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -896,13 +896,13 @@ foo x
               (2 2)
               (3 2))
 
-(hindent-test "55 data constructor on separate line" "
+(hindent-test "55* data constructor on separate line" "
 data Foo = Bar
          | Baz"
               (1 0)
               (2 9))
 
-(hindent-test "55a deriving below aligned data constructors" "
+(hindent-test "55a* deriving below aligned data constructors" "
 data Foo = Bar
          | Baz
          deriving (Show)"

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -896,6 +896,19 @@ foo x
               (2 2)
               (3 2))
 
+(hindent-test "55 data constructor on separate line" "
+data Foo = Bar
+         | Baz"
+              (1 0)
+              (2 9))
+
+(hindent-test "55a deriving below aligned data constructors" "
+data Foo = Bar
+         | Baz
+         deriving (Show)"
+              (1 0)
+              (2 9)
+              (3 9))
 
 (ert-deftest haskell-indentation-ret-indents ()
   (with-temp-switch-to-buffer


### PR DESCRIPTION
This adds two tests for indenting simple data type definitions.  I didn't entirely understand the numbering scheme, so I just made an educated guess and added them at the end.  If that's wrong, let me know and I can fix it.

See #1125 for a brief explanation.