### PR TITLE
Use `haskell-interactive-switch` in process-load

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -519,7 +519,7 @@ FILE-NAME only."
         (with-current-buffer buffer
           (haskell-interactive-mode)
           (haskell-session-assign s))
-        (switch-to-buffer-other-window buffer)
+        (haskell-interactive-switch)
         buffer))))
 
 (defun haskell-process-cabal-live (state buffer)


### PR DESCRIPTION
This sets a variable with the source buffer so we can switch back.

This is pretty bizzare, though.  Both before and after this commit,
`haskell-session-interactive-buffer` switches to the buffer if it's
newly created, but if the buffer already exists, just returns the buffer
without visiting.  This function shouldn't switch, and callers
should decide if they want to switch.

closes #955