### PR TITLE
Fix #1146 by treating . as punctuation

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -80,7 +80,6 @@
     ;; We could use font-lock-syntactic-keywords, but is it worth it?
     ;; (modify-syntax-entry ?-  ". 12" st)
     (modify-syntax-entry ?\n ">" st)
-    (modify-syntax-entry ?. "w"  st)
     (modify-syntax-entry ?- "w"  st)
     st))
 

--- a/tests/haskell-cabal-tests.el
+++ b/tests/haskell-cabal-tests.el
@@ -50,6 +50,24 @@
       (haskell-cabal-previous-subsection)
       (haskell-cabal-previous-section))))
 
+(ert-deftest haskell-cabal-period-is-a-word-break ()
+  (with-temp-buffer
+    (insert "Executable bin
+    Main-Is:           Main
+    Exposed-Modules:   Some.Internal.Type
+")
+    (haskell-cabal-mode)
+    (goto-char (point-min))
+    (search-forward "Modules:")
+    (skip-chars-forward " ")
+    (should (looking-at-p "Some"))
+    (forward-word)
+    (should (looking-at-p ".Internal"))
+    (forward-word)
+    (should (looking-at-p ".Type"))
+    (backward-word)
+    (should (looking-at-p "Internal"))))
+
 (ert-deftest haskell-cabal-subsection-arrange-lines-keep-trailing-commas ()
   (should (with-temp-buffer
             (insert "Executable bin-1


### PR DESCRIPTION
In `haskell-cabal-mode` with the point indicated with the vertical bar below, `forward-char` should leave the point after `Some` instead of after `Type`.
```haskell
Exposed-Modules:   |Some.Internal.Type
```

This was caused by the following line:
```emacs-lisp
(modify-syntax-entry ?. "w"  st)
```

Which makes "." a word constituent instead of a punctuation character. This was added in aa970092a1e812ff78af2c1d65484b4281ce2234, "merge caballero with haskell-cabal". The fix: remove the line above.