### PR TITLE
Implement backward case in haskell-forward-sexp

### DIFF
--- a/tests/haskell-mode-tests.el
+++ b/tests/haskell-mode-tests.el
@@ -464,4 +464,25 @@ of sexp."
             (haskell-forward-sexp 1)
             (eq (point) 6))))
 
+(ert-deftest backward-sexp ()
+  "Check if `forward-sexp-function' behaves properly on
+beginning of sexp."
+  (should (with-temp-buffer
+            (haskell-mode)
+            (insert "(foo) bar")
+            (goto-char 2)
+            (condition-case err
+                (progn (backward-sexp)
+                       nil)
+              (scan-error (equal (cddr err) (list 1 1)))))))
+
+(ert-deftest haskell-backward-sexp ()
+  "Check if `haskell-forward-sexp' with negatives arg properly
+moves over sexps."
+  (should (with-temp-buffer
+            (insert "a (b c) = d . e")
+            (goto-char 15)
+            (haskell-forward-sexp -4)
+            (eq (point) 3))))
+
 (provide 'haskell-mode-tests)


### PR DESCRIPTION
I implemented the backward case, basically according to your hints in #759. The main difference is that I do not skip back to whitespace, but use plain `backward-sexp`, which also properly skips over parens.