### PR TITLE
Fix haskell-hoogle to work with buffer local var

### DIFF
--- a/haskell-hoogle.el
+++ b/haskell-hoogle.el
@@ -65,13 +65,13 @@ is asked to show extra info for the items matching QUERY.."
            current-prefix-arg)))
   (if (null haskell-hoogle-command)
       (browse-url (format haskell-hoogle-url (url-hexify-string query)))
-    (with-help-window "*hoogle*"
-      (with-current-buffer standard-output
-        (insert (shell-command-to-string
-                 (concat haskell-hoogle-command
-                         (if info " -i " "")
-                         " --color " (shell-quote-argument query))))
-        (ansi-color-apply-on-region (point-min) (point-max))))))
+    (let ((command (concat haskell-hoogle-command
+                           (if info " -i " "")
+                           " --color " (shell-quote-argument query))))
+      (with-help-window "*hoogle*"
+        (with-current-buffer standard-output
+          (insert (shell-command-to-string command))
+          (ansi-color-apply-on-region (point-min) (point-max)))))))
 
 ;;;###autoload
 (defalias 'hoogle 'haskell-hoogle)


### PR DESCRIPTION
Read the `haskell-hoogle-command` variable before switching to the help window which removes the buffer local `haskell-hoogle-command` from the scope.

In other words: This is a tiny change, I just extracted the command text into a variable defined outside the context of the new buffer so that the right buffer local `haskell-hoogle-command` is used.