### PR TITLE
[WIP] Use single session per stack project

### DIFF
--- a/haskell-session.el
+++ b/haskell-session.el
@@ -80,11 +80,13 @@
 
 (defun haskell-session-default-name ()
   "Generate a default project name for the new project prompt."
-  (let ((file (haskell-cabal-find-file)))
-    (or (when file
-          (downcase (file-name-sans-extension
-                     (file-name-nondirectory file))))
-        "haskell")))
+  (if (eq 'stack-ghci (haskell-process-type))
+      (locate-dominating-file default-directory "stack.yaml")
+    (let ((file (haskell-cabal-find-file)))
+      (or (when file
+            (downcase (file-name-sans-extension
+                       (file-name-nondirectory file))))
+          "haskell"))))
 
 (defun haskell-session-assign (session)
   "Assing current buffer to SESSION.


### PR DESCRIPTION
I have a stack project with a few local packages that I work on together.  I found that haskell-mode would create a `stack ghci` process/buffer for each project, and each one would load all the projects, as stack ghci does.

This change defaults each module under the stack project to the same ghci instance.

What do you think?  I haven't had any problems with it, and it saves a ton of memory for ghci processes, as well as simplifying work on multiple packages.

WIP because the buffer name is inconsistent with cabal, but using the package name on its own seems kind of fragile too...  Maybe it should be the full path to the stack.yaml / .cabal with some sort of prefix?

TODO: share the file logic with (haskell-process-type)