### PR TITLE
Treat insides of quasiquotes as strings

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -587,7 +587,13 @@ executable found in PATH.")
                 (put-text-property (match-beginning 3) (1+ (match-end 3)) 'syntax-table (string-to-syntax "|")))))
            ((equal token-kind 'template-haskell-quasi-quote)
             (put-text-property (match-beginning 2) (match-end 2) 'syntax-table (string-to-syntax "\""))
-            (put-text-property (match-beginning 4) (match-end 4) 'syntax-table (string-to-syntax "\""))))
+            (put-text-property (match-beginning 4) (match-end 4) 'syntax-table (string-to-syntax "\""))
+            (save-excursion
+              (goto-char (match-beginning 3))
+              (let ((limit (match-end 3)))
+                (save-match-data
+                  (while (re-search-forward "\"" limit t)
+                    (put-text-property (match-beginning 0) (match-end 0) 'syntax-table (string-to-syntax "."))))))))
           (if token-kind
               (goto-char (match-end 0))
             (goto-char end)))))))

--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -656,12 +656,22 @@ test = [randomQQ| This is
 "
               (4 0 2))
 
-(hindent-test "29c* quasiquote with quotes in it and a string outside" "
+(hindent-test "29c quasiquote with quotes in it and a string outside" "
 foo = do
   let bar = [text|\"some text\"|]
   button \"Cancel\" $ do
 "
               (4 4))
+
+(hindent-test "29d unfinished quasiquote" "
+foo = [text|some
+"
+              (2 0 11))
+
+(hindent-test "29e an expression quotation" "
+foo = [|forever $ do
+"
+              (2 10))
 
 (hindent-test "30* parse '[] identifier correctly" "
 instance Callable '[]


### PR DESCRIPTION
See #1189. Since the insides of quasiquotes are regarded as ordinary characters now, `\s"` no longer stumbles on `"`s inside quasiquotes.