### PR TITLE
Change a couple hook properties

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -104,7 +104,7 @@ when showing type information about symbols."
   :type 'boolean
   :safe 'booleanp)
 
-(defvar haskell-process-end-hook nil
+(defvar haskell-process-ended-functions (list 'haskell-process-prompt-restart)
   "Hook for when the haskell process ends.")
 
 ;;;###autoload

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -95,10 +95,10 @@ Key bindings:
   (setq haskell-interactive-mode-history (list))
   (setq haskell-interactive-mode-history-index 0)
 
-  (setq next-error-function 'haskell-interactive-next-error-function)
+  (setq next-error-function #'haskell-interactive-next-error-function)
   (add-hook 'completion-at-point-functions
-            'haskell-interactive-mode-completion-at-point-function nil t)
-
+            #'haskell-interactive-mode-completion-at-point-function nil t)
+  (add-hook 'kill-buffer-hook #'haskell-interactive-kill nil t)
   (haskell-interactive-mode-prompt))
 
 (defvar haskell-interactive-mode-prompt-start

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -138,7 +138,7 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
           (haskell-process-log
            (propertize "Process reset.\n"
                        'face font-lock-comment-face))
-          (run-hook-with-args 'haskell-process-ended-hook process))))))
+          (run-hook-with-args 'haskell-process-ended-functions process))))))
 
 (defun haskell-process-filter (proc response)
   "The filter for the process pipe."
@@ -233,7 +233,7 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
                        'face '((:weight bold))))
           (process-send-string child out))
       (unless (haskell-process-restarting process)
-        (run-hook-with-args 'haskell-process-ended process)))))
+        (run-hook-with-args 'haskell-process-ended-functions process)))))
 
 (defun haskell-process-live-updates (process)
   "Process live updates."
@@ -271,7 +271,7 @@ the response."
             (haskell-command-exec-go cmd))))
     (progn (haskell-process-reset process)
            (haskell-process-set process 'command-queue nil)
-           (run-hook-with-args 'haskell-process-ended process))))
+           (run-hook-with-args 'haskell-process-ended-functions process))))
 
 (defun haskell-process-queue-flushed-p (process)
   "Return t if command queue has been completely processed."

--- a/haskell.el
+++ b/haskell.el
@@ -36,12 +36,6 @@
 (require 'haskell-utils)
 (require 'haskell-customize)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Basic configuration hooks
-
-(add-hook 'haskell-process-ended-hook 'haskell-process-prompt-restart)
-(add-hook 'kill-buffer-hook 'haskell-interactive-kill)
-
 (defvar interactive-haskell-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-l") 'haskell-process-load-file)


### PR DESCRIPTION
1) `haskell-interactive-kill` was added to the global hook instead of
the local hook.

2) Typo: `haskell-process-end-hook` was used instead of
`haskell-process-ended-hook`

3) Rename `haskell-process-ended-hook` to
`haskell-process-ended-functions` as per
https://www.gnu.org/software/emacs/manual/html_node/emacs/Hooks.html