### PR TITLE
Small improvements of completion functions

### DIFF
--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -286,17 +286,18 @@ GHC's options, and language extensions.
 PREFIX should be a list such one returned by
 `haskell-completions-grab-identifier-prefix'."
   (cl-destructuring-bind (beg end _pfx typ) prefix
-    (let ((candidates
-           (cl-case typ
-             ('haskell-completions-pragma-name-prefix
-              haskell-completions--pragma-names)
-             ('haskell-completions-ghc-option-prefix
-              haskell-ghc-supported-options)
-             ('haskell-completions-language-extension-prefix
-              haskell-ghc-supported-extensions)
-             (otherwise
-              haskell-completions--keywords))))
-      (list beg end candidates))))
+    (when (not (eql typ 'haskell-completions-general-prefix))
+      (let ((candidates
+             (cl-case typ
+               ('haskell-completions-pragma-name-prefix
+                haskell-completions--pragma-names)
+               ('haskell-completions-ghc-option-prefix
+                haskell-ghc-supported-options)
+               ('haskell-completions-language-extension-prefix
+                haskell-ghc-supported-extensions)
+               (otherwise
+                haskell-completions--keywords))))
+        (list beg end candidates)))))
 
 
 (defun haskell-completions-completion-at-point ()

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -305,7 +305,8 @@ This function is used in non-interactive `haskell-mode'.  It
 provides completions for haskell keywords, language pragmas,
 GHC's options, and language extensions, but not identifiers."
   (let ((prefix (haskell-completions-grab-prefix)))
-    (haskell-completions--simple-completions prefix)))
+    (when prefix
+      (haskell-completions--simple-completions prefix))))
 
 (defun haskell-completions-sync-repl-completion-at-point ()
   "A completion function used in `interactive-haskell-mode'.

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -338,7 +338,11 @@ Returns nil if no completions available."
                    (candidates
                     (when (and (haskell-session-maybe)
                                (not (haskell-process-cmd
-                                     (haskell-interactive-process))))
+                                     (haskell-interactive-process)))
+                               ;; few possible extra checks would be:
+                               ;; (haskell-process-get 'is-restarting)
+                               ;; (haskell-process-get 'evaluating)
+                               )
                       ;; if REPL is available and not busy try to query it for
                       ;; completions list in case of module name or identifier
                       ;; prefixes

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -311,16 +311,20 @@ Returns NIL when no completions found."
     (if (eq 'unknown-command response-status)
         (error
          "GHCi lacks `:complete' support (try installing GHC 7.8+ or ghci-ng)")
-      (let* ((s1 (split-string rawstr "\r?\n" t))
-             (cs (mapcar #'haskell-string-literal-decode (cdr s1)))
-             (h0 (car s1))) ;; "<limit count> <all count> <unused string>"
-        (unless (string-match "\\`\\([0-9]+\\) \\([0-9]+\\) \\(\".*\"\\)\\'" h0)
-          (error "Invalid `:complete' response"))
-        (let ((cnt1 (match-string 1 h0))
-              (h1 (haskell-string-literal-decode (match-string 3 h0))))
-          (unless (= (string-to-number cnt1) (length cs))
-            (error "Lengths inconsistent in `:complete' reponse"))
-          (cons h1 cs))))))
+      (when rawstr
+        ;; parse REPL response if any
+        (let* ((s1 (split-string rawstr "\r?\n" t))
+               (cs (mapcar #'haskell-string-literal-decode (cdr s1)))
+               (h0 (car s1))) ;; "<limit count> <all count> <unused string>"
+          (unless (string-match
+                   "\\`\\([0-9]+\\) \\([0-9]+\\) \\(\".*\"\\)\\'"
+                   h0)
+            (error "Invalid `:complete' response"))
+          (let ((cnt1 (match-string 1 h0))
+                (h1 (haskell-string-literal-decode (match-string 3 h0))))
+            (unless (= (string-to-number cnt1) (length cs))
+              (error "Lengths inconsistent in `:complete' reponse"))
+            (cons h1 cs)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Accessing the process

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -296,7 +296,7 @@ This uses `accept-process-output' internally."
     (car-safe (haskell-command-state cmd))))
 
 (defun haskell-process-get-repl-completions (process inputstr &optional limit)
-  "Perform `:complete repl ...' query for INPUTSTR using PROCESS.
+  "Query PROCESS with `:complete repl ...' for INPUTSTR.
 Give optional LIMIT arg to limit completion candidates count,
 zero, negative values, and nil means all possible completions.
 Returns NIL when no completions found."

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -127,18 +127,21 @@ Returns one of the following symbols:
   (:type-at and maybe some other commands error)
 * *all other reposnses* are treated as success reposneses and
   'no-error is returned."
-  (let ((first-line (car (split-string response "\n" t))))
-    (cond
-     ((null first-line) 'no-error)
-     ((string-match-p "^unknown command" first-line)
-      'unknown-command)
-     ((string-match-p
-       "^Couldn't guess that module name. Does it exist?"
-       first-line)
-      'option-missing)
-     ((string-match-p "^<interactive>:" first-line)
-      'interactive-error)
-     (t 'no-error))))
+  (if response
+      (let ((first-line (car (split-string response "\n" t))))
+        (cond
+         ((null first-line) 'no-error)
+         ((string-match-p "^unknown command" first-line)
+          'unknown-command)
+         ((string-match-p
+           "^Couldn't guess that module name. Does it exist?"
+           first-line)
+          'option-missing)
+         ((string-match-p "^<interactive>:" first-line)
+          'interactive-error)
+         (t 'no-error)))
+    ;; in case of nil-ish reponse it's not clear is it error response or not
+    'no-error))
 
 (defun haskell-utils-compose-type-at-command (pos)
   "Prepare :type-at command to be send to haskell process.


### PR DESCRIPTION
As a user of company mode I see errors in mini-buffer very often:

> Company: An error occurred in auto-begin
> Wrong type argument: stringp, nil

Small investigation lead me to proposed changes