### PR TITLE
Move haskell-interactive-prompt-state related definitions to haskell-utils.el

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -51,7 +51,6 @@
 
 (require 'cl-lib)
 (require 'haskell-utils)
-(require 'haskell-mode)
 
 (defconst haskell-cabal-general-fields
   ;; Extracted with (haskell-cabal-extract-fields-from-doc "general-fields")

--- a/haskell-debug.el
+++ b/haskell-debug.el
@@ -23,6 +23,7 @@
 (require 'haskell-process)
 (require 'haskell-interactive-mode)
 (require 'haskell-font-lock)
+(require 'haskell-utils)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Configuration

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -305,6 +305,7 @@
 (require 'haskell-mode)
 (require 'haskell-process)
 (require 'haskell)
+(require 'haskell-utils)
 (require 'inf-haskell)
 (require 'imenu)
 (require 'eldoc)

--- a/haskell-hoogle.el
+++ b/haskell-hoogle.el
@@ -28,6 +28,7 @@
 
 (require 'ansi-color)
 (require 'haskell-mode)
+(require 'haskell-utils)
 
 
 (defcustom haskell-hoogle-command

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -36,6 +36,7 @@
 (require 'haskell-session)
 (require 'haskell-font-lock)
 (require 'haskell-presentation-mode)
+(require 'haskell-utils)
 
 (require 'ansi-color)
 (require 'cl-lib)

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -26,6 +26,7 @@
 (require 'haskell-modules)
 (require 'haskell-commands)
 (require 'haskell-session)
+(require 'haskell-utils)
 
 (defun haskell-process-look-config-changes (session)
   "Check whether a cabal configuration file has changed.

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -663,10 +663,6 @@ May return a qualified name."
 
 (defvar eldoc-print-current-symbol-info-function)
 
-(defvar haskell-mode-interactive-prompt-state nil
-  "Special variable indicating a state of user input waiting.")
-
-
 ;; The main mode functions
 ;;;###autoload
 (define-derived-mode haskell-mode prog-mode "Haskell"
@@ -1072,12 +1068,6 @@ successful, nil otherwise."
     (insert (format haskell-auto-insert-module-format-string (haskell-guess-module-name)))
     (goto-char (point-min))
     (end-of-line)))
-
-(defun haskell-mode-toggle-interactive-prompt-state (&optional disabled)
-  "Set `haskell-mode-interactive-prompt-state' to t.
-If given DISABLED argument sets variable value to nil, otherwise to t."
-  (setq haskell-mode-interactive-prompt-state (not disabled)))
-
 
 ;; Provide ourselves:
 

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -35,9 +35,12 @@
 
 ;;; Code:
 
-;; NOTE: This module is supposed to be a leaf-module and shall not
-;;       require/depend-on any other haskell-mode modules in order to
-;;       stay at the bottom of the module dependency graph.
+;; =============================================================================
+;;                                     NOTE:
+;; THIS MODULE IS SUPPOSED TO BE A LEAF-MODULE AND SHALL NOT REQUIRE/DEPEND-ON
+;; ANY OTHER HASKELL-MODE MODULES IN ORDER TO STAY AT THE BOTTOM OF THE MODULE
+;; DEPENDENCY GRAPH.
+;; =============================================================================
 
 (eval-when-compile (require 'cl-lib))
 

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -44,8 +44,6 @@
 
 (eval-when-compile (require 'cl-lib))
 
-(require 'haskell-customize)
-
 (defvar haskell-utils-async-post-command-flag nil
   "Non-nil means some commands were triggered during async function execution.")
 (make-variable-buffer-local 'haskell-utils-async-post-command-flag)

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -48,6 +48,9 @@
   "Non-nil means some commands were triggered during async function execution.")
 (make-variable-buffer-local 'haskell-utils-async-post-command-flag)
 
+(defvar haskell-mode-interactive-prompt-state nil
+  "Special variable indicating a state of user input waiting.")
+
 (defun haskell-utils-read-directory-name (prompt default)
   "Read directory name and normalize to true absolute path.
 Refer to `read-directory-name' for the meaning of PROMPT and
@@ -180,6 +183,12 @@ expression bounds."
                end-l
                end-c
                value)))))
+
+
+(defun haskell-mode-toggle-interactive-prompt-state (&optional disabled)
+  "Set `haskell-mode-interactive-prompt-state' to t.
+If given DISABLED argument sets variable value to nil, otherwise to t."
+  (setq haskell-mode-interactive-prompt-state (not disabled)))
 
 (provide 'haskell-utils)
 ;;; haskell-utils.el ends here

--- a/tests/haskell-doc-tests.el
+++ b/tests/haskell-doc-tests.el
@@ -31,6 +31,7 @@
 (require 'haskell-mode)
 (require 'haskell-doc)
 (require 'haskell-test-utils)
+(require 'haskell-utils)
 
 
 (ert-deftest interactive-prompt-state ()


### PR DESCRIPTION
We have a circular dependency `haskell-mode` ⟷ `haskell-cabal` now.  Looks like that the only thing required in `haskell-cabal` from `haskell-mode` is `haskell-mode-toggle-interactive-prompt-state` function.  To resolve circular dependency I moved this function to Utils module.