### PR TITLE
Extend static completions with candidates from tags table

### DIFF
--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -296,7 +296,8 @@ PREFIX should be a list such one returned by
                ('haskell-completions-language-extension-prefix
                 haskell-ghc-supported-extensions)
                (otherwise
-                haskell-completions--keywords))))
+                (append (tags-completion-table)
+                        haskell-completions--keywords)))))
         (list beg end candidates)))))
 
 


### PR DESCRIPTION
Related #1184 

I thought to add `tags-completion-at-point-function` to `completion-at-point-functions` hook at first, but this approach is not good enough because in this case completion functions are run sequentially and candidates are not merged.  So, if haskell completion function will go first and it is able to complete thing at point there is no candidates from tags and vice versa.  And it is not clear what function should go first.

Fortunately, I've discovered `tags-completion-table` function, with it now it's possible to merge tags completions with keyword completions.

One question: should we revisit tags table automatically when it is regenerated (in `haskell-mode-generate-tags`)?