### PR TITLE
Use plain syntax in inferior-haskell-send-decl-post-filter

### DIFF
--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -215,9 +215,9 @@ setting up the inferior-haskell buffer."
 
 (defun inferior-haskell-send-decl-post-filter (string)
   (when (and inferior-haskell-send-decl-post-filter-on
-             #1=(string-match inferior-haskell-multiline-prompt-re string))
+             (string-match inferior-haskell-multiline-prompt-re string))
     ;; deleting sequence of `%s|' multiline promts
-    (while #1#
+    (while (string-match inferior-haskell-multiline-prompt-re string)
       (setq string (substring string (match-end 0))))
     ;; deleting regular prompts
     (setq string (replace-regexp-in-string comint-prompt-regexp "" string)


### PR DESCRIPTION
Fixes #1240.