### PR TITLE
Implement electric characters

### DIFF
--- a/doc/haskell-mode.texi
+++ b/doc/haskell-mode.texi
@@ -468,6 +468,13 @@ position, @kbd{S-TAB} selects the previous one. If a block is selected
 you can use @kbd{TAB} to indent the block more and @kbd{S-TAB} to indent
 the block less.
 
+When @code{electric-indent-mode} is enabled or the variable
+@code{haskell-indentation-electric-flag} is non-nil, the insertion of
+some characters (by default @kbd{,} @kbd{;} @kbd{)} @kbd{@}} @kbd{]})
+may trigger auto reindentation under appropriate conditions. See the
+documentation of @code{haskell-indentation-common-electric-command} for
+more details.
+
 @item @code{haskell-indent-mode} (optional).
 
 This is a semi-intelligent indentation mode doing a decent job at

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -679,16 +679,15 @@ For example
              (haskell-indentation-with-starter
               #'haskell-indentation-type-1)))))
         ((string= current-token "where")
-         (let ((starter-indent-inside (current-column)))
+         (haskell-indentation-with-starter
+          #'haskell-indentation-expression-layout nil)
+         (cond
+          ((equal current-token 'end-tokens)
+           (when (string= following-token "deriving")
+             (haskell-indentation-add-left-indent)))
+          ((equal current-token "deriving")
            (haskell-indentation-with-starter
-            #'haskell-indentation-expression-layout nil)
-           (cond
-            ((equal current-token 'end-tokens)
-             (when (string= following-token "deriving")
-               (haskell-indentation-add-left-indent)))
-            ((equal current-token "deriving")
-             (haskell-indentation-with-starter
-              #'haskell-indentation-type-1)))))))
+            #'haskell-indentation-type-1))))))
 
 (defun haskell-indentation-import ()
   "Parse import declaration."


### PR DESCRIPTION
This does it like in `cc-mode'.

Also, I removed a few unnecessary things in the minor mode definition and removed an unused variable (Fixes #1294).

Closes #1133