### PR TITLE
Update xref-push-marker-stack

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -352,13 +352,11 @@ position with `xref-pop-marker-stack'."
   (interactive "P")
   (let ((initial-loc (point-marker))
         (loc (haskell-mode-find-def (haskell-ident-at-point))))
-    (if loc
-        (haskell-mode-handle-generic-loc loc)
-      (call-interactively 'haskell-mode-tag-find))
-    (unless (equal initial-loc (point-marker))
-      (save-excursion
-        (goto-char initial-loc)
-        (xref-push-marker-stack)))))
+    (if (not loc)
+        (call-interactively 'haskell-mode-tag-find)
+      (haskell-mode-handle-generic-loc loc)
+      (unless (equal initial-loc (point-marker))
+        (xref-push-marker-stack initial-loc)))))
 
 ;;;###autoload
 (defun haskell-mode-goto-loc ()
@@ -379,7 +377,7 @@ Requires the :loc-at command from GHCi."
   (forward-char (plist-get span :start-col)))
 
 (defun haskell-process-insert-type ()
-  "Get the identifer at the point and insert its type.
+  "Get the identifier at the point and insert its type.
 Use GHCi's :type if it's possible."
   (let ((ident (haskell-ident-at-point)))
     (when ident

--- a/haskell-compat.el
+++ b/haskell-compat.el
@@ -35,9 +35,9 @@
 (unless (fboundp 'xref-push-marker-stack)
   (defalias 'xref-pop-marker-stack 'pop-tag-mark)
 
-  (defun xref-push-marker-stack ()
-    "Add point to the marker stack."
-    (ring-insert find-tag-marker-ring (point-marker))))
+  (defun xref-push-marker-stack (&optional m)
+    "Add point M (defaults to `point-marker') to the marker stack."
+    (ring-insert find-tag-marker-ring (or m (point-marker)))))
 
 (unless (fboundp 'outline-hide-sublevels)
   (defalias 'outline-hide-sublevels 'hide-sublevels))


### PR DESCRIPTION
25.1 allows for an optional marker argument.

Also do not push the marker when it is done already in
haskell-mode-tag-find.

Fixes #1311