### PR TITLE
Enable adaptive-fill-mode

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -793,7 +793,6 @@ Minor modes that work well with `haskell-mode':
   (setq-local paragraph-separate (concat " *$\\| *\\({-\\|-}\\) *$\\|" page-delimiter))
   (setq-local fill-paragraph-function 'haskell-fill-paragraph)
   ;; (setq-local adaptive-fill-function 'haskell-adaptive-fill)
-  (setq-local adaptive-fill-mode nil)
   (setq-local comment-start "-- ")
   (setq-local comment-padding 0)
   (setq-local comment-start-skip "[-{]-[ \t]*")

--- a/tests/haskell-mode-tests.el
+++ b/tests/haskell-mode-tests.el
@@ -297,8 +297,8 @@ the beginning of the buffer.
 
 (ert-deftest fill-comment-2 ()
   (check-fill '("{- a b c d e"
-                "f g h i j"
-                "k -}")
+                " f g h i j"
+                " k -}")
               '("{- @a b c d e f g h i j k -}")))
 
 (ert-deftest fill-comment-3 ()
@@ -322,7 +322,7 @@ the beginning of the buffer.
 (ert-deftest fill-comment-5 ()
   (check-fill '("    {-"
                 " a b c d e"
-                "f g h i"
+                " f g h i"
                 "    -}")
               '("    {-" " @a b c d e f g h i" "    -}")))
 
@@ -398,7 +398,6 @@ Also should respect 10 column fill."
 as defined, just the content should move properly.
 
 Also should respect 10 column fill."
-  :expected-result :failed
   (check-fill '("  --  a b"
                 "  -- c d e"
                 "  -- f g h"
@@ -412,7 +411,6 @@ as defined, just the content should move properly. Following
 lines should take position from second line.
 
 Also should respect 10 column fill."
-  :expected-result :failed
   (check-fill '("  --  a b"
                 "  -- c d e"
                 "  -- f g h"


### PR DESCRIPTION
It was disabled in 96c8bbfb37c237415a14c7d616681cb8d9681eb4 because
`haskell-adaptive-fill` didn't work well. However, the default adaptive
fill rulles play nicely with Haskell, so it's pretty useful to keep it
enabled even without a custom adaptive-fill-function.