### PR TITLE
Re-introduce local (lexical) bindings to fix #1327.

### DIFF
--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -1535,14 +1535,18 @@ If SYNC is non-nil, make the call synchronously instead."
       (if sync
           (let ((response (haskell-process-queue-sync-request process ghci-command)))
             (funcall callback (funcall process-response response)))
-        (haskell-process-queue-command
-         process
-         (make-haskell-command
-          :go (lambda (_) (haskell-process-send-string process ghci-command))
-          :complete
-          (lambda (_ response)
-            (funcall callback (funcall process-response response))))))
-      'async)))
+        (let ((process process)
+              (callback callback)
+              (ghci-command ghci-command)
+              (process-response process-response))
+          (haskell-process-queue-command
+           process
+           (make-haskell-command
+            :go (lambda (_) (haskell-process-send-string process ghci-command))
+            :complete
+            (lambda (_ response)
+              (funcall callback (funcall process-response response))))))
+        'async))))
 
 (defun haskell-doc-sym-doc (sym)
   "Show the type of given symbol SYM.


### PR DESCRIPTION
Fixes #1327 by reintroducing the lexical bindings using emacs native lexical bind
(the file local lexical-binding is already set in the file header), which were removed by removing
the lexical-let in commit 31426d720b2a40e607c6c95207b238af72158233