### PR TITLE
Fallback to tags if there is no haskell-session

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -350,13 +350,13 @@ If the definition or tag is found, the location from which you jumped
 will be pushed onto `xref--marker-ring', so you can return to that
 position with `xref-pop-marker-stack'."
   (interactive "P")
-  (let ((initial-loc (point-marker))
-        (loc (haskell-mode-find-def (haskell-ident-at-point))))
-    (if (not loc)
-        (call-interactively 'haskell-mode-tag-find)
-      (haskell-mode-handle-generic-loc loc)
-      (unless (equal initial-loc (point-marker))
-        (xref-push-marker-stack initial-loc)))))
+  (if (haskell-session-maybe)
+        (let ((initial-loc (point-marker))
+            (loc (haskell-mode-find-def (haskell-ident-at-point))))
+          (haskell-mode-handle-generic-loc loc)
+          (unless (equal initial-loc (point-marker))
+            (xref-push-marker-stack initial-loc)))
+      (call-interactively 'haskell-mode-tag-find)))
 
 ;;;###autoload
 (defun haskell-mode-goto-loc ()


### PR DESCRIPTION
The function name & docs suggest this is the intended behavior.
`haskell-mode-find-def` errors if there is no session, so we need to
only call it if there is a session.

closes https://github.com/haskell/haskell-mode/issues/1180

See discussion in https://github.com/haskell/haskell-mode/pull/1326