### PR TITLE
Use PWD instead of CURDIR in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ deploy-manual : doc/html
 $(AUTOLOADS): $(ELFILES)
 	$(BATCH) \
 		--eval '(setq make-backup-files nil)' \
-		--eval '(setq generated-autoload-file "$(CURDIR)/$@")' \
+		--eval "(setq generated-autoload-file \"$${PWD}/$@\")" \
 		-f batch-update-autoloads "."
 	# check if autoloads will really load
 	$(BATCH) -l "$@"


### PR DESCRIPTION
Produces correct autoloads when the source tree has been symlinked. If the source tree is a symlink, `CURDIR` will always be the dereferenced path, while `PWD` is usually what we expect. Using `CURDIR` can lead to some incorrect paths in `haskell-mode-autoloads.el`.

#### Context

I noticed this when trying to build a haskell-mode source tree that had been symlinked from another directory (I use GNU Stow to symlink things from a git repo):

```
[tim@axiom:~] % ls -alr ~/.emacs.d/haskell-mode
lrwxr-xr-x  1 tim  staff  40 21 May 23:31 /Users/tim/.emacs.d/haskell-mode -> ../src/emacs/emacs/.emacs.d/haskell-mode
```

During `cd ~/.emacs.d/haskell-mode && make`, the following are true:

```
CURDIR=/Users/tim/src/emacs/emacs/.emacs.d/haskell-mode
PWD=/Users/tim/.emacs.d/haskell-mode
```

... and this leads to broken relative paths in `haskell-mode-autoloads.el`:

```
Generating autoloads for ../../../../../.emacs.d/haskell-mode/highlight-uses-mode.el...
Generating autoloads for ../../../../../.emacs.d/haskell-mode/highlight-uses-mode.el...done
Generating autoloads for ../../../../../.emacs.d/haskell-mode/inf-haskell.el...
Generating autoloads for ../../../../../.emacs.d/haskell-mode/inf-haskell.el...done
Generating autoloads for ../../../../../.emacs.d/haskell-mode/w3m-haddock.el...
Generating autoloads for ../../../../../.emacs.d/haskell-mode/w3m-haddock.el...done
```

This fix should not break the build for the regular unsymlinked case. The Makefile shelled out to `pwd` before commit e4418c3 without incident.