### PR TITLE
Added font lock tests for pattern synonyms (for #1313)

### DIFF
--- a/tests/haskell-font-lock-tests.el
+++ b/tests/haskell-font-lock-tests.el
@@ -883,22 +883,20 @@
      "pattern A :: (C a) => () => a -> B"
      "pattern A :: (C a) => (C a) => a -> B"
      "pattern A :: (C a) => (C a) => a -> B")
-   '(("pattern"  t haskell-keyword-face)
-     ("where"    t haskell-keyword-face)
-     ("module"   t haskell-keyword-face)
-     ("A"        t haskell-constructor-face)
-     ("B"        t haskell-type-face)
-     ("C"        t haskell-type-face)
-     ("<-"       t haskell-operator-face)
-     ("←"        t haskell-operator-face)
-     ("=>"       t haskell-operator-face)
-     ("::"       t haskell-operator-face)
-     ("+"        t nil)
-     ("1"        t nil)
-     ("("        t nil)
-     (")"        t nil)
-     ("a"        t nil)
-     ("subtract" t nil))))
+   '(("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("module"  t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("where"   t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face)
+     ("pattern" t haskell-keyword-face))))
 
 (ert-deftest haskell-no-pattern-1 ()
   "Don't fontify \"pattern\" in contexts unrelated to pattern synonyms."
@@ -907,7 +905,8 @@
   (check-properties
    '("pattern :: Int"
      "pattern = 3")
-   '(("pattern" t haskell-definition-face))))
+   '(("pattern" t haskell-definition-face)
+     ("pattern" t haskell-definition-face))))
 
 (ert-deftest haskell-no-pattern-2 ()
   "Don't fontify \"pattern\" in contexts unrelated to pattern synonyms."
@@ -917,4 +916,9 @@
    '("foo :: (a -> pattern) -> a -> pattern"
      "foo pattern x = pattern x"
      "bar = pattern where pattern = 5")
-   '(("pattern" t nil))))
+   '(("pattern" t nil)
+     ("pattern" t nil)
+     ("pattern" t nil)
+     ("pattern" t nil)
+     ("pattern" t nil)
+     ("pattern" t nil))))

--- a/tests/haskell-font-lock-tests.el
+++ b/tests/haskell-font-lock-tests.el
@@ -866,3 +866,55 @@
      ("Y" t haskell-constructor-face)
      ("Z" t haskell-type-face)
      ("C" t haskell-constructor-face))))
+
+(ert-deftest haskell-pattern ()
+  "Fontify the \"pattern\" keyword in contexts related to pattern synonyms."
+  :expected-result :failed
+  (check-properties
+   '("pattern A = B"
+     "pattern A <- B"
+     "pattern A ← B"
+     "pattern A n <- (subtract 1 -> n) where A n = n + 1"
+     "module Main (pattern A) where"
+     "pattern A :: a -> B"
+     "pattern A :: (C a) => a -> B"
+     "pattern A :: (C a) => a -> B"
+     "pattern A :: (C a) => () => a -> B"
+     "pattern A :: (C a) => () => a -> B"
+     "pattern A :: (C a) => (C a) => a -> B"
+     "pattern A :: (C a) => (C a) => a -> B")
+   '(("pattern"  t haskell-keyword-face)
+     ("where"    t haskell-keyword-face)
+     ("module"   t haskell-keyword-face)
+     ("A"        t haskell-constructor-face)
+     ("B"        t haskell-type-face)
+     ("C"        t haskell-type-face)
+     ("<-"       t haskell-operator-face)
+     ("←"        t haskell-operator-face)
+     ("=>"       t haskell-operator-face)
+     ("::"       t haskell-operator-face)
+     ("+"        t nil)
+     ("1"        t nil)
+     ("("        t nil)
+     (")"        t nil)
+     ("a"        t nil)
+     ("subtract" t nil))))
+
+(ert-deftest haskell-no-pattern-1 ()
+  "Don't fontify \"pattern\" in contexts unrelated to pattern synonyms."
+  ;; This already works properly
+  ;;:expected-result :failed
+  (check-properties
+   '("pattern :: Int"
+     "pattern = 3")
+   '(("pattern" t haskell-definition-face))))
+
+(ert-deftest haskell-no-pattern-2 ()
+  "Don't fontify \"pattern\" in contexts unrelated to pattern synonyms."
+  ;; This already works properly
+  ;;:expected-result :failed
+  (check-properties
+   '("foo :: (a -> pattern) -> a -> pattern"
+     "foo pattern x = pattern x"
+     "bar = pattern where pattern = 5")
+   '(("pattern" t nil))))


### PR DESCRIPTION
I wrote tests for the font lock issues with the `pattern` keyword, as discussed in #1313.

Please check if the way I used `check-properties` is correct, since:
* It wasn't entirely clear but it seemed like the triplets in the second argument of `check-properties` each describe the fact that a token should be fontified a particular way in all the test strings given in the first argument (the alternative interpretation is that the triplets describe a series of fontifications for each token in order, and since none of the existing tests duplicate the first element of a triple, it's ambiguous which it is).
* I gave `t` as the second element of each triple, which I am not sure about either. This element is the "syntax" of the token, but I don't know enough about Emacs fontification to know what that means.

The `haskell-no-pattern-1` and `haskell-no-pattern-2` tests currently pass, so I commented out the `:expected-result :failed` so as to prevent an error.

cc: @gracjan 

EDIT: fun fact, this is pull request number 1337 on haskell-mode :D