### PR TITLE
Document `defun haskell-indent-mode`'s arg

### DIFF
--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -1579,6 +1579,9 @@ these functions also align the guards and rhs of the current definition
     \\[haskell-indent-put-region-in-literate]
       makes the region a piece of literate code in a literate script
 
+If `ARG' is falsey, toggle `haskell-indent-mode'.  Else sets
+`haskell-indent-mode' to whether `ARG' is greater than 0.
+
 Invokes `haskell-indent-hook' if not nil."
   (interactive "P")
   (setq haskell-indent-mode


### PR DESCRIPTION
It seemed to me when reading the documentation that the `haskell-indent-hook` note refered to the argument, so document it separately