### PR TITLE
Space calls to the function to be tested to enhance readability

### DIFF
--- a/tests/haskell-decl-scan-tests.el
+++ b/tests/haskell-decl-scan-tests.el
@@ -37,10 +37,13 @@
     (insert-lines "" "fun :: Int -> Int" "fun = id"
                   "" "f2 :: Int" "f2 = 3" "")
     (goto-char (point-max))
+
     (should (haskell-ds-backward-decl))
     (should (looking-at-p "f2 :: Int"))
+
     (should (haskell-ds-backward-decl))
     (should (looking-at-p "fun :: Int -> Int"))
+
     (should-not (haskell-ds-backward-decl))
     (should (= (point-min) (point)))))
 
@@ -53,10 +56,13 @@
                   "" "" "f2 = 3"
                   "" "" "")
     (goto-char (point-max))
+
     (should (haskell-ds-backward-decl))
     (should (looking-at-p "f2 :: Int"))
+
     (should (haskell-ds-backward-decl))
     (should (looking-at-p "fun :: Int -> Int"))
+
     (should-not (haskell-ds-backward-decl))
     (should (= (point-min) (point)))))
 
@@ -67,11 +73,14 @@
                   "" "f2 :: Int" "f2 = 3"
                   "")
     (goto-char (point-min))
+
     (should (haskell-ds-forward-decl))
     (should (looking-at-p "$"))
     (should (= (point) (save-excursion (goto-line 4) (point))))
+
     (should (haskell-ds-forward-decl))
     (should (looking-at-p "f2 :: Int"))
+
     (should (= (point-max) (haskell-ds-forward-decl)))))
 
 (ert-deftest haskell-ds-forward-decl-2 ()
@@ -83,13 +92,17 @@
                   "" "" "f2 = 3"
                   "" "" "")
     (goto-char (point-min))
+
     (should (haskell-ds-forward-decl))
     (should (looking-at-p "$"))
     (should (= (point) (save-excursion (goto-line 7) (point))))
+
     (should (haskell-ds-forward-decl))
     (should (looking-at-p "f2 :: Int"))
+
     (should (haskell-ds-forward-decl))
     (should (= (point) (save-excursion (goto-line 13) (point))))
+
     (should (= (point-max) (progn (haskell-ds-forward-decl) (point))))))
 
 (provide 'haskell-decl-scan-tests)


### PR DESCRIPTION
Space out tests in `haskell-decl-scan-tests.el` to make more readable.