### PR TITLE
allow pasting into multiline expressions

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -249,10 +249,10 @@ do the
 :}"
   (if (not (string-match-p "\n" expr))
       expr
-    (let ((len (length haskell-interactive-prompt))
+    (let ((pre (format "^%s" (regexp-quote haskell-interactive-prompt)))
           (lines (split-string expr "\n")))
       (cl-loop for elt on (cdr lines) do
-               (setcar elt (substring (car elt) len)))
+               (setcar elt (replace-regexp-in-string pre "" (car elt))))
       ;; Temporarily set prompt2 to be empty to avoid unwanted output
       (concat ":set prompt2 \"\"\n"
               ":{\n"


### PR DESCRIPTION
If user pastes something into a multiline expr, the lines won't have
the initial prompt2, so try to avoid removing them in that case

(I was looking at https://github.com/haskell/haskell-mode/issues/608 and wondering if I could make a quick hack by simply sending defun-at-point as a multiline expression, but it seems to require quite a lot of fiddling with indentation, seems like something that should be built-in to ghci rather …)