### PR TITLE
[WIP] Replace haskell-indentation-mode tokenizer, fixes #1369

### DIFF
--- a/tests/haskell-indentation-tests.el
+++ b/tests/haskell-indentation-tests.el
@@ -1005,6 +1005,12 @@ data X = X |
               (2 2 9)
               (3 0 7 9))
 
+(hindent-test "61 unterminated/multiline strings whose line doesn't end in backslash" "
+func = \"unterminated
+           where"
+              (1 0)
+              (2 9))
+
 
 (ert-deftest haskell-indentation-ret-indents ()
   (with-temp-switch-to-buffer


### PR DESCRIPTION
Added a test for #1369. Note that this test neither passes nor fails, it freezes up the test suite!

@gracjan: If there is a way to stop it from doing that, or you'd like me to add/expand anything in this PR please let me know and I'll try to fix it.