### PR TITLE
Add an alias to fix the breakage of #1375

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -1137,6 +1137,11 @@ This function usually will be used with `buffer-file-name':
                              collect part)))
     (mapconcat 'identity (reverse components) ".")))
 
+(defun haskell-guess-module-name ()
+  "Guess the current module name of the buffer.
+Uses `haskell-guess-module-name-from-file-name'."
+  (haskell-guess-module-name-from-file-name (buffer-file-name)))
+
 (defvar haskell-auto-insert-module-format-string
   "-- | \n\nmodule %s where\n\n"
   "Template string that will be inserted in new haskell buffers via `haskell-auto-insert-module-template'.")


### PR DESCRIPTION
In #1375, `haskell-guess-module-name` was renamed to
`haskell-guess-module-name-from-file-name` which caused breakage for
users of the original function name. Fix the breakage by defining an
alias that makes the original name point to the new function name.