### PR TITLE
Map haskell-mode-format-imports to C-c C-,

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -200,7 +200,7 @@ be set to the preferred literate style."
   (let ((map (make-sparse-keymap)))
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ;; Editing-specific commands
-    (define-key map (kbd "C-c C-.") 'haskell-mode-format-imports)
+    (define-key map (kbd "C-c C-,") 'haskell-mode-format-imports)
     (define-key map [remap delete-indentation] 'haskell-delete-indentation)
     (define-key map (kbd "C-c C-l") 'haskell-mode-enable-process-minor-mode)
     (define-key map (kbd "C-c C-b") 'haskell-mode-enable-process-minor-mode)


### PR DESCRIPTION
Map haskell-mode-format-imports to C-c C-, to avoid conflict with haskell-indent

Fixes #396.