### PR TITLE
Fix inferior-haskell warning font lock for GHC 8.0

### DIFF
--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -81,7 +81,7 @@ The command can include arguments."
   ;; The format of error messages used by Hugs.
   `(("^ERROR \"\\(.+?\\)\"\\(:\\| line \\)\\([0-9]+\\) - " 1 3)
     ;; Format of error messages used by GHCi.
-    ("^\\(.+?\\):\\([0-9]+\\):\\(\\([0-9]+\\):\\)?\\( \\|\n *\\)\\(Warning\\)?"
+    ("^\\(.+?\\):\\([0-9]+\\):\\(\\([0-9]+\\):\\)?\\( \\|\n *\\)\\(.arning\\)?"
      1 2 4 ,@(if (fboundp 'compilation-fake-loc)
                  '((6) nil (5 '(face nil font-lock-multiline t)))))
     ;; Runtime exceptions, from ghci.

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -81,7 +81,7 @@ The command can include arguments."
   ;; The format of error messages used by Hugs.
   `(("^ERROR \"\\(.+?\\)\"\\(:\\| line \\)\\([0-9]+\\) - " 1 3)
     ;; Format of error messages used by GHCi.
-    ("^\\(.+?\\):\\([0-9]+\\):\\(\\([0-9]+\\):\\)?\\( \\|\n *\\)\\(.arning\\)?"
+    ("^\\(.+?\\):\\([0-9]+\\):\\(\\([0-9]+\\):\\)?\\( \\|\n *\\)\\([Ww]arning\\)?"
      1 2 4 ,@(if (fboundp 'compilation-fake-loc)
                  '((6) nil (5 '(face nil font-lock-multiline t)))))
     ;; Runtime exceptions, from ghci.


### PR DESCRIPTION
GHC 8.0 uses an error message of the form

```
/home/alanz/mysrc/github/alanz/ghc-exactprint/tests/Test.hs:99:3: warning: [-Wunused-matches]
    Defined but not used: ‘prettyRoundTripTests’
```

The word "warning" no longer has an initial capital letter.