### PR TITLE
Removed unused lexical variables.

### DIFF
--- a/haskell-lexeme.el
+++ b/haskell-lexeme.el
@@ -138,8 +138,7 @@ When match is successful, match-data will contain:
   (match-text 2) - whole qualified identifier
   (match-text 3) - unqualified part of identifier
   (match-text 4) - closing backtick"
-  (let ((begin (point))
-        (match-data-old (match-data))
+  (let ((match-data-old (match-data))
         first-backtick-start
         last-backtick-start
         qid-start

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -160,9 +160,7 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
 (defun haskell-process-log (msg)
   "Effective append MSG to the process log (if enabled)."
   (when haskell-process-log
-    (let* ((append-to (get-buffer-create "*haskell-process-log*"))
-           (windows (get-buffer-window-list append-to t t))
-           move-point-in-windows)
+    (let* ((append-to (get-buffer-create "*haskell-process-log*")))
       (with-current-buffer append-to
         ;; point should follow insertion so that it stays at the end
         ;; of the buffer


### PR DESCRIPTION
Current emacs fails to build with some errors on unused lexical variables.  
As the complaint seems legitimately, I removed them.

Fixes #1428.