### PR TITLE
Fix documentation of haskell-mode-format-imports key binding

### DIFF
--- a/doc/haskell-mode.texi
+++ b/doc/haskell-mode.texi
@@ -278,7 +278,7 @@ To generally format (sort, align) your imports, you can run
 
     @kbd{M-x} @code{haskell-mode-format-imports}
 
-Or @kbd{C-c C-.}.
+Or @kbd{C-c C-,}.
 
 @subsection Sort imports
 


### PR DESCRIPTION
PR #1403 changed the code but the manual was not updated.