### PR TITLE
Make most interactive text optionally writable

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -343,6 +343,21 @@ printing compilation messages."
   :type 'boolean
   :group 'haskell-interactive)
 
+(defcustom haskell-interactive-mode-read-only
+  t
+  "Non-nil means most GHCi/haskell-interactive-mode output is read-only.
+This does not include the prompt.  Configure
+`haskell-interactive-prompt-read-only' to change the prompt's
+read-only property."
+  :type 'boolean
+  :group 'haskell-interactive)
+
+(defcustom haskell-interactive-prompt-read-only
+  haskell-interactive-mode-read-only
+  "Non-nil means the prompt (and prompt2) is read-only."
+  :type 'boolean
+  :group 'haskell-interactive)
+
 (defcustom haskell-import-mapping
   '()
   "Support a mapping from module to import lines.

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -298,7 +298,7 @@ SESSION, otherwise operate on the current buffer."
       (let ((prompt (propertize haskell-interactive-prompt
                                 'font-lock-face 'haskell-interactive-face-prompt
                                 'prompt t
-                                'read-only t
+                                'read-only haskell-interactive-prompt-read-only
                                 'rear-nonsticky t)))
         ;; At the time of writing, front-stickying the first char gives an error
         ;; Has unfortunate side-effect of being able to insert before the prompt
@@ -318,17 +318,16 @@ SESSION, otherwise operate on the current buffer."
                                  'font-lock-face 'haskell-interactive-face-result
                                  'front-sticky t
                                  'prompt t
-                                 'read-only t
+                                 'read-only haskell-interactive-mode-read-only
                                  'rear-nonsticky t
                                  'result t)))
       (save-excursion
         (goto-char (point-max))
         (when (string= text haskell-interactive-prompt2)
-          (put-text-property 0
-                             (length haskell-interactive-prompt2)
-                             'font-lock-face
-                             'haskell-interactive-face-prompt2
-                             prop-text))
+          (setq prop-text
+                (propertize prop-text
+                            'font-lock-face 'haskell-interactive-face-prompt2
+                            'read-only haskell-interactive-prompt-read-only)))
         (insert (ansi-color-apply prop-text))
         (haskell-interactive-mode-handle-h)
         (let ((marker (setq-local haskell-interactive-mode-result-end (make-marker))))
@@ -366,7 +365,7 @@ SESSION, otherwise operate on the current buffer."
                                   'expandable t
                                   'font-lock-face type
                                   'front-sticky t
-                                  'read-only t
+                                  'read-only haskell-interactive-mode-read-only
                                   'rear-nonsticky t))
               (insert (propertize (concat (match-string 2 message) "\n")
                                   'collapsible t
@@ -374,12 +373,12 @@ SESSION, otherwise operate on the current buffer."
                                   'front-sticky t
                                   'invisible haskell-interactive-mode-hide-multi-line-errors
                                   'message-length (length (match-string 2 message))
-                                  'read-only t
+                                  'read-only haskell-interactive-mode-read-only
                                   'rear-nonsticky t)))
           (insert (propertize (concat message "\n")
                               'font-lock-face type
                               'front-sticky t
-                              'read-only t
+                              'read-only haskell-interactive-mode-read-only
                               'rear-nonsticky t)))))))
 
 (defun haskell-interactive-mode-insert (session message)


### PR DESCRIPTION
Text that was explicitly documented as read-only is still
unconditionally read-only.

Fixes #1437.