### PR TITLE
Remove reference to haskell-mode-suggest-indent-choice.

### DIFF
--- a/ghci-script-mode.el
+++ b/ghci-script-mode.el
@@ -36,7 +36,6 @@
   (setq-local comment-start-skip "[-{]-[ \t]*")
   (setq-local comment-end "")
   (setq-local comment-end-skip "[ \t]*\\(-}\\|\\s>\\)")
-  (setq-local indent-line-function 'haskell-mode-suggest-indent-choice)
   (setq-local font-lock-defaults '(ghci-script-mode-keywords t t nil nil))
   (setq-local indent-tabs-mode nil)
   (setq-local tab-width 8)


### PR DESCRIPTION
Commit ee5effd110cd0f23d36cc391fbba767816dfc83b removed the function
from haskell-mode.el but missed this reference.