### PR TITLE
Recognize documentation comments as comments

### DIFF
--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -372,8 +372,9 @@ there."
            (setf fontfaces (list fontfaces)))
          (delq nil (mapcar
                     #'(lambda (f)
-                        (or (eq f 'font-lock-comment-face)
-                            (eq f 'font-lock-comment-delimiter-face)))
+                        (member f '(font-lock-comment-face
+                                    font-lock-doc-face
+                                    font-lock-comment-delimiter-face)))
                     fontfaces))))
       t
     nil))

--- a/tests/haskell-decl-scan-tests.el
+++ b/tests/haskell-decl-scan-tests.el
@@ -35,7 +35,8 @@
   "All lines in this buffer should count as comments"
   (with-temp-buffer
     (haskell-mode)
-    (insert-lines "" "--hi" "  -- hi\t " "" "{-hi-}" " \t{-hi-}  ")
+    (insert-lines "" "--hi" "  -- hi\t " "" "{-hi-}" " \t{-hi-}  "
+                  "-- | hi" "{-| hi -}")
     (font-lock-fontify-buffer)
     (goto-char (point-min))
 


### PR DESCRIPTION
This will fix edge cases in haskell-ds-forward-decl that would cause it to go forward to the beginning of the next decl when there are documentation comments, rather than the correct behavior of going to the end of the current declaration.

Behavior demonstrated (cursor is at POINTBEFORE at the beginning and should go to NEWPOINTAFTER, used to go to POINTAFTER).

    POINTBEFOREmain = x
    NEWPOINTAFTER
    -- | Documentation
    POINTAFTERx = return ()

