### PR TITLE
Use functions `bobp' and `member' instead of manual implementations.

### DIFF
--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -360,10 +360,7 @@ there."
   ;; ensure result is `t' or `nil' instead of just truthy
   (if (or
        ;; is cursor on whitespace
-       (let ((f (following-char)))
-         (or (= f ?\t)
-             (= f ?\n)
-             (= f ? )))
+       (member (following-char) '(?\t ?\n ?\ ))
        ;; http://emacs.stackexchange.com/questions/14269/how-to-detect-if-the-point-is-within-a-comment-area
        ;; is cursor at begging, inside, or end of comment
        (let ((fontfaces (get-text-property (or pt
@@ -419,8 +416,7 @@ declaration.  As `haskell-ds-backward-decl' but forward."
       (forward-line -1)
       (while (and (haskell-ds-line-commented-p)
                   ;; prevent infinite loop
-                  (not (= (point)
-                          (point-min))))
+                  (not (bobp)))
         (forward-line -1))
       (forward-line 1)))
   (point))


### PR DESCRIPTION
This simplifies the code, making it consistent and readable.