### PR TITLE
Fix stack-ghci invocation argument

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -159,7 +159,7 @@ pass additional flags to `ghc'."
   :type '(repeat (string :tag "Argument")))
 
 (defcustom haskell-process-args-stack-ghci
-  '("--ghc-options=-ferror-spans")
+  '("--ghci-options=-ferror-spans")
   "Additional arguments for `stack ghci' invocation."
   :group 'haskell-interactive
   :type '(repeat (string :tag "Argument")))


### PR DESCRIPTION
This option has been renamed to `--ghci-options`:

https://github.com/commercialhaskell/stack/commit/3348ec867bb339ff5f525f68f2e40248d5bfedce#diff-36766742aefd855fe3d2063edae89117

I notice there has been discussion about this (#1455). Can we consider changing the default instead of everyone fixing on their own? After all the change was more than one year old.