### PR TITLE
Point at new info in haskell-presentation-present

### DIFF
--- a/haskell-presentation-mode.el
+++ b/haskell-presentation-mode.el
@@ -89,10 +89,10 @@ buffer before presenting message."
 
       (when clear (haskell-presentation-clear))
       (haskell-session-assign session)
+      (goto-char (point-min))
+      (forward-line 2)
       (save-excursion
         (let ((buffer-read-only nil))
-          (goto-char (point-min))
-          (forward-line 2)
           (insert code "\n\n"))))
 
     (if (eq major-mode 'haskell-presentation-mode)


### PR DESCRIPTION
Makes it so that the point is at the beginning of any the new information added. This simplifies for example copying a type signature after `haskell-process-do-type`.