### PR TITLE
Fix error in haskell-session-interactive-buffer

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -504,7 +504,7 @@ FILE-NAME only."
     (if (and buffer (buffer-live-p buffer))
         buffer
       (let ((buffer-name (format "*%s*" (haskell-session-name s)))
-            index)
+            (index 0))
         (while (get-buffer buffer-name)
           (setq buffer-name (format "*%s <%d>*" (haskell-session-name s) index))
           (setq index (1+ index)))


### PR DESCRIPTION
haskell-session-interactive-buffer: Format specifier doesn’t match argument type