### PR TITLE
Make haskell-process-wrapper-function safe for .dir-locals.

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -85,7 +85,8 @@ a per-project basis."
   :group 'haskell-interactive
   :type '(choice
           (function-item :tag "None" :value identity)
-          (function :tag "Custom function")))
+          (function :tag "Custom function"))
+  :safe 'functionp)
 
 (defcustom haskell-ask-also-kill-buffers
   t


### PR DESCRIPTION
In its documentation, we recommend configuring `haskell-process-wrapper-function` per-directory in a `.dir-locals.el` file, but doing this creates an unnecessary warning because it is not marked as safe. This change suppresses that warning as long as the local value is a function, streamlining the experience.