### PR TITLE
Make haskell-cabal-subsection-arrange-lines sort base before other packages in build-depends

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -728,7 +728,7 @@ Respect the comma style."
      (haskell-cabal-goto-mark)
      (haskell-cabal-remove-mark)))
 
-(defun haskell-cabal-sort-lines-predicate (key1 key2)
+(defun haskell-cabal-sort-lines-depends-compare (key1 key2)
   (let* ((key1str (buffer-substring (car key1) (cdr key1)))
          (key2str (buffer-substring (car key2) (cdr key2)))
          (base-regex "^[ \t]*base\\($\\|[^[:alnum:]-]\\)"))
@@ -741,14 +741,18 @@ Respect the comma style."
   "Sort lines of current subsection"
   (interactive)
   (haskell-cabal-save-position
-   (haskell-cabal-with-subsection
-    (haskell-cabal-subsection) t
-    (haskell-cabal-with-cs-list
-     (sort-subr nil 'forward-line 'end-of-line
-                'haskell-cabal-sort-lines-key-fun
-                'end-of-line
-                'haskell-cabal-sort-lines-predicate
-                )))))
+   (let* ((subsection (haskell-cabal-section-name (haskell-cabal-subsection)))
+          (compare-lines (if (string= (downcase subsection) "build-depends")
+                            'haskell-cabal-sort-lines-depends-compare
+                          nil)))
+     (haskell-cabal-with-subsection
+      (haskell-cabal-subsection) t
+      (haskell-cabal-with-cs-list
+       (sort-subr nil 'forward-line 'end-of-line
+                  'haskell-cabal-sort-lines-key-fun
+                  'end-of-line
+                  compare-lines
+                  ))))))
 
 (defun haskell-cabal-subsection-beginning ()
   "find the beginning of the current subsection"

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -728,6 +728,15 @@ Respect the comma style."
      (haskell-cabal-goto-mark)
      (haskell-cabal-remove-mark)))
 
+(defun haskell-cabal-sort-lines-predicate (key1 key2)
+  (let* ((key1str (buffer-substring (car key1) (cdr key1)))
+         (key2str (buffer-substring (car key2) (cdr key2)))
+         (base-regex "^[ \t]*base\\($\\|[^[:alnum:]-]\\)"))
+    (cond
+     ((string-match base-regex key1str) t)
+     ((string-match base-regex key2str) nil)
+     (t (string< key1str key2str)))))
+
 (defun haskell-cabal-subsection-arrange-lines ()
   "Sort lines of current subsection"
   (interactive)
@@ -736,8 +745,10 @@ Respect the comma style."
     (haskell-cabal-subsection) t
     (haskell-cabal-with-cs-list
      (sort-subr nil 'forward-line 'end-of-line
-                'haskell-cabal-sort-lines-key-fun)
-     ))))
+                'haskell-cabal-sort-lines-key-fun
+                'end-of-line
+                'haskell-cabal-sort-lines-predicate
+                )))))
 
 (defun haskell-cabal-subsection-beginning ()
   "find the beginning of the current subsection"

--- a/tests/haskell-cabal-tests.el
+++ b/tests/haskell-cabal-tests.el
@@ -316,6 +316,33 @@ Executable bin-1
                       -- Foo, bar
 "))))
 
+(ert-deftest haskell-cabal-subsection-arrange-lines-dependencies ()
+  (with-temp-buffer
+    (insert "
+Executable bin-1
+    Main-Is:          TestParsing.hs
+    Build-Depends: aeson
+                 , text
+                 , base >= 4.8 && < 5
+                 , base64
+                 , bytestring
+                 , base-compat
+")
+    (haskell-cabal-mode)
+    (goto-char (point-min))
+    (search-forward "build-depends:")
+    (haskell-cabal-subsection-arrange-lines)
+    (should (string= (buffer-string) "
+Executable bin-1
+    Main-Is:          TestParsing.hs
+    Build-Depends: base >= 4.8 && < 5
+                 , aeson
+                 , base-compat
+                 , base64
+                 , bytestring
+                 , text
+"))))
+
 (ert-deftest haskell-cabal-add-dependency-01 ()
   ;; cannot add dependency when there is no 'Build-depends' section already
   :expected-result :failed


### PR DESCRIPTION
Changes sorting of dependencies so "base" appears at the type of the list.

E.g. instead of 

```
build-depends: aeson
             , base >= 4.8 && < 5
             , text
```

we have

```
build-depends: base >= 4.8 && < 5
             , aeson
             , text
```