### PR TITLE
added build-* dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ haskell-mode-autoloads.el
 haskell-mode.info
 haskell-mode.tmp.texi
 dir
+build-*


### PR DESCRIPTION
build-* is created when we build the project, it would be helpful if it were in the `.gitignore` file because we don't need it.