### PR TITLE
haskell-font-lock-dot-is-not-composition fix

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -108,6 +108,7 @@ This is the case if the \".\" is part of a \"forall <tvar> . <type>\"."
                             (line-beginning-position) t)
         (not (or
               (string= " " (string (char-after start)))
+              (null (char-before start))
               (string= " " (string (char-before start))))))))
 
 (defvar haskell-yesod-parse-routes-mode-keywords


### PR DESCRIPTION
I was getting a lot of `error in process filter: Wrong type argument: number-or-marker-p, nil` errors and tracked it to this function.  `.` can appear as the first character of the buffer, so the logic was falling over a touch.

Fixes #1497