### PR TITLE
Improved travis, appveyor build mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: generic
 sudo: required
-dist: trusty
+
+services:
+  - docker
 
 env:
   matrix:
     - TARGET=emacs24
     - TARGET=emacs-snapshot
+    - TARGET=emacs25
     - TARGET=deploy-manual
     - TARGET=check-external
   global:
@@ -19,13 +22,19 @@ matrix:
 install: |
     case "$TARGET" in
       emacs24)
-        sudo apt-get update &&
-        sudo apt-get install --no-install-suggests --no-install-recommends --force-yes emacs24-nox;
+        docker build -t haskell-mode-24 ./emacs-24 &&
+        docker create --name haskell-mode-24 haskell-mode-24 &&
+        docker cp $PWD haskell-mode-24:/root;
+        ;;
+      emacs25)
+        docker build -t haskell-mode-25 ./emacs-25 &&
+        docker create --name haskell-mode-25 haskell-mode-25 &&
+        docker cp $PWD haskell-mode-25:/root;
         ;;
       emacs-snapshot)
-        sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
-        sudo apt-get update &&
-        sudo apt-get install --no-install-suggests --no-install-recommends --force-yes emacs-snapshot;
+        docker build -t haskell-mode-snapshot ./emacs-snapshot &&
+        docker create --name haskell-mode-snapshot haskell-mode-snapshot &&
+        docker cp $PWD haskell-mode-snapshot:/root;
         ;;
       deploy-manual)
         sudo apt-get update &&
@@ -42,10 +51,13 @@ install: |
 script: |
     case "$TARGET" in
       emacs24)
-        EMACS=emacs24 make check;
+        docker start -i haskell-mode-24;
+        ;;
+      emacs25)
+        docker start -i haskell-mode-25;
         ;;
       emacs-snapshot)
-        EMACS=emacs-snapshot make check;
+        docker start -i haskell-mode-snapshot;
         ;;
       deploy-manual)
         EMACS=emacs24 make deploy-manual;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,16 @@
 
 clone_depth: 1
 
-init:
+environment:
+  matrix:
+  - emacs: 24
+  - emacs: 25
 
 install:
-  - ps: Invoke-WebRequest "https://ftp.gnu.org/gnu/emacs/windows/emacs-24.5-bin-i686-mingw32.zip" -OutFile "emacs-24.5-bin-i686-mingw32.zip"
-  - 7z x emacs-24.5-bin-i686-mingw32.zip
-
+  - ps: switch($env:emacs){ 24 {choco install emacs} 25 {choco install emacs64} default {throw "Emacs install fail"}}
+  - choco install ghc
+  - choco install haskell-stack
+  - refreshenv
 
 build_script:
-  - C:\msys64\usr\bin\bash -l -c "cd ${APPVEYOR_BUILD_FOLDER} && make check compile EMACS=./bin/emacs.exe"
-
-test_script:
+  - C:\msys64\usr\bin\bash -l -c "cd ${APPVEYOR_BUILD_FOLDER} && make check"

--- a/emacs-24/Dockerfile
+++ b/emacs-24/Dockerfile
@@ -1,0 +1,14 @@
+# For Emacs 24.x
+FROM ubuntu:rolling
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get install --no-install-suggests --no-install-recommends -y emacs24-nox \
+    && apt-get install -y ghc \
+    && apt-get install -y haskell-stack
+
+WORKDIR /root/haskell-mode
+
+CMD [ "make", "check" ]

--- a/emacs-25/Dockerfile
+++ b/emacs-25/Dockerfile
@@ -1,0 +1,14 @@
+# For Emacs 25.x
+FROM ubuntu:rolling
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get install -y emacs-nox \
+    && apt-get install -y ghc \
+    && apt-get install -y haskell-stack
+
+WORKDIR /root/haskell-mode
+
+CMD ["make", "check"]

--- a/emacs-25/Dockerfile
+++ b/emacs-25/Dockerfile
@@ -11,4 +11,4 @@ RUN apt-get update \
 
 WORKDIR /root/haskell-mode
 
-CMD ["make", "check"]
+CMD [ "make", "check" ]

--- a/emacs-snapshot/Dockerfile
+++ b/emacs-snapshot/Dockerfile
@@ -1,0 +1,17 @@
+# For Emacs snapshot
+FROM ubuntu:rolling
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-elisp/ppa \
+    && apt-get update \
+    && apt-get install --no-install-suggests --no-install-recommends -y emacs-snapshot \
+    && apt-get install -y ghc \
+    && apt-get install -y haskell-stack
+
+WORKDIR /root/haskell-mode
+
+CMD [ "make", "check" ]


### PR DESCRIPTION
+ In travis:
  - We use docker, so it is very flexible to choose distributions etc.
  - Emacs24
  - Emacs25
  - Emacs26 / snapshot
  - GHC 8.0.2

+ Appveyor:
  - Emacs24
  - Emacs25
  - GHC 8.0.2