### PR TITLE
Improve sorting of imports

### DIFF
--- a/haskell-sort-imports.el
+++ b/haskell-sort-imports.el
@@ -89,11 +89,15 @@ within that region."
 
 (defun haskell-sort-imports-goto-group-start ()
   "Go to the start of the import group."
-  (or (and (search-backward "\n\n" nil t 1)
-           (goto-char (+ 2 (line-end-position))))
-      (when (search-backward-regexp "^module " nil t 1)
-        (goto-char (1+ (line-end-position))))
-      (goto-char (point-min))))
+  (when (or (and (search-backward "\n\n" nil t 1)
+                 (goto-char (+ 2 (line-end-position))))
+            (when (search-backward-regexp "^module " nil t 1)
+              (goto-char (1+ (line-end-position))))
+            (goto-char (point-min)))
+    (beginning-of-line)
+    (while (looking-at-p "^[ \t]*--")
+      (forward-line))
+    t))
 
 (defun haskell-sort-imports-at-import ()
   "Are we at an import?"

--- a/tests/haskell-sort-imports-tests.el
+++ b/tests/haskell-sort-imports-tests.el
@@ -77,6 +77,46 @@ import A
 import B
 "))))
 
+(ert-deftest two-rev-with-comment ()
+  (with-temp-buffer
+    (insert "-- A descriptive comment
+import B
+import A
+")
+    (goto-char (point-min))
+    (forward-line)
+    (haskell-sort-imports)
+    (should
+     (equal
+      (buffer-substring-no-properties (point-min) (point-max))
+      "-- A descriptive comment
+import A
+import B
+"))))
+
+(ert-deftest two-rev-block-with-comment ()
+  (with-temp-buffer
+    (insert "import Misc1
+import Misc2
+
+-- A descriptive comment
+import B
+import A
+")
+    (goto-char (point-max))
+    (forward-line -2)
+    (haskell-sort-imports)
+    (should
+     (equal
+      (buffer-substring-no-properties (point-min) (point-max))
+      "import Misc1
+import Misc2
+
+-- A descriptive comment
+import A
+import B
+"))))
+
 (ert-deftest file-structure ()
   (should (with-temp-buffer
             (insert "module A where


### PR DESCRIPTION
I noticed that buffer sorting does not work for cases like this (`_|_` denoting the cursor):

```
module Foo where

import Bar
import Baz

-- Unrelated group of imports
import Mod3
_|_import Mod2
import Mod1
```