### PR TITLE
Better targets

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -785,12 +785,7 @@ inferior GHCi process."
   "Set the build TARGET for cabal REPL."
   (interactive
    (list
-    (completing-read "New build target: "
-                     (haskell-session-get-targets (haskell-process-type))
-                     nil
-                     nil
-                     nil
-                     'haskell-cabal-targets-history)))
+    (haskell-session-choose-target "New build target: " nil 'haskell-cabal-targets-history)))
   (let* ((session haskell-session)
          (old-target (haskell-session-get session 'target)))
     (when session
@@ -801,25 +796,6 @@ inferior GHCi process."
             (when (y-or-n-p "Target changed, restart haskell process? ")
               (haskell-process-start session)))
         (haskell-mode-toggle-interactive-prompt-state t)))))
-
-(defun haskell-session-get-targets (process-type)
-  "Return a list of available targets."
-  (case process-type
-    ('stack-ghci
-     (haskell-session-get-targets-command haskell-process-path-stack "ide" "targets"))
-    (t
-     (haskell-cabal-enum-targets (haskell-process-type)))))
-
-(defun haskell-session-get-targets-command (command &rest args)
-  "Run an external command to obtain a list of available targets."
-  (with-temp-buffer
-    (case (apply #'process-file command nil (current-buffer) t args)
-      (0
-       (cl-remove-if
-        (lambda (line)
-          (string= "" line))
-        (split-string (buffer-string))))
-      (1 nil))))
 
 ;;;###autoload
 (defun haskell-mode-stylish-buffer ()

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -89,9 +89,9 @@ You can create new session using function `haskell-session-make'."
     (progn (set-process-sentinel (haskell-process-process process) 'haskell-process-sentinel)
            (set-process-filter (haskell-process-process process) 'haskell-process-filter))
     (haskell-process-send-startup process)
-    (unless (or (eq 'cabal-repl (haskell-process-type))
-                (eq 'cabal-new-repl (haskell-process-type))
-                   (eq 'stack-ghci (haskell-process-type))) ;; Both "cabal repl" and "stack ghci" set the proper CWD.
+    (unless (memq (haskell-process-type)
+                  ;; These all set the proper CWD.
+                  (list 'cabal-repl 'cabal-new-repl 'stack-ghci))
       (haskell-process-change-dir session
                                   process
                                   (haskell-session-current-dir session)))

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -27,6 +27,8 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'cl))
+
 (require 'cl-lib)
 (require 'haskell-cabal)
 (require 'haskell-customize)
@@ -181,7 +183,7 @@ HISTORY provides the history to `completing-read'."
 (defun haskell-session-get-targets (process-type)
   "Return a list of available targets."
   (case process-type
-    ('stack-ghci
+    (stack-ghci
      (haskell-session-get-targets-command haskell-process-path-stack "ide" "targets"))
     (t
      (haskell-cabal-enum-targets (haskell-process-type)))))

--- a/haskell-session.el
+++ b/haskell-session.el
@@ -27,7 +27,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (require 'cl-lib)
 (require 'haskell-cabal)
@@ -182,7 +182,7 @@ HISTORY provides the history to `completing-read'."
 
 (defun haskell-session-get-targets (process-type)
   "Return a list of available targets."
-  (case process-type
+  (cl-case process-type
     (stack-ghci
      (haskell-session-get-targets-command haskell-process-path-stack "ide" "targets"))
     (t
@@ -191,7 +191,7 @@ HISTORY provides the history to `completing-read'."
 (defun haskell-session-get-targets-command (command &rest args)
   "Run an external command to obtain a list of available targets."
   (with-temp-buffer
-    (case (apply #'process-file command nil (current-buffer) t args)
+    (cl-case (apply #'process-file command nil (current-buffer) t args)
       (0
        (cl-remove-if
         (lambda (line)


### PR DESCRIPTION
Two main changes from this (apart from a little bit of code cleanup):

1. Can now get the list of targets from `stack ide targets`, which should help in multi-package projects

2. When starting a session, the prompt of available targets is presented as well (rather than having to remember them or using the default, the latter of which fails in the case of a package having the same name as an executable)