### PR TITLE
option to disable ':set prompt2" for ghci sessions. ghci>=8.2 breaks

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -49,6 +49,12 @@
   :group 'haskell-interactive
   :type 'boolean)
 
+(defcustom haskell-interactive-set-multiline-prompt
+  t
+  "Issue ':set prompt2' in interactive session. Not supported by ghci >= 8.2"
+  :group 'haskell-interactive
+  :type 'boolean)
+
 ;;;###autoload
 (defun haskell-process-restart ()
   "Restart the inferior Haskell process."
@@ -114,9 +120,9 @@ You can create new session using function `haskell-session-make'."
                                                             '(":set +c"))) ; :type-at in GHC 8+
                                                   "\n"))
           (haskell-process-send-string process ":set prompt \"\\4\"")
-          (haskell-process-send-string process (format ":set prompt2 \"%s\""
-                                                       haskell-interactive-prompt2)))
-
+          (when haskell-interactive-set-multiline-prompt
+            (haskell-process-send-string process (format ":set prompt2 \"%s\""
+                                                         haskell-interactive-prompt2))))
     :live (lambda (process buffer)
             (when (haskell-process-consume
                    process


### PR DESCRIPTION
One of the issues after upgrading to ghc 8.2.1 I had (next to parsing the new default ghc(i) error log messages) was that when starting a new interactive session (stack ghci) it automaticaly issued an `:set prompt2 <prompt>` to the ghci which 8.2.1 no longer accepts and creates a warning.

For now I simply added a new config variable `haskell-interactive-set-multiline-prompt` to disable the `:set prompt2` output.
