### PR TITLE
Hardcoded Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ BATCH = @echo EMACS $@; $(EMACS) $(EFLAGS) --batch -Q -L .
 
 ELFILES := $(filter-out haskell-mode-autoloads.el haskell-mode-pkg.el,$(wildcard *.el))
 
+# fix
+ELFILES := $(filter-out haskell-mode.el,$(ELFILES))
+ELFILES += haskell-mode.el
+
 ELCHECKS := $(wildcard tests/*-tests.el)
 
 AUTOLOADS = haskell-mode-autoloads.el


### PR DESCRIPTION
- Build haskell-mode.el after all.

It should fix building problem

```
error in process sentinel: el-get-installation-failed: el-get: make el-get could not build haskell-mode [make EMACS=/usr/local/Cellar/emacs/25.2/Emacs.app/Contents/MacOS/Emacs all]
error in process sentinel: el-get: make el-get could not build haskell-mode [make EMACS=/usr/local/Cellar/emacs/25.2/Emacs.app/Contents/MacOS/Emacs all]
```

```
EMACS check-emacs-version
Using EMACS = /usr/local/Cellar/emacs/25.2/Emacs.app/Contents/MacOS/Emacs, version = 25.2.1
mkdir build-25.2.1
EMACS build-25.2.1/ghc-core.elc
Checking ghc-core.el...
Scanning ghc-core.el...
Scanning ghc-core.el...done
Checking ghc-core.el...OK
EMACS build-25.2.1/ghci-script-mode.elc
Checking ghci-script-mode.el...
Scanning ghci-script-mode.el...
Scanning ghci-script-mode.el...done
Checking ghci-script-mode.el...OK
EMACS build-25.2.1/haskell-align-imports.elc
Checking haskell-align-imports.el...
Scanning haskell-align-imports.el...
Scanning haskell-align-imports.el...done
Checking haskell-align-imports.el...OK
EMACS build-25.2.1/haskell-c2hs.elc
Checking haskell-c2hs.el...
Scanning haskell-c2hs.el...
Scanning haskell-c2hs.el...done
Checking haskell-c2hs.el...OK
EMACS build-25.2.1/haskell-cabal.elc
Checking haskell-cabal.el...
Scanning haskell-cabal.el...
Scanning haskell-cabal.el...done
Checking haskell-cabal.el...OK
EMACS build-25.2.1/haskell-collapse.elc
Checking haskell-collapse.el...
Scanning haskell-collapse.el...
Scanning haskell-collapse.el...done
Checking haskell-collapse.el...OK
EMACS build-25.2.1/haskell-commands.elc
Checking haskell-commands.el...
Scanning haskell-commands.el...
Scanning haskell-commands.el...done
Checking haskell-commands.el...OK
EMACS build-25.2.1/haskell-compat.elc
Checking haskell-compat.el...
Scanning haskell-compat.el...
Scanning haskell-compat.el...done
Checking haskell-compat.el...OK
EMACS build-25.2.1/haskell-compile.elc
Checking haskell-compile.el...
Scanning haskell-compile.el...
Scanning haskell-compile.el...done
Checking haskell-compile.el...OK
EMACS build-25.2.1/haskell-complete-module.elc
Checking haskell-complete-module.el...
Scanning haskell-complete-module.el...
Scanning haskell-complete-module.el...done
Checking haskell-complete-module.el...OK
EMACS build-25.2.1/haskell-completions.elc
Checking haskell-completions.el...
Scanning haskell-completions.el...
Scanning haskell-completions.el...done
Checking haskell-completions.el...OK
EMACS build-25.2.1/haskell-customize.elc
Checking haskell-customize.el...
Scanning haskell-customize.el...
Scanning haskell-customize.el...done
Checking haskell-customize.el...OK
EMACS build-25.2.1/haskell-debug.elc
Checking haskell-debug.el...
Scanning haskell-debug.el...
Scanning haskell-debug.el...done
Checking haskell-debug.el...OK
EMACS build-25.2.1/haskell-decl-scan.elc
Checking haskell-decl-scan.el...
Scanning haskell-decl-scan.el...
Scanning haskell-decl-scan.el...done
Checking haskell-decl-scan.el...OK
EMACS build-25.2.1/haskell-doc.elc
Checking haskell-doc.el...
Scanning haskell-doc.el...
Scanning haskell-doc.el...done
Checking haskell-doc.el...OK
EMACS build-25.2.1/haskell-font-lock.elc
Checking haskell-font-lock.el...
Scanning haskell-font-lock.el...
Scanning haskell-font-lock.el...done
Checking haskell-font-lock.el...OK
EMACS build-25.2.1/haskell-ghc-support.elc
Checking haskell-ghc-support.el...
Scanning haskell-ghc-support.el...
Scanning haskell-ghc-support.el...done
Checking haskell-ghc-support.el...OK
EMACS build-25.2.1/haskell-hoogle.elc
Checking haskell-hoogle.el...
Scanning haskell-hoogle.el...
Scanning haskell-hoogle.el...done
Checking haskell-hoogle.el...OK
EMACS build-25.2.1/haskell-indent.elc
Checking haskell-indent.el...
Scanning haskell-indent.el...
Scanning haskell-indent.el...done
Checking haskell-indent.el...OK
EMACS build-25.2.1/haskell-indentation.elc
Checking haskell-indentation.el...
Scanning haskell-indentation.el...
Scanning haskell-indentation.el...done
Checking haskell-indentation.el...OK
EMACS build-25.2.1/haskell-interactive-mode.elc
Checking haskell-interactive-mode.el...
Scanning haskell-interactive-mode.el...
Scanning haskell-interactive-mode.el...done
Checking /Users/netsu/Dropbox/Mackup/.emacs.d/el-get/haskell-mode/haskell.el...
Checking /Users/netsu/Dropbox/Mackup/.emacs.d/el-get/haskell-mode/haskell.el...OK
Checking haskell-interactive-mode.el...OK
EMACS build-25.2.1/haskell-lexeme.elc
Checking haskell-lexeme.el...
Scanning haskell-lexeme.el...
Scanning haskell-lexeme.el...done
Checking haskell-lexeme.el...OK
EMACS build-25.2.1/haskell-load.elc
Checking haskell-load.el...
Scanning haskell-load.el...
Scanning haskell-load.el...done
Checking haskell-load.el...OK
EMACS build-25.2.1/haskell-menu.elc
Checking haskell-menu.el...
Scanning haskell-menu.el...
Scanning haskell-menu.el...done
Checking haskell-menu.el...OK
EMACS build-25.2.1/haskell-mode.elc
Checking haskell-mode.el...
Scanning haskell-mode.el...
Scanning haskell-mode.el...done
Checking /Users/netsu/Dropbox/Mackup/.emacs.d/el-get/haskell-mode/haskell-commands.el...
Checking /Users/netsu/Dropbox/Mackup/.emacs.d/el-get/haskell-mode/haskell-commands.el...OK
Checking haskell-mode.el...OK
EMACS build-25.2.1/haskell-modules.elc
Checking haskell-modules.el...
Scanning haskell-modules.el...
Scanning haskell-modules.el...done
Checking haskell-modules.el...OK
EMACS build-25.2.1/haskell-move-nested.elc
Checking haskell-move-nested.el...
Scanning haskell-move-nested.el...
Scanning haskell-move-nested.el...done
Checking haskell-move-nested.el...OK
EMACS build-25.2.1/haskell-navigate-imports.elc
Checking haskell-navigate-imports.el...
Scanning haskell-navigate-imports.el...
Scanning haskell-navigate-imports.el...done
Checking haskell-navigate-imports.el...OK
EMACS build-25.2.1/haskell-presentation-mode.elc
Checking haskell-presentation-mode.el...
Scanning haskell-presentation-mode.el...
Scanning haskell-presentation-mode.el...done
Checking haskell-presentation-mode.el...OK
EMACS build-25.2.1/haskell-process.elc
Checking haskell-process.el...
Scanning haskell-process.el...
Scanning haskell-process.el...done
Checking haskell-process.el...OK
EMACS build-25.2.1/haskell-repl.elc
Checking haskell-repl.el...
Scanning haskell-repl.el...
Scanning haskell-repl.el...done
Checking haskell-repl.el...OK
EMACS build-25.2.1/haskell-sandbox.elc
Checking haskell-sandbox.el...
Scanning haskell-sandbox.el...
Scanning haskell-sandbox.el...done
Checking haskell-sandbox.el...OK
EMACS build-25.2.1/haskell-session.elc
Checking haskell-session.el...
Scanning haskell-session.el...
Scanning haskell-session.el...done
Checking haskell-session.el...OK
EMACS build-25.2.1/haskell-sort-imports.elc
Checking haskell-sort-imports.el...
Scanning haskell-sort-imports.el...
Scanning haskell-sort-imports.el...done
Checking haskell-sort-imports.el...OK
EMACS build-25.2.1/haskell-string.elc
Checking haskell-string.el...
Scanning haskell-string.el...
Scanning haskell-string.el...done
Checking haskell-string.el...OK
EMACS build-25.2.1/haskell-unicode-input-method.elc
Checking haskell-unicode-input-method.el...
Scanning haskell-unicode-input-method.el...
Scanning haskell-unicode-input-method.el...done
Checking haskell-unicode-input-method.el...OK
EMACS build-25.2.1/haskell-utils.elc
Checking haskell-utils.el...
Scanning haskell-utils.el...
Scanning haskell-utils.el...done
Checking haskell-utils.el...OK
EMACS build-25.2.1/haskell.elc
Checking haskell.el...
Scanning haskell.el...
Scanning haskell.el...done
Checking haskell.el...OK
EMACS build-25.2.1/highlight-uses-mode.elc
Checking highlight-uses-mode.el...
Scanning highlight-uses-mode.el...
Scanning highlight-uses-mode.el...done
Checking highlight-uses-mode.el...OK
EMACS build-25.2.1/inf-haskell.elc
Checking inf-haskell.el...
Scanning inf-haskell.el...
Scanning inf-haskell.el...done
Checking inf-haskell.el...OK
EMACS build-25.2.1/w3m-haddock.elc
Checking w3m-haddock.el...
Scanning w3m-haddock.el...
Scanning w3m-haddock.el...done
Checking ext:/Users/netsu/Dropbox/Mackup/.emacs.d/el-get/haskell-mode/w3m.el...
Checking ext:/Users/netsu/Dropbox/Mackup/.emacs.d/el-get/haskell-mode/w3m.el...skipping external file
Checking w3m-haddock.el...OK
touch build-25.2.1/build-flag
EMACS haskell-mode-autoloads.el
EMACS haskell-mode-autoloads.el
LANG=en_US.UTF-8 makeinfo  -o haskell-mode.info doc/haskell-mode.texi
doc/haskell-mode.texi:5: warning: unrecognized encoding name `UTF-8'.
doc/haskell-mode.texi:1153: warning: ignoring stray text `0.3 0.7' after @multitable.
doc/haskell-mode.texi:1154: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1156: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1159: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1162: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1165: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1168: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1171: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1174: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1177: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1180: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1183: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1186: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1189: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1192: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1195: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1198: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1201: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1204: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1207: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1210: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1213: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1216: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1219: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1222: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1225: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1228: Too many columns in multitable item (max 0).
doc/haskell-mode.texi:1467: warning: `.' or `,' must follow @xref, not `f'.
doc/haskell-mode.texi:2859: Unknown command `atchar'.
doc/haskell-mode.texi:2859: Misplaced {.
doc/haskell-mode.texi:2859: Misplaced }.
doc/haskell-mode.texi:2874: Unknown command `atchar'.
doc/haskell-mode.texi:2874: Misplaced {.
doc/haskell-mode.texi:2874: Misplaced }.
makeinfo: Removing output file `haskell-mode.info' due to errors; use --force to preserve.
make: *** [haskell-mode.info] Error 1
```