### PR TITLE
Fix haskell-process-load-complete for GHC 8.2.1

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -107,6 +107,14 @@ actual Emacs buffer of the module being loaded."
   (let* ((ok (cond
               ((haskell-process-consume
                 process
+                "Ok, \\([0-9]+\\) modules? loaded\\.$")
+               t)
+              ((haskell-process-consume
+                process
+                "Failed, \\([0-9]+\\) modules? loaded\\.$")
+               nil)
+              ((haskell-process-consume
+                process
                 "Ok, modules loaded: \\(.+\\)\\.$")
                t)
               ((haskell-process-consume

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -107,11 +107,11 @@ actual Emacs buffer of the module being loaded."
   (let* ((ok (cond
               ((haskell-process-consume
                 process
-                "Ok, \\([0-9]+\\) modules? loaded\\.$")
+                "Ok, \\(?:[0-9]+\\) modules? loaded\\.$")
                t)
               ((haskell-process-consume
                 process
-                "Failed, \\([0-9]+\\) modules? loaded\\.$")
+                "Failed, \\(?:[0-9]+\\) modules? loaded\\.$")
                nil)
               ((haskell-process-consume
                 process


### PR DESCRIPTION
At some point by GHC 8.2.1, the text for successful load of a module
into ghci changed. This patch allows for the new format, in addition
to the existing ones.