### PR TITLE
Provide customization option `haskell-process-show-overlays'

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -200,6 +200,13 @@ See `haskell-process-do-cabal' for more details."
   :type 'boolean
   :group 'haskell-interactive)
 
+(defcustom haskell-process-show-overlays
+  t
+  "Show in-buffer overlays for errors/warnings.
+Flycheck users might like to disable this."
+  :type 'boolean
+  :group 'haskell-interactive)
+
 (defcustom haskell-notify-p
   nil
   "Notify using notifications.el (if loaded)?"

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -532,7 +532,7 @@ When MODULE-BUFFER is non-NIL, paint error overlays."
                         (concat file ":" location-raw ": x")))
              (line (plist-get location :line))
              (col1 (plist-get location :col)))
-        (when module-buffer
+        (when (and module-buffer haskell-process-show-overlays)
           (haskell-check-paint-overlay
            module-buffer
            (string= (file-truename (buffer-file-name module-buffer))


### PR DESCRIPTION
When using haskell-interactive-mode's REPL support in environments that already have in-buffer flycheck support (e.g. `intero', `dante'), the redundant overlays become problematic and confusing for users. This commit adds a customization option to suppress haskell-mode's overlays so that users with such set-ups can choose to see only their flycheck errors.

Submitting this as a PR for visibility, but will assume this is okay to merge in a day or two if no other maintainers have an objection, since it seems fairly uncontroversial.