### PR TITLE
remove unused variable `haskell-indent-spaces`

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -404,8 +404,7 @@ properties; such as an indentation mode) that don't know what
 extensions to use can use this variable. Examples: hlint,
 hindent, structured-haskell-mode, tool-de-jour, etc.
 
-You can set this per-project with a .dir-locals.el file, in the
-same vein as `haskell-indent-spaces'."
+You can set this per-project with a .dir-locals.el file"
   :group 'haskell
   :type '(repeat 'string))
 

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -1020,11 +1020,6 @@ list marker of some kind), and end of the obstacle."
 (defvar haskell-saved-check-command nil
   "Internal use.")
 
-(defcustom haskell-indent-spaces 2
-  "Number of spaces to indent inwards."
-  :group 'haskell
-  :type 'integer)
-
 ;; Like Python.  Should be abstracted, sigh.
 (defun haskell-check (command)
   "Check a Haskell file (default current buffer's file).


### PR DESCRIPTION
The variables actually used to customize indentation are
`haskell-indentation-*-offset`.