### PR TITLE
fix `haskell-process-extract-modules' for ghc 8.2

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -332,7 +332,7 @@ list of modules where missed IDENT was found."
 (defun haskell-process-extract-modules (buffer)
   "Extract the modules from the process buffer."
   (let* ((modules-string (match-string 1 buffer))
-         (modules (split-string modules-string ", ")))
+         (modules (and modules-string (split-string modules-string ", "))))
     (cons modules modules-string)))
 
 ;;;###autoload


### PR DESCRIPTION
ghc 8.2 reports only a number of loaded modules https://github.com/haskell/haskell-mode/commit/eac5567e2a47be1272ed73b19c43025a457fa416