### PR TITLE
limit ubuntu to zesty for emacs24

### DIFF
--- a/emacs-24/Dockerfile
+++ b/emacs-24/Dockerfile
@@ -1,5 +1,5 @@
 # For Emacs 24.x
-FROM ubuntu:rolling
+FROM ubuntu:zesty
 
 USER root
 


### PR DESCRIPTION
There isn't any emacs24 on later versions of ubuntu