### PR TITLE
Log stderr into separate buffer

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -832,7 +832,11 @@ output.  If CMD fails the buffer remains unchanged."
                   (insert-file-contents out-file nil nil nil t))
               (progn
                 ;; non-null stderr, command must have failed
-                (message "Error: %s ended with errors, leaving buffer alone" cmd)
+                (with-current-buffer
+                    (get-buffer-create "*haskell-mode*")
+                  (insert-file-contents err-file)
+                  (buffer-string))
+                (message "Error: %s ended with errors, leaving buffer alone, see *haskell-mode* buffer for stderr" cmd)
                 (with-temp-buffer
                   (insert-file-contents err-file)
                   ;; use (warning-minimum-level :debug) to see this


### PR DESCRIPTION
I have come with similar use case as in #651

I just want to be able to see the `stylish-haskell` stderr because it could fail with errors like:

```
stylish-haskell: Language.Haskell.Stylish.Editor.applyChanges: refusing to make overlapping changes on lines 59-60, 59-60
CallStack (from HasCallStack):
  error, called at lib/Language/Haskell/Stylish/Editor.hs:46:28 in stylish-haskell-0.8.1.0-Dqoruy2bCD1Kn6ytiOdLeZ:Language.Haskell.Stylish.Editor
```

59-60 lines in my code:

> Declaration uses unicodeSyntax but it is not consistent: `... Integer -> IO ...`

``` haskell
getLimitedRange ∷ Integer → Maybe Integer → Maybe Integer -> IO (UTCTime, UTCTime)
getLimitedRange limit fromTime toTime = do ...
```

This kind of errors is not covered by flycheck and running `stylish-haskell File.hs` every time I see `Error: stylish-haskell ended with errors, leaving buffer alone` in minibuffer is just boring.

_I don't know much about elisp, sorry for any strange things in the code :)_