### PR TITLE
[security] Don't make functions safe file-local values

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -89,8 +89,7 @@ a per-project basis."
   :group 'haskell-interactive
   :type '(choice
           (function-item :tag "None" :value identity)
-          (function :tag "Custom function"))
-  :safe 'functionp)
+          (function :tag "Custom function")))
 
 (defcustom haskell-ask-also-kill-buffers
   t


### PR DESCRIPTION
Remove `:safe 'functionp` from the definition of the `haskell-process-wrapper-function` Customize variable.  

Marking values which validate `functionp` as "safe" meant that any file could potentially execute any code on the Emacs instance it's been open.  This commit removes this possibility.  

Thanks!