### PR TITLE
Add display of SVG images in REPL.

### DIFF
--- a/doc/haskell-mode.texi
+++ b/doc/haskell-mode.texi
@@ -1939,6 +1939,43 @@ Or @kbd{C-c C-v}:
 There you can choose `haskell-mode`, for example, to pretty print the
 output as Haskell.
 
+@subsection @acronym{SVG} images rendering
+
+@cindex Rendering SVG images
+@cindex SVG images, rendering
+@cindex Images, rendering SVG images
+
+If you are working on @acronym{SVG} images, you can instruct Emacs to
+render the image as the output of an image producing command at the
+@acronym{REPL}@.
+
+The following example uses the @code{diamgrams} library with the default
+@acronym{SVG} backend to produce a circle:
+
+@example
+    @{-# LANGUAGE OverloadedStrings #-@}
+
+    import Diagrams.Prelude
+    import Diagrams.Backend.SVG
+
+    myCircle :: Diagram B
+    myCircle = circle 1 # lc purple # fc yellow
+
+    circle = renderDia SVG (SVGOptions (mkWidth 250) Nothing "" [] True) myCircle
+@end example
+
+@findex haskell-svg-toggle-render-images
+
+After enabling @acronym{SVG} rendering with @kbd{M-x
+haskell-svg-toggle-render-images}, if you load the above code and type
+@code{circle} at the @acronym{REPL}, you will see the rendered circle
+instead of the @acronym{XML} representation of the image.
+
+@vindex haskell-svg-render-images
+
+This feature can be enabled by default by setting the customization
+variable @code{haskell-svg-render-images} to a non-nil value.
+
 @subsection Presentations
 
 If you have the @file{present} package installed, you can use the following

--- a/haskell-repl.el
+++ b/haskell-repl.el
@@ -20,6 +20,7 @@
 (require 'cl-lib)
 (require 'haskell-interactive-mode)
 (require 'haskell-collapse)
+(require 'haskell-svg)
 
 (defun haskell-interactive-handle-expr ()
   "Handle an inputted expression at the REPL."
@@ -116,7 +117,7 @@
     (let ((inhibit-read-only t))
       (delete-region (1+ haskell-interactive-mode-prompt-start) (point))
       (goto-char (point-max))
-      (insert (haskell-fontify-as-mode text
+      (insert (haskell-fontify-as-mode (haskell-svg-maybe-render-images text)
                                        haskell-interactive-mode-eval-mode))
       (when haskell-interactive-mode-collapse
         (haskell-hide-toggle)))))

--- a/haskell-svg.el
+++ b/haskell-svg.el
@@ -1,0 +1,66 @@
+;;; haskell-svg.el --- SVG Rendering -*- lexical-binding: t -*-
+
+;; Copyright (c) 2018 Federico Beffa. All rights reserved.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(defcustom haskell-svg-render-images nil
+  "Replace SVG image text with actual images."
+  :group 'haskell-interactive
+  :type 'boolean)
+
+(defconst haskell-svg-supported (image-type-available-p 'svg)
+  "Defines if SVG images are supported by this instance of Emacs.")
+
+
+
+(defun haskell-svg-render-images-p ()
+  "Shall we render SVG images?"
+  (and haskell-svg-supported (display-images-p) haskell-svg-render-images))
+
+(defun haskell-svg-maybe-render-images (text)
+  "Render SVG images if desired and supported, or terurn the
+input unmodified."
+  (if (haskell-svg-render-images-p)
+      (haskell-svg-render-images text)
+    text))
+
+(defun haskell-svg-render-images (text)
+  "Replace an SVG image text with an actual image."
+  (with-temp-buffer
+      (insert text)
+      (goto-char (point-min))
+      (when (re-search-forward
+             "\"?<\\?xml\\(.\\|\n\\|\r\\)* PUBLIC \"-//W3C//DTD SVG [0-9]\.[0-9]//EN\\(.\\|\n\\|\r\\)*</svg>\"?"
+             nil t)
+        (let ((svg-string (match-string 0))
+              (begin (match-beginning 0))
+              (end (match-end 0)))
+          (delete-region begin end)
+          (goto-char begin)
+          (insert-image (create-image svg-string nil t) "SVG image")))
+      (buffer-substring (point-min) (point-max))))
+
+(defun haskell-svg-toggle-render-images ()
+  "Toggle rendering of SVG images at the REPL output."
+  (interactive)
+  (setq haskell-svg-render-images (not haskell-svg-render-images)))
+
+
+
+(provide 'haskell-svg)
+
+;;; haskell-svg.el ends here


### PR DESCRIPTION
When working on SVG images, it's sometimes useful to see them directly as the REPL output within Emacs.
