### PR TITLE
Add support for `signature`s and .hsig files

### DIFF
--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -118,6 +118,7 @@ This list comes from GHC documentation (URL
    "proc"
    "qualified"
    "rec"
+   "signature"
    "then"
    "type family"
    "type instance"

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -93,7 +93,7 @@ be disabled at that position."
   '("case" "class" "data" "default" "deriving" "do"
     "else" "if" "import" "in" "infix" "infixl"
     "infixr" "instance" "let" "module" "mdo" "newtype" "of"
-    "rec" "pattern" "proc" "then" "type" "where" "_")
+    "rec" "pattern" "proc" "signature" "then" "type" "where" "_")
   "Identifiers treated as reserved keywords in Haskell."
   :group 'haskell-appearance
   :type '(repeat string))

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -126,7 +126,7 @@
 (defconst haskell-indent-start-keywords-re
   (concat "\\<"
           (regexp-opt '("class" "data" "import" "infix" "infixl" "infixr"
-                        "instance" "module" "newtype" "primitive" "type") t)
+                        "instance" "module" "newtype" "primitive" "signature" "type") t)
           "\\>")
   "Regexp for keywords to complete when standing at the first word of a line.")
 

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -517,16 +517,17 @@ and indent when all of the following are true:
   "Translation from UnicodeSyntax tokens to their ASCII representation.")
 
 (defconst haskell-indentation-toplevel-list
-  `(("module"   . haskell-indentation-module)
-    ("data"     . haskell-indentation-data)
-    ("type"     . haskell-indentation-data)
-    ("newtype"  . haskell-indentation-data)
-    ("import"   . haskell-indentation-import)
-    ("foreign"  . haskell-indentation-foreign)
-    ("where"    . haskell-indentation-toplevel-where)
-    ("class"    . haskell-indentation-class-declaration)
-    ("instance" . haskell-indentation-class-declaration)
-    ("deriving" . haskell-indentation-deriving))
+  `(("module"    . haskell-indentation-module)
+    ("signature" . haskell-indentationmodule)
+    ("data"      . haskell-indentation-data)
+    ("type"      . haskell-indentation-data)
+    ("newtype"   . haskell-indentation-data)
+    ("import"    . haskell-indentation-import)
+    ("foreign"   . haskell-indentation-foreign)
+    ("where"     . haskell-indentation-toplevel-where)
+    ("class"     . haskell-indentation-class-declaration)
+    ("instance"  . haskell-indentation-class-declaration)
+    ("deriving"  . haskell-indentation-deriving))
   "Alist of toplevel keywords with associated parsers.")
 
 (defconst haskell-indentation-type-list
@@ -1217,7 +1218,7 @@ line."
 
 (defun haskell-indentation-peek-token ()
   "Return token starting at point."
-  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|rec\\|do\\|proc\\|case\\|of\\|where\\|module\\|deriving\\|import\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
+  (cond ((looking-at "\\(if\\|then\\|else\\|let\\|in\\|mdo\\|rec\\|do\\|proc\\|case\\|of\\|where\\|module\\|signature\\|deriving\\|import\\|data\\|type\\|newtype\\|class\\|instance\\)\\([^[:alnum:]'_]\\|$\\)")
          (match-string-no-properties 1))
         ((looking-at "[][(){}[,;]")
          (match-string-no-properties 0))

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -518,7 +518,7 @@ and indent when all of the following are true:
 
 (defconst haskell-indentation-toplevel-list
   `(("module"    . haskell-indentation-module)
-    ("signature" . haskell-indentationmodule)
+    ("signature" . haskell-indentation-module)
     ("data"      . haskell-indentation-data)
     ("type"      . haskell-indentation-data)
     ("newtype"   . haskell-indentation-data)

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -989,6 +989,8 @@ list marker of some kind), and end of the obstacle."
 ;;;###autoload
 (add-to-list 'auto-mode-alist        '("\\.[gh]s\\'" . haskell-mode))
 ;;;###autoload
+(add-to-list 'auto-mode-alist        '("\\.hsig\\'" . haskell-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist        '("\\.l[gh]s\\'" . literate-haskell-mode))
 ;;;###autoload
 (add-to-list 'auto-mode-alist        '("\\.hsc\\'" . haskell-mode))


### PR DESCRIPTION
This adds font-lock, indentation and recognition for GHCs Backpack signatures. @purcell 