### PR TITLE
Fix compilation error

### DIFF
--- a/ghc-core.el
+++ b/ghc-core.el
@@ -45,6 +45,9 @@
   :type 'string
   :group 'ghc-core)
 
+(define-obsolete-variable-alias 'ghc-core-create-options 'ghc-core-program-args
+  "haskell-mode 13.7")
+
 (defcustom ghc-core-program-args
   '("-O2")
   "Additional options to be passed to GHC when generating core output.
@@ -65,9 +68,6 @@ The following `-ddump-simpl` options might be of interest:
 See `M-x manual-entry RET ghc' for more details."
   :type '(repeat (string :tag "Argument"))
   :group 'ghc-core)
-
-(define-obsolete-variable-alias 'ghc-core-create-options 'ghc-core-program-args
-  "haskell-mode 13.7")
 
 (defun ghc-core-clean-region (start end)
   "Remove commonly ignored annotations and namespace prefixes

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -118,12 +118,12 @@ The format should be the same as for `compilation-error-regexp-alist'.")
 ;;; -> Make font lock work for strings, directories, hyperlinks
 ;;; -> Make font lock work for key words???
 
+(defvaralias 'inferior-haskell-mode-map 'inf-haskell-map)
+
 (defvar inf-haskell-map
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-c\C-d" 'comint-kill-subjob)
     map))
-
-(defvaralias 'inferior-haskell-mode-map 'inf-haskell-map)
 
 (define-derived-mode inferior-haskell-mode comint-mode "Inf-Haskell"
   "Major mode for interacting with an inferior Haskell process."


### PR DESCRIPTION
fix #1600 

## Environment
```
This is GNU Emacs 27.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.22.30)
 of 2018-06-09
```

## Errors

`make EMACS=/usr/local/bin/emacs all` give two errors.

first is #1600  and second is below. this PR fix these errors.

```
In toplevel form:
ghc-core.el:69:1:Error: Alias for ‘ghc-core-program-args’ should be declared before its referent
```

