### PR TITLE
support ANSI colours in the compilation buffer

### DIFF
--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -28,6 +28,7 @@
 
 (require 'compile)
 (require 'haskell-cabal)
+(require 'ansi-color)
 
 ;;;###autoload
 (defgroup haskell-compile nil
@@ -59,6 +60,11 @@ The `%s' placeholder is replaced by the current buffer's filename."
 (defcustom haskell-compile-ghc-filter-linker-messages
   t
   "Filter out unremarkable \"Loading package...\" linker messages during compilation."
+  :group 'haskell-compile
+  :type 'boolean)
+
+(defcustom haskell-compile-color nil
+  "When non-nil will render ANSI color sequences correctly."
   :group 'haskell-compile
   :type 'boolean)
 
@@ -100,7 +106,12 @@ This is a child of `compilation-mode-map'.")
     (delete-matching-lines "^ *Loading package [^ \t\r\n]+ [.]+ linking [.]+ done\\.$"
                            (save-excursion (goto-char compilation-filter-start)
                                            (line-beginning-position))
-                           (point))))
+                           (point)))
+
+  (when haskell-compile-color
+    (read-only-mode -1)
+    (ansi-color-apply-on-region compilation-filter-start (point-max))
+    (read-only-mode 1)))
 
 (define-compilation-mode haskell-compilation-mode "HsCompilation"
   "Haskell/GHC specific `compilation-mode' derivative.

--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -63,11 +63,6 @@ The `%s' placeholder is replaced by the current buffer's filename."
   :group 'haskell-compile
   :type 'boolean)
 
-(defcustom haskell-compile-color nil
-  "When non-nil will render ANSI color sequences correctly."
-  :group 'haskell-compile
-  :type 'boolean)
-
 (defconst haskell-compilation-error-regexp-alist
   `((,(concat
        "^ *\\(?1:[^\t\r\n]+?\\):"
@@ -108,10 +103,8 @@ This is a child of `compilation-mode-map'.")
                                            (line-beginning-position))
                            (point)))
 
-  (when haskell-compile-color
-    (read-only-mode -1)
-    (ansi-color-apply-on-region compilation-filter-start (point-max))
-    (read-only-mode 1)))
+  (let ((inhibit-read-only t))
+    (ansi-color-apply-on-region compilation-filter-start (point-max))))
 
 (define-compilation-mode haskell-compilation-mode "HsCompilation"
   "Haskell/GHC specific `compilation-mode' derivative.


### PR DESCRIPTION
For example, when tasty is called with `--color=always` // @feuerbach

Disabled by default to avoid any performance impact, but perhaps we can do a test cycle and if people like it maybe turn it on by default?

BTW, I think there is a bug in Emacs... I had to use `(point-max)` but the docs said `(point)` should work.

![2018-09-02-004013_1918x1078_scrot](https://user-images.githubusercontent.com/1914041/44950783-c3c2c500-ae48-11e8-85f5-4368ebbf6555.png)
