### PR TITLE
failed tasty tests are errors

### DIFF
--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -78,8 +78,8 @@ The `%s' placeholder is replaced by the current buffer's filename."
      1 2 4 0) ;; info locus
 
     ;; failed tasty tests
-    ;; error, called at src/Course/State.hs:42:3 in
-    (".*error, called at \\(.*\\):\\([0-9]+\\):\\([0-9]+\\) in .*" 1 2 3 2 1)
+    (".*error, called at \\(.*\\.hs\\):\\([0-9]+\\):\\([0-9]+\\) in .*" 1 2 3 2 1)
+    (" +\\(.*\\.hs\\):\\([0-9]+\\):$" 1 2 nil 2 1)
 
     ;; this is the weakest pattern as it's subject to line wrapping et al.
     (" at \\(?1:[^ \t\r\n]+\\):\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)\\(?:-\\(?5:[0-9]+\\)\\)?[)]?$"

--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -77,6 +77,10 @@ The `%s' placeholder is replaced by the current buffer's filename."
     ("^    \\(?:Declared at:\\|            \\) \\(?1:[^ \t\r\n]+\\):\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)$"
      1 2 4 0) ;; info locus
 
+    ;; failed tasty tests
+    ;; error, called at src/Course/State.hs:42:3 in
+    (".*error, called at \\(.*\\):\\([0-9]+\\):\\([0-9]+\\) in .*" 1 2 3 2 1)
+
     ;; this is the weakest pattern as it's subject to line wrapping et al.
     (" at \\(?1:[^ \t\r\n]+\\):\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)\\(?:-\\(?5:[0-9]+\\)\\)?[)]?$"
      1 2 (4 . 5) 0)) ;; info locus


### PR DESCRIPTION
follow up to #1608 (ansi colours included in this screenshot to show them playing well together)

Note that `next-error` (i.e. jump to error) works as expected... and everything you see that is underlined is clickable, if you are so inclined as to use something as clumsy as a mouse :stuck_out_tongue_closed_eyes: 

![2018-09-02-005739_1918x1078_scrot](https://user-images.githubusercontent.com/1914041/44950865-3cc31c00-ae4b-11e8-882e-594e2c7d38c8.png)