### PR TITLE
Fix haskell-process-load-complete for ghc 8.4+

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -107,15 +107,11 @@ actual Emacs buffer of the module being loaded."
   (let* ((ok (cond
               ((haskell-process-consume
                 process
-                "Ok, \\(?:[0-9]+\\) modules? loaded\\.$")
-               t)
-               ((haskell-process-consume
-                process
-                "Ok, \\(?:[a-z]+\\) module loaded\\.$") ;; for ghc 8.4
+                "Ok, \\(?:[a-z0-9]+\\) modules? loaded\\.$")
                t)
               ((haskell-process-consume
                 process
-                "Failed, \\(?:[0-9]+\\) modules? loaded\\.$")
+                "Failed, \\(?:[a-z0-9]+\\) modules? loaded\\.$")
                nil)
               ((haskell-process-consume
                 process


### PR DESCRIPTION
Newer GHC versions will emit messages containing English words for numbers in place of Latin script numerals, e.g. "Ok, five modules loaded." instead of "Ok, 5 modules loaded."; a regex meant to match such messages is updated in accordance. This fixes commands such as `haskell-process-load-file-complete`, which were failing due to no regex matching the emitted message.