### PR TITLE
Fix lexer to read ':' as character

### DIFF
--- a/haskell-lexeme.el
+++ b/haskell-lexeme.el
@@ -218,7 +218,7 @@ only escape sequences defined in Haskell Report.")
 
 (defconst haskell-lexeme--char-literal-rx
   (rx-to-string `(: (group "'")
-                    (| (: (group (regexp "[[:alpha:]_([]")) (group "'")) ; exactly one char
+                    (| (: (group (regexp "[[:alpha:]_:([]")) (group "'")) ; exactly one char
                        (: (group (| (regexp "\\\\[^\n][^'\n]*") ; allow quote just after first backslash
                                     (regexp "[^[:alpha:]_:(['\n][^'\n]*")))
                           (| (group "'") "\n" (regexp "\\'"))))))

--- a/tests/haskell-lexeme-tests.el
+++ b/tests/haskell-lexeme-tests.el
@@ -184,6 +184,16 @@ buffer."
    '("'D'")
    '("'D'")))
 
+(ert-deftest haskell-lexeme-char-literal-5 ()
+  (check-lexemes
+   '("':'")
+   '("':'")))
+
+(ert-deftest haskell-lexeme-char-literal-6 ()
+  (check-lexemes
+   '("(':')")
+   '("(" "':'" ")")))
+
 (ert-deftest haskell-lexeme-string-literal-1 ()
   (check-lexemes
    '("\"\\   \\\"")


### PR DESCRIPTION
This PR fixes issue https://github.com/haskell/haskell-mode/issues/1615. Another related issue (now resolved) is https://github.com/haskell/haskell-mode/issues/1615. The character lexeme regex does not take into account the single colon character, which caused haskell-mode to interpret it as the type operator `':` (enabled with `DataKinds` and `TypeOperators`). This generally did not cause any issues, however in my case (in a parsing function), if `':'` was followed by a closed paren it confused the lexer and caused the rest of the lines to be indented the wrong way (also notice the red closing quote):

![screenshot from 2018-11-20 18-31-38](https://user-images.githubusercontent.com/16580246/48794721-ae945e80-ecf2-11e8-9061-6fbd009458c2.png)
