### PR TITLE
Fix for "Unexpected output.." when modules load failed on GHC 8.6.3

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -119,6 +119,10 @@ actual Emacs buffer of the module being loaded."
                nil)
               ((haskell-process-consume
                 process
+                "Failed, \\(?:[a-z]+\\) modules? loaded\\.$") ;; ghc 8.6.3 says so
+               nil)
+              ((haskell-process-consume
+                process
                 "Ok, modules loaded: \\(.+\\)\\.$")
                t)
               ((haskell-process-consume


### PR DESCRIPTION
Looks like there was similar fix for successful modules load with GHC 8.4 (commit e6169a6597c79e53aa3632c8455c5ba10fa2ba74). I've just upgraded to 8.6.3 and struggled with it's output. Found out that it sometimes says "Failed, five modules loaded.". Respective fix attached.