### PR TITLE
Remove extra loading of haskell-indentation-mode

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -845,8 +845,7 @@ Minor modes that work well with `haskell-mode':
   (add-hook 'completion-at-point-functions
             'haskell-completions-completion-at-point
             nil
-            t)
-  (haskell-indentation-mode))
+            t))
 
 (defcustom haskell-mode-hook '(haskell-indentation-mode interactive-haskell-mode)
   "List of functions to run after `haskell-mode' is enabled.


### PR DESCRIPTION
haskell-indentation-mode is already loaded by default in the
haskell-mode-hook.  By forcing it to load every time haskell-mode loads,
the user can disable it only by toggling it off again; removing
haskell-indentation-mode from haskell-mode-hook will have no effect.