### PR TITLE
Use haskell-hoogle-command instead of hardcoded "hoogle"

### DIFF
--- a/haskell-hoogle.el
+++ b/haskell-hoogle.el
@@ -85,14 +85,13 @@ is asked to show extra info for the items matching QUERY.."
 (defun haskell-hoogle-start-server ()
   "Start hoogle local server."
   (interactive)
-  (if (executable-find "hoogle")
-      (unless (haskell-hoogle-server-live-p)
-        (set 'haskell-hoogle-server-process
-             (start-process
-              haskell-hoogle-server-process-name
-              (get-buffer-create haskell-hoogle-server-buffer-name)
-              "hoogle" "server" "-p" (number-to-string haskell-hoogle-port-number))))
-    (error "\"hoogle\" executable not found")))
+    (unless (haskell-hoogle-server-live-p)
+    (set 'haskell-hoogle-server-process
+            (start-process
+            haskell-hoogle-server-process-name
+            (get-buffer-create haskell-hoogle-server-buffer-name)
+            haskell-hoogle-command "server" "-p" (number-to-string haskell-hoogle-port-number))))
+    )
 
 (defun haskell-hoogle-server-live-p ()
   "Whether the hoogle server process is live."


### PR DESCRIPTION
Obviously it allows the insertion of a custom hoogle command. I now have this server running in a nix-shell per project:

```emacs-lisp
(use-package haskell-mode
  :config
  (custom-set-variables
   ...
   '(haskell-hoogle-command (concat (projectile-project-root) "scripts/hoogle.sh"))
   )
...
)
```
and that hoogle script:
```shell
#! /bin/sh
set -x 

# https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
ARGS="$@"

nix-shell --run "hoogle $ARGS" $DIR/../shell.nix 
exit 0
```

It would  be slightly more convenient to have this command be a function so it can always return the most recent (projectile-project-root), and do the argument juggling inside lisp instead of a custom script.
But this works for me.