### PR TITLE
Make {-# and #-} not be paragraph boundaries

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -793,8 +793,8 @@ Minor modes that work well with `haskell-mode':
     (error "haskell-mode requires at least Emacs 24.3"))
 
   ;; paragraph-{start,separate} should treat comments as paragraphs as well.
-  (setq-local paragraph-start (concat " *{-\\| *-- |\\|" page-delimiter))
-  (setq-local paragraph-separate (concat " *$\\| *\\({-\\|-}\\) *$\\|" page-delimiter))
+  (setq-local paragraph-start (concat " *{-\\([^#]\\|$\\)\\| *-- |\\|" page-delimiter))
+  (setq-local paragraph-separate (concat " *$\\| *\\({-\\([^#]\\|$\\)\\|\\([^#]\\|^\\)-}\\) *$\\|" page-delimiter))
   (setq-local fill-paragraph-function 'haskell-fill-paragraph)
   ;; (setq-local adaptive-fill-function 'haskell-adaptive-fill)
   (setq-local comment-start "-- ")


### PR DESCRIPTION
{- and -} are recognised as paragraph boundaries. While this makes a lot
of sense, it does not make sense to also recognise {-# and #-} as
paragraph boundaries.

Every time I want to do something at the top of the file I go to the first line, but then if I move around as usual using paragraph-wise navigation I have to go over all the language pragmas one by one, which is super annoying.