### PR TITLE
Don’t show message when minibuffer is active

### DIFF
--- a/haskell-string.el
+++ b/haskell-string.el
@@ -203,7 +203,8 @@ If the identifier is not qualified return it unchanged."
   "Echo STR in mini-buffer.
 Given string is shrinken to single line, multiple lines just
 disturbs the programmer."
-  (message "%s" (haskell-mode-one-line str (frame-width))))
+  (unless (active-minibuffer-window)
+    (message "%s" (haskell-mode-one-line str (frame-width)))))
 
 (defun haskell-mode-one-line (str &optional width)
   "Try to fit STR as much as possible on one line according to given WIDTH."


### PR DESCRIPTION
This messes up minibuffer editing when active. We only want a message
to show up when there is no active minibuffer window.

/cc @purcell