### PR TITLE
Do not obsoletely redefine byte-compile-dest-file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ build-$(EMACS_VERSION) :
 # proper dependency tracking (yet).
 build-$(EMACS_VERSION)/%.elc : %.el $(ELFILES)
 	$(BATCH) --eval '(setq byte-compile-error-on-warn t)'						\
-	         --eval "(defun byte-compile-dest-file (filename)					\
+	         --eval "(setq byte-compile-dest-file-function (lambda (filename)			\
 	               	       (concat (file-name-directory filename) \"build-\" emacs-version \"/\"	\
-	                      	    (file-name-nondirectory filename) \"c\"))"				\
+				    (file-name-nondirectory filename) \"c\")))"				\
 	         --eval "(when (check-declare-file \"$<\") (kill-emacs 2))" \
 	         -f batch-byte-compile $<								\
 


### PR DESCRIPTION
Since Emacs 23.2, redefining byte-compile-dest-file has been
deprecated in favour of setting byte-compile-dest-file-function.  As
haskell-mode only supports Emacs 24.3 or later,
byte-compile-dest-file-function's value will always be honoured.