### PR TITLE
added: stack ghci fallback when `(eq 'auto haskell-process-type)`

### DIFF
--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -459,6 +459,9 @@ This function also sets the `inferior-haskell-root-dir'"
          ((executable-find "ghc")
           (setq inferior-haskell-root-dir default-directory)
           'ghci)
+         ((executable-find "stack")
+          (setq inferior-haskell-root-dir default-directory)
+          'stack-ghci)
          (t
           (error "Could not find any installation of GHC.")))
       haskell-process-type)))


### PR DESCRIPTION
I have GHC installed only by Stack.
GHC alone is not installed.
I'm afraid of conflicts because I'm using Gentoo and it takes time to compile GHC.

In that environment, `switch-to-haskell` doesn't work in the global space.
This is because `haskell-process-type` only runs `stack ghci` in a Stack project.
Actually `stack ghci` can operate in global space.
This will not break the behavior of those who want to use a single ghci for the final fallback.