### PR TITLE
Handle cabal indentation relative to first line

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -460,9 +460,13 @@ OTHER-WINDOW use `find-file-other-window'."
       (list :name (match-string-no-properties 2)
             :beginning (match-end 0)
             :end (save-match-data (haskell-cabal-subsection-end))
-            :data-start-column (save-excursion (goto-char (match-end 0))
-                                               (current-column)
-                                               )))))
+	    :data-start-column (save-excursion (goto-char (match-end 0))
+					       (current-column)
+                                               )
+            :data-indent-column (save-excursion (goto-char (match-end 0))
+						(when (looking-at "\n  +\\(\\w*\\)") (goto-char (match-beginning 1)))
+						(current-column)
+						)))))
 
 
 (defun haskell-cabal-section-name (section)
@@ -476,6 +480,9 @@ OTHER-WINDOW use `find-file-other-window'."
 
 (defun haskell-cabal-section-data-start-column (section)
   (plist-get section :data-start-column))
+
+(defun haskell-cabal-section-data-indent-column (section)
+  (plist-get section :data-indent-column))
 
 (defun haskell-cabal-map-component-type (component-type)
   "Map from cabal file COMPONENT-TYPE to build command component-type."
@@ -1035,7 +1042,7 @@ Source names from main-is and c-sources sections are left untouched
   (cl-case (haskell-cabal-classify-line)
     (section-data
      (save-excursion
-       (let ((indent (haskell-cabal-section-data-start-column
+       (let ((indent (haskell-cabal-section-data-indent-column
                       (haskell-cabal-subsection))))
          (indent-line-to indent)
          (beginning-of-line)

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -460,13 +460,12 @@ OTHER-WINDOW use `find-file-other-window'."
       (list :name (match-string-no-properties 2)
             :beginning (match-end 0)
             :end (save-match-data (haskell-cabal-subsection-end))
-	    :data-start-column (save-excursion (goto-char (match-end 0))
-					       (current-column)
-                                               )
+            :data-start-column (save-excursion (goto-char (match-end 0))
+                                               (current-column))
             :data-indent-column (save-excursion (goto-char (match-end 0))
-						(when (looking-at "\n  +\\(\\w*\\)") (goto-char (match-beginning 1)))
-						(current-column)
-						)))))
+                                                (when (looking-at "\n  +\\(\\w*\\)") (goto-char (match-beginning 1)))
+                                                (current-column)
+                                                )))))
 
 
 (defun haskell-cabal-section-name (section)


### PR DESCRIPTION
Previously, cabal-mode indented to the ":" column of a subsection in a
cabal file. This was not how most users indented their .cabal files
and was surprising. Instead of doing this, we indent relatively to the
first entry in a subsection list. When it doesn’t exist, use the old
behavior.

:data-indent-column is added to store this new indent level. It needs
to be separate from :data-start-column due to :data-start-colum also
being used in finding the start of a subsection heading.

/cc @purcell 