### PR TITLE
Fix for #1691: disable-obsolete-face-alias is defined to require three args

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -136,7 +136,7 @@ be nil.")
   :group 'haskell-interactive)
 
 ;;;###autoload
-(define-obsolete-face-alias 'haskell-interactive-face-prompt2 'haskell-interactive-face-prompt-cont)
+(define-obsolete-face-alias 'haskell-interactive-face-prompt2 'haskell-interactive-face-prompt-cont t)
 
 ;;;###autoload
 (defface haskell-interactive-face-compile-error


### PR DESCRIPTION
... so we need to supply a non-sense third argument here.