### PR TITLE
Fix haskell-compile.el

### DIFF
--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -200,7 +200,7 @@ base directory for build tools, or the current buffer for
   (let* ((default (or (symbol-value last-sym) fallback))
          (template (cond
                     ((null edit) default)
-                    ((< edit 0) alt)
+                    ((eq edit '-) alt)
                     (t (compilation-read-command default))))
          (command (format template dir-or-file))
          (dir (if (directory-name-p dir-or-file)


### PR DESCRIPTION
It is currently checking for the prefix to be a negative integer, which throws a compiler error because we are checking for it to be a `'-` in other places. Looks like this error is introduced in b8892291c0e44f964dc1634351e62b1b242d55f7 commit. This PR reverts it to the earlier behaviour. 