### PR TITLE
Enable fontification for qualified quasiquoters

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -28,6 +28,7 @@
 
 (require 'cl-lib)
 (require 'haskell-lexeme)
+(require 'haskell-string)
 (require 'font-lock)
 
 ;;;###autoload
@@ -539,7 +540,8 @@ on an uppercase identifier."
                         (goto-char (nth 8 state))
                         (skip-syntax-backward "w._")
                         (buffer-substring-no-properties (point) (nth 8 state))))
-               (lang-mode (cdr (assoc qqname haskell-font-lock-quasi-quote-modes))))
+               (lang-mode (cdr (assoc (haskell-string-drop-qualifier qqname)
+                                      haskell-font-lock-quasi-quote-modes))))
 
           (if (and lang-mode
                    (fboundp lang-mode))

--- a/haskell-lexeme.el
+++ b/haskell-lexeme.el
@@ -373,6 +373,7 @@ names according to Template Haskell specification."
   (let ((match-data-old (match-data)))
     (if (and
          (looking-at (rx-to-string `(: "[" (optional "$")
+                                       (regexp ,haskell-lexeme-modid-opt-prefix)
                                        (group (regexp ,haskell-lexeme-id))
                                        (group "|"))))
          (equal (haskell-lexeme-classify-by-first-char (char-after (match-beginning 1)))

--- a/tests/haskell-font-lock-tests.el
+++ b/tests/haskell-font-lock-tests.el
@@ -471,6 +471,15 @@
    '(("Title" t default)
      ("Books" t default))))
 
+(ert-deftest haskell-syntactic-test-quasiquoter-sql-3 ()
+  "Embedded SQL statements"
+  (check-properties
+   '("sql = [Mod.sql| SELECT title FROM books; |]")
+   '(("SELECT" t font-lock-keyword-face)
+     ("title" t default)
+     ("FROM" t font-lock-keyword-face)
+     ("books" t default))))
+
 
 (ert-deftest haskell-syntactic-test-special-not-redefined ()
   "QuasiQuote should not conflict with TemplateHaskell"

--- a/tests/haskell-lexeme-tests.el
+++ b/tests/haskell-lexeme-tests.el
@@ -292,6 +292,26 @@ buffer."
    "[xml| <xml />"
    '("[xml| <xml />")))
 
+(ert-deftest haskell-lexeme-quasi-quote-qual-1 ()
+  (check-lexemes
+   '("[Mod.xml| <xml /> |]")
+   '("[Mod.xml| <xml /> |]")))
+
+(ert-deftest haskell-lexeme-quasi-quote-qual-2 ()
+  (check-lexemes
+   '("[Mod.xml| <xml /> |] |]")
+   '("[Mod.xml| <xml /> |]" "|" "]")))
+
+(ert-deftest haskell-lexeme-quasi-quote-qual-3 ()
+  (check-lexemes
+   "[Mod.xml| <xml /> |"
+   '("[Mod.xml| <xml /> |")))
+
+(ert-deftest haskell-lexeme-quasi-quote-qual-4 ()
+  (check-lexemes
+   "[Mod.xml| <xml />"
+   '("[Mod.xml| <xml />")))
+
 (ert-deftest haskell-lexeme-literate-1 ()
   (check-lexemes
    '("no code"


### PR DESCRIPTION
This enables font-locking when the quasiquoter name is imported qualified, e.g.:

```
[SomeModule.sql|SELECT * from table|]
```