### PR TITLE
`haskell-prompt-regexp` ignores characters before the '> '.

### DIFF
--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -108,8 +108,10 @@ directory structure."
 The format should be the same as for `compilation-error-regexp-alist'.")
 
 (defconst haskell-prompt-regexp
-  ;; Why the backslash in [\\._[:alnum:]]?
-  "^\\*?[[:upper:]][\\._[:alnum:]]*\\(?: \\*?[[:upper:]][\\._[:alnum:]]*\\)*\\( λ\\)?> \\|^λ?> $")
+  "^[[:alnum:].*_() |λ]*> "
+  "Ignore everything before the first '> '.  This allows us to
+correctly interpret multi-line input even when modules are
+imported.")
 
 ;;; TODO
 ;;; -> Make font lock work for strings, directories, hyperlinks


### PR DESCRIPTION
This allows us to correctly interpret multi-line input even when modules are imported.

For reference, please see:

https://lists.gnu.org/archive/html/emacs-orgmode/2020-05/msg00852.html

This new regexp is significantly shorter than the previous regexp because it cares far less about the formatting of the Haskell prompt. The previous regexp tries to divide the prompt into two parenthesis delimited groups, but there's no clear need to do so, as long as the prompt ends with the "> " suffix.  Now, we just treat any alphanumeric character or special character, including "_*|λ .()", as part of the prompt, if they occur before the suffix.

The current haskell-prompt-regexp works in many cases, but not when GHC receives multi-line input from org-mode's ob-haskell.  This can occur when evaluating blocks like this:

    #+name: chain-ecm
    #+BEGIN_SRC haskell
      :{
      chain :: (Integral a) => a -> [a]
      chain 1 = [1]
      chain n
          | even n = n:chain (n `div` 2)
          | odd n  = n:chain (n*3 + 1)
      :}
      chain 10
    #+END_SRC

The contents of the inf-haskell buffer are as follows, and inf-haskell should return everything that isn't prompt between the "org-babel-haskell-eoe" strings:

    Prelude> :{
    chain :: (Integral a) => a -> [a]
    chain 1 = [1]
    chain n
        | even n = n:chain (n `div` 2)
        | odd n  = n:chain (n*3 + 1)
    :}
    chain 10
    "org-babel-haskell-eoe"
    Prelude| Prelude| Prelude| Prelude| Prelude| Prelude| Prelude> [10,5,16,8,4,2,1]
    Prelude> "org-babel-haskell-eoe"

Unfortunately, the current regexp incorrectly includes the GHC line continuations that occur when parsing multiple lines of input at once.

    Prelude| Prelude| Prelude| Prelude| Prelude| Prelude| Prelude> [10,5,16,8,4,2,1]

With this prompt change, we correctly elide the continuation characters when parsing the output, and receive only the answer:

    [10, 5, 16, 8, 4, 2, 1]

Additionally, at least 3 other types of blocks may then be processed correctly.

1. Silent multi-line blocks:

       #+BEGIN_SRC haskell :results silent
         :{
         flip' :: (a -> b -> c) -> (b -> a -> c)
         flip' f = \x y -> f y x
         :}
       #+END_SRC

2. Multi-line blocks with value results:

       #+BEGIN_SRC haskell
         :{
         sum' :: (Num a) => [a] -> a
         sum' xs = foldl (\ acc x -> acc + x) 0 xs
         :}
         sum' [1,2,3,4] == 10
       #+END_SRC
   
       #+RESULTS:
       : True

3. Multi-line blocks with printable results:

       #+BEGIN_SRC haskell :results output
         :{
         sum' :: (Num a) => [a] -> a
         sum' xs = foldl (\ acc x -> acc + x) 0 xs
         :}
         print "hi"
       #+END_SRC
   
       #+RESULTS:
       :
       : hi