### PR TITLE
Fall back to 'haskell-mode-tag-find' when 'haskell-mode-find-def' fails in 'haskell-mode-jump-to-def-or-tag'

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -376,7 +376,7 @@ If the definition or tag is found, the location from which you jumped
 will be pushed onto `xref--marker-ring', so you can return to that
 position with `xref-pop-marker-stack'."
   (interactive "P")
-  (if-let ((_ (haskell-session-maybe))
+  (if-let ((session (haskell-session-maybe))
            (initial-loc (point-marker))
            (loc (haskell-mode-find-def (haskell-ident-at-point))))
       (progn

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -376,13 +376,14 @@ If the definition or tag is found, the location from which you jumped
 will be pushed onto `xref--marker-ring', so you can return to that
 position with `xref-pop-marker-stack'."
   (interactive "P")
-  (if (haskell-session-maybe)
-        (let ((initial-loc (point-marker))
-            (loc (haskell-mode-find-def (haskell-ident-at-point))))
-          (haskell-mode-handle-generic-loc loc)
-          (unless (equal initial-loc (point-marker))
-            (xref-push-marker-stack initial-loc)))
-      (call-interactively 'haskell-mode-tag-find)))
+  (if-let ((_ (haskell-session-maybe))
+           (initial-loc (point-marker))
+           (loc (haskell-mode-find-def (haskell-ident-at-point))))
+      (progn
+        (haskell-mode-handle-generic-loc loc)
+        (unless (equal initial-loc (point-marker))
+          (xref-push-marker-stack)))
+    (call-interactively 'haskell-mode-tag-find)))
 
 ;;;###autoload
 (defun haskell-mode-goto-loc ()


### PR DESCRIPTION
This PR changes the behavior of `haskell-mode-jump-to-def-or-tag` to fall back on `haskell-mode-tag-find`when `haskell-mode-find-def` fails. This fixes #351.