### PR TITLE
Always use buffer-file-name for ghc compilation

### DIFF
--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -2,6 +2,7 @@
 
 ;; Copyright (C) 2013  Herbert Valerio Riedel
 ;;               2020  Marc Berkowitz <mberkowitz@github.com>
+;;               2020  Jacob Ilsø
 
 ;; Author: Herbert Valerio Riedel <hvr@gnu.org>
 
@@ -170,7 +171,7 @@ base directory for build tools, or the current buffer for
   (interactive "P")
   (save-some-buffers (not compilation-ask-about-save)
                      compilation-save-buffers-predicate)
-  (let (htype dir)                      
+  (let (htype dir)
     ;;test haskell-compiler-type to set htype and dir
     (cond
      ((eq haskell-compiler-type 'cabal)
@@ -180,8 +181,7 @@ base directory for build tools, or the current buffer for
       (setq htype 'stack)
       (setq dir (locate-dominating-file default-directory "stack.yaml")))
      ((eq haskell-compiler-type 'ghc)
-      (setq htype 'ghc)
-      (setq dir (buffer-file-name)))
+      (setq htype 'ghc))
      ((eq haskell-compiler-type 'auto)
       (let ((r (haskell-build-type)))
         (setq htype (car r))
@@ -204,7 +204,7 @@ base directory for build tools, or the current buffer for
         haskell-compile-stack-build-command
         haskell-compile-stack-build-alt-command))
      ((eq htype 'ghc)
-      (haskell--compile dir edit-command
+      (haskell--compile (buffer-file-name) edit-command
         'haskell--compile-ghc-last
         haskell-compile-command
         haskell-compile-command)))))

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -409,9 +409,9 @@ imports."
 presence of a *.cabal file or stack.yaml file or something similar.")
 
 (defun haskell-build-type ()
-  "Looks for cabal and stack spec files. 
-   When found, returns a pair (TAG . DIR) 
-   where TAG is 'cabal-project, 'cabal-sandbox. 'cabal, or 'stack; 
+  "Looks for cabal and stack spec files.
+   When found, returns a pair (TAG . DIR)
+   where TAG is 'cabal-project, 'cabal-sandbox. 'cabal, or 'stack;
    and DIR is the directory containing cabal or stack file.
    When none found, DIR is nil, and TAG is 'ghc"
   ;; REVIEW maybe just 'cabal is enough.

--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2004, 2005, 2007, 2009  Free Software Foundation, Inc.
 ;; Copyright (C) 1997-1998  Graeme E Moss
 ;; Copyright (C) 2016  Chris Gregory
+;; Copyright (C) 2020  Jacob Ilsø
 
 ;; Author: 1997-1998 Graeme E Moss <gem@cs.york.ac.uk>
 ;; Maintainer: Stefan Monnier <monnier@gnu.org>
@@ -542,9 +543,6 @@ datatypes) in a Haskell file for the `imenu' package."
          (index-imp-alist '())   ;; Imports
          (index-inst-alist '())  ;; Instances
          (index-type-alist '())  ;; Datatypes
-         ;; Variables for showing progress.
-         (bufname (buffer-name))
-         (divisor-of-progress (max 1 (/ (buffer-size) 100)))
          ;; The result we wish to return.
          result)
     (goto-char (point-min))


### PR DESCRIPTION
Seems ghc compilation was broken recently. Invoking haskell-compile in a buffer with a single haskell source file calls ghc with the directory and not the filename.