### PR TITLE
Add package prefix to `haskell-compilation-error-regexp-alist`

### DIFF
--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -92,7 +92,8 @@ The `%s' placeholder is replaced by the current buffer's filename."
 
 (defconst haskell-compilation-error-regexp-alist
   `((,(concat
-       "^ *\\(?1:[^\t\r\n]+?\\):"
+       "^ *\\([^\n\r\t>]*\s*> \\)?" ;; if using multi-package stack project, remove the package name that is prepended
+       "\\(?1:[^\t\r\n]+?\\):"
        "\\(?:"
        "\\(?2:[0-9]+\\):\\(?4:[0-9]+\\)\\(?:-\\(?5:[0-9]+\\)\\)?" ;; "121:1" & "12:3-5"
        "\\|"


### PR DESCRIPTION
## Problem

When compiling a package with Stack that declares multiple packages on its `stack.yaml` file, the output of each package compilation is prepended with the string `package-name\s*>\s` like this:

```
testing> /home/javier/testing/src/Lib.hs:7:1: warning: [-Wmissing-signatures]
testing>     Top-level binding with no type signature: someFunc :: IO ()
```

Without this change, the string `testing> ` would be matched in the first part of the regexp and then emacs would fail to find the file as it would be searching for:
```
testing> /home/javier/testing/src/Lib.hs
```
as filename. The string before the `>` is also padded to the longest package name in the compilation.

## Proposed solution
The change modifies slightly the regexp to match and filter out this prefix.

## Before the change
Padded package:
![image](https://user-images.githubusercontent.com/9791461/109848701-d81ded80-7c50-11eb-9451-7429ae8dbf17.png)
Un-padded package:
![image](https://user-images.githubusercontent.com/9791461/109848534-ac9b0300-7c50-11eb-926d-50d62f5a65d1.png)

## After the change:
Padded package:
![image](https://user-images.githubusercontent.com/9791461/109848861-07ccf580-7c51-11eb-9430-cbb79d5f0dda.png)
Un-padded package:
![image](https://user-images.githubusercontent.com/9791461/109848489-a0af4100-7c50-11eb-8117-f97630a6f2cf.png)

Errors on simple stack packages still work as expected:
![image](https://user-images.githubusercontent.com/9791461/109849095-4367bf80-7c51-11eb-8f0f-a543d2a9fbf8.png)
Errors on Cabal compilations work as expected:
![image](https://user-images.githubusercontent.com/9791461/109849175-5d090700-7c51-11eb-9b80-7067a6e55d11.png)
Errors on plain GHC work as expected:
![image](https://user-images.githubusercontent.com/9791461/109849333-8d50a580-7c51-11eb-8033-32ee8d58290f.png)
