### PR TITLE
Use "!" class for literate comments instead of "<" (fixes #1594)

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -586,10 +586,10 @@ on an uppercase identifier."
               (goto-char (1+ (point)))))))
       ;; must return nil here so that it is not fontified again as string
       nil))
-   ;; Detect literate comment lines starting with syntax class '<'
+   ;; Detect literate comment lines starting with syntax class '!'
    ((save-excursion
       (goto-char (nth 8 state))
-      (equal (string-to-syntax "<") (syntax-after (point))))
+      (equal (string-to-syntax "!") (syntax-after (point))))
     'haskell-literate-comment-face)
    ;; Detect pragmas. A pragma is enclosed in special comment
    ;; delimiters {-# .. #-}.

--- a/haskell-lexeme.el
+++ b/haskell-lexeme.el
@@ -475,7 +475,7 @@ See `haskell-lexeme-classify-by-first-char' for details."
        (point (point-marker)))
     (or
      (and
-      (equal (string-to-syntax "<")
+      (equal (string-to-syntax "!")
              (get-char-property (point) 'syntax-table))
       (progn
         (set-match-data (list point (set-marker (make-marker) (line-end-position))))

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -505,6 +505,7 @@ be set to the preferred literate style."
                    (or
                     (and
                      (not (equal (string-to-syntax "<") (syntax-after (point))))
+                     (not (equal (string-to-syntax "!") (syntax-after (point))))
                      (not (looking-at-p "^>")))
                     (looking-at-p "^\\\\begin{code}[\t ]*$")))))))
         (while (< (point) end)
@@ -512,7 +513,10 @@ be set to the preferred literate style."
             (if previous-line-latex-code
                 (if (looking-at-p "^\\\\end{code}[\t ]*$")
                     (progn
-                      (put-text-property (point) (1+ (point)) 'syntax-table (string-to-syntax "<"))
+                      (put-text-property (point) (1+ (point)) 'syntax-table (string-to-syntax "!"))
+                      (save-excursion
+                       (end-of-line)
+                       (put-text-property (point) (1+ (point)) 'syntax-table (string-to-syntax "!")))
                       (setq previous-line-latex-code nil))
                   ;; continue latex-code
                   )
@@ -521,7 +525,10 @@ be set to the preferred literate style."
                   (put-text-property (point) (1+ (point)) 'syntax-table (string-to-syntax "-"))
                 ;; this is a literate comment
                 (progn
-                  (put-text-property (point) (1+ (point)) 'syntax-table (string-to-syntax "<"))
+                  (put-text-property (point) (1+ (point)) 'syntax-table (string-to-syntax "!"))
+                  (save-excursion
+                   (end-of-line)
+                   (put-text-property (point) (1+ (point)) 'syntax-table (string-to-syntax "!")))
                   (when (looking-at-p "^\\\\begin{code}[\t ]*$")
                     (setq previous-line-latex-code t))))))
           (forward-line 1))))


### PR DESCRIPTION
The `!` syntax class is intended for making arbitrary pieces of text into comments; thus, tools such as `fill-paragraph` and `auto-fill-mode` treat it differently than `<`, which is intended for specifying actual comment characters.