### PR TITLE
Run hooks for haskell-error-mode

### DIFF
--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -652,6 +652,7 @@ wrapped in compiler directive at the top of FILE."
         (with-current-buffer buf
 
           (haskell-error-mode)
+          (run-hooks 'haskell-error-mode-hook)
           (let ((inhibit-read-only t))
             (erase-buffer)
             (insert (propertize response


### PR DESCRIPTION
When `haskell-interactive-popup-error` is called, `haskell-error-mode`
hooks aren't running because `run-hooks` call is missed