### PR TITLE
Add font-lock support for ImportQualifiedPost

### DIFF
--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -417,11 +417,12 @@ on an uppercase identifier."
 
             ;; Special case for `as', `hiding', `safe' and `qualified', which are
             ;; keywords in import statements but are not otherwise reserved.
-            ("\\<import[ \t]+\\(?:\\(safe\\>\\)[ \t]*\\)?\\(?:\\(qualified\\>\\)[ \t]*\\)?\\(?:\"[^\"]*\"[\t ]*\\)?[^ \t\n()]+[ \t]*\\(?:\\(\\<as\\>\\)[ \t]*[^ \t\n()]+[ \t]*\\)?\\(\\<hiding\\>\\)?"
+            ("\\<import[ \t]+\\(?:\\(safe\\>\\)[ \t]*\\)?\\(?:\\(qualified\\>\\)[ \t]*\\)?\\(?:\"[^\"]*\"[\t ]*\\)?[^ \t\n()]+[ \t]*\\(?:\\(qualified\\>\\)[ \t]*\\)?\\(?:\\(\\<as\\>\\)[ \t]*[^ \t\n()]+[ \t]*\\)?\\(\\<hiding\\>\\)?"
              (1 'haskell-keyword-face nil lax)
              (2 'haskell-keyword-face nil lax)
              (3 'haskell-keyword-face nil lax)
-             (4 'haskell-keyword-face nil lax))
+             (4 'haskell-keyword-face nil lax)
+             (5 'haskell-keyword-face nil lax))
 
             ;; Special case for `foreign import'
             ;; keywords in foreign import statements but are not otherwise reserved.

--- a/tests/haskell-font-lock-tests.el
+++ b/tests/haskell-font-lock-tests.el
@@ -987,6 +987,14 @@
      ("Cons2" t haskell-constructor-face)
      ("Cons3" t haskell-constructor-face))))
 
+(ert-deftest haskell-type-colors-33 ()
+  (check-properties
+   "import X qualified as Y"
+   '(("X" t haskell-constructor-face)
+     ("qualified" t haskell-keyword-face)
+     ("as" t haskell-keyword-face)
+     ("Y" t haskell-constructor-face))))
+
 (ert-deftest haskell-pattern-1 ()
   "Fontify the \"pattern\" keyword in contexts related to pattern synonyms."
   (check-properties


### PR DESCRIPTION
Now the `qualified` keyword in

```haskell
import X qualified as Y
```

is correctly highlighted.