### PR TITLE
Remove autoloads from face and group definitions

### DIFF
--- a/ghc-core.el
+++ b/ghc-core.el
@@ -32,7 +32,6 @@
 (require 'haskell-mode)
 (require 'haskell-font-lock)
 
-;;;###autoload
 (defgroup ghc-core nil
   "Major mode for viewing pretty printed GHC Core output."
   :link '(custom-manual "(haskell-mode)")

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -348,7 +348,6 @@ OTHER-WINDOW use `find-file-other-window'."
     "help"
     "run"))
 
-;;;###autoload
 (defgroup haskell-cabal nil
   "Haskell cabal files"
   :group 'haskell

--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -34,7 +34,6 @@
 (require 'ansi-color)
 (eval-when-compile (require 'subr-x))
 
-;;;###autoload
 (defgroup haskell-compile nil
   "Settings for Haskell compilation mode"
   :link '(custom-manual "(haskell-mode)compilation")

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -40,7 +40,6 @@
 (require 'haskell-process)
 (require 'haskell-interactive-mode)
 
-;;;###autoload
 (defgroup haskell-completions nil
   "Settings for completions provided by `haskell-mode'"
   :link '(custom-manual "(haskell-mode)Completion support")

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -28,7 +28,6 @@
   :type 'boolean
   :group 'haskell-interactive)
 
-;;;###autoload
 (defgroup haskell nil
   "Major mode for editing Haskell programs."
   :link '(custom-manual "(haskell-mode)")
@@ -115,7 +114,6 @@ when showing type information about symbols."
 (defvar haskell-process-ended-functions (list 'haskell-process-prompt-restart)
   "Hook for when the haskell process ends.")
 
-;;;###autoload
 (defgroup haskell-interactive nil
   "Settings for REPL interaction via `haskell-interactive-mode'"
   :link '(custom-manual "(haskell-mode)haskell-interactive-mode")

--- a/haskell-debug.el
+++ b/haskell-debug.el
@@ -28,43 +28,36 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Configuration
 
-;;;###autoload
 (defgroup haskell-debug nil
   "Settings for debugging support."
   :link '(custom-manual "(haskell-mode)haskell-debug")
   :group 'haskell)
 
-;;;###autoload
 (defface haskell-debug-warning-face
   '((t :inherit 'compilation-warning))
   "Face for warnings."
   :group 'haskell-debug)
 
-;;;###autoload
 (defface haskell-debug-trace-number-face
   '((t :weight bold :background "#f5f5f5"))
   "Face for numbers in backtrace."
   :group 'haskell-debug)
 
-;;;###autoload
 (defface haskell-debug-newline-face
   '((t :weight bold :background "#f0f0f0"))
   "Face for newlines in trace steps."
   :group 'haskell-debug)
 
-;;;###autoload
 (defface haskell-debug-keybinding-face
   '((t :inherit 'font-lock-type-face :weight bold))
   "Face for keybindings."
   :group 'haskell-debug)
 
-;;;###autoload
 (defface haskell-debug-heading-face
   '((t :inherit 'font-lock-keyword-face))
   "Face for headings."
   :group 'haskell-debug)
 
-;;;###autoload
 (defface haskell-debug-muted-face
   '((t :foreground "#999"))
   "Face for muteds."

--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -107,7 +107,6 @@
 (require 'syntax)
 (require 'imenu)
 
-;;;###autoload
 (defgroup haskell-decl-scan nil
   "Haskell declaration scanning (`imenu' support)."
   :link '(custom-manual "(haskell-mode)haskell-decl-scan-mode")

--- a/haskell-doc.el
+++ b/haskell-doc.el
@@ -308,7 +308,6 @@
 (require 'imenu)
 (require 'eldoc)
 
-;;;###autoload
 (defgroup haskell-doc nil
   "Show Haskell function types in echo area."
   :group 'haskell

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -31,7 +31,6 @@
 (require 'haskell-string)
 (require 'font-lock)
 
-;;;###autoload
 (defgroup haskell-appearance nil
   "Haskell Appearance."
   :group 'haskell)
@@ -145,19 +144,16 @@ font faces assigned as if respective mode was enabled."
   :group 'haskell-appearance
   :type '(repeat (cons string symbol)))
 
-;;;###autoload
 (defface haskell-keyword-face
   '((t :inherit font-lock-keyword-face))
   "Face used to highlight Haskell keywords."
   :group 'haskell-appearance)
 
-;;;###autoload
 (defface haskell-type-face
   '((t :inherit font-lock-type-face))
   "Face used to highlight Haskell types"
   :group 'haskell-appearance)
 
-;;;###autoload
 (defface haskell-constructor-face
   '((t :inherit font-lock-type-face))
   "Face used to highlight Haskell constructors."
@@ -174,25 +170,21 @@ font faces assigned as if respective mode was enabled."
 ;; This is probably just wrong, but it used to use
 ;; `font-lock-function-name-face' with a result that was not consistent with
 ;; other major modes, so I just exchanged with `haskell-definition-face'.
-;;;###autoload
 (defface haskell-operator-face
   '((t :inherit font-lock-variable-name-face))
   "Face used to highlight Haskell operators."
   :group 'haskell-appearance)
 
-;;;###autoload
 (defface haskell-pragma-face
   '((t :inherit font-lock-preprocessor-face))
   "Face used to highlight Haskell pragmas ({-# ... #-})."
   :group 'haskell-appearance)
 
-;;;###autoload
 (defface haskell-liquid-haskell-annotation-face
   '((t :inherit haskell-pragma-face))
   "Face used to highlight LiquidHaskell annotations ({-@ ... @-})."
   :group 'haskell-appearance)
 
-;;;###autoload
 (defface haskell-literate-comment-face
   '((t :inherit font-lock-doc-face))
   "Face with which to fontify literate comments.

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -92,7 +92,6 @@
 
 (defvar haskell-literate)
 
-;;;###autoload
 (defgroup haskell-indent nil
   "Haskell indentation."
   :group 'haskell

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -43,7 +43,6 @@
 (require 'cl-lib)
 (require 'haskell-lexeme)
 
-;;;###autoload
 (defgroup haskell-indentation nil
   "Haskell indentation."
   :link '(custom-manual "(haskell-mode)Indentation")

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -123,40 +123,33 @@ be nil.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Faces
 
-;;;###autoload
 (defface haskell-interactive-face-prompt
   '((t :inherit font-lock-function-name-face))
   "Face for the prompt."
   :group 'haskell-interactive)
 
-;;;###autoload
 (defface haskell-interactive-face-prompt-cont
   '((t :inherit font-lock-keyword-face))
   "Face for GHCi's prompt-cont in multi-line mode."
   :group 'haskell-interactive)
 
-;;;###autoload
 (define-obsolete-face-alias 'haskell-interactive-face-prompt2 'haskell-interactive-face-prompt-cont "16.2")
 
-;;;###autoload
 (defface haskell-interactive-face-compile-error
   '((t :inherit compilation-error))
   "Face for compile errors."
   :group 'haskell-interactive)
 
-;;;###autoload
 (defface haskell-interactive-face-compile-warning
   '((t :inherit compilation-warning))
   "Face for compiler warnings."
   :group 'haskell-interactive)
 
-;;;###autoload
 (defface haskell-interactive-face-result
   '((t :inherit font-lock-string-face))
   "Face for the result."
   :group 'haskell-interactive)
 
-;;;###autoload
 (defface haskell-interactive-face-garbage
   '((t :inherit font-lock-string-face))
   "Face for trailing garbage after a command has completed."

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -130,7 +130,7 @@ actual Emacs buffer of the module being loaded."
                 process
                 "Failed, modules loaded: \\(.+\\)\\.$")
                nil)
-	      ((haskell-process-consume
+              ((haskell-process-consume
                 process
                 "Failed, no modules loaded\\.$") ;; for ghc 8.4
                nil)
@@ -336,7 +336,6 @@ list of modules where missed IDENT was found."
          (modules (and modules-string (split-string modules-string ", "))))
     (cons modules modules-string)))
 
-;;;###autoload
 (defface haskell-error-face
   '((((supports :underline (:style wave)))
      :underline (:style wave :color "#dc322f"))
@@ -345,7 +344,6 @@ list of modules where missed IDENT was found."
   "Face used for marking error lines."
   :group 'haskell-mode)
 
-;;;###autoload
 (defface haskell-warning-face
   '((((supports :underline (:style wave)))
      :underline (:style wave :color "#b58900"))
@@ -354,7 +352,6 @@ list of modules where missed IDENT was found."
   "Face used for marking warning lines."
   :group 'haskell-mode)
 
-;;;###autoload
 (defface haskell-hole-face
   '((((supports :underline (:style wave)))
      :underline (:style wave :color "#6c71c4"))

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -40,7 +40,6 @@
 (require 'cl-lib)
 (require 'haskell-string)
 
-;;;###autoload
 (defgroup inferior-haskell nil
   "Settings for REPL interaction via `inferior-haskell-mode'"
   :link '(custom-manual "(haskell-mode)inferior-haskell-mode")

--- a/w3m-haddock.el
+++ b/w3m-haddock.el
@@ -35,7 +35,6 @@
 
 (add-hook 'w3m-display-hook 'w3m-haddock-display)
 
-;;;###autoload
 (defface w3m-haddock-heading-face
   '((((class color)) :inherit highlight))
   "Face for quarantines."


### PR DESCRIPTION
Generally only functions and modes should be autoloaded. add-to-list can also be
used cautiously to register modes etc. Faces are usually not autoloaded. To make
faces, groups and custom variables available for customization, a package must
be loaded.