### PR TITLE
Add interactive command to insert a LANGUAGE pragma

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -936,13 +936,13 @@ newlines and extra whitespace in signature before insertion."
         (insert sig "\n")
         (indent-to col)))))
 
-(defun haskell-mode-add-language-pragma (extension)
+(defun haskell-command-insert-language-pragma (extension)
   "Insert a {-# LANGUAGE _ #-} pragma at the top of the current
 buffer for the given extension."
   (interactive
    (list (completing-read "Extension: " haskell-ghc-supported-extensions)))
   (save-excursion
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (insert (format "{-# LANGUAGE %s #-}\n" extension))))
 
 (provide 'haskell-commands)

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -36,6 +36,7 @@
 (require 'haskell-utils)
 (require 'highlight-uses-mode)
 (require 'haskell-cabal)
+(require 'haskell-ghc-support)
 
 (defcustom haskell-mode-stylish-haskell-path "stylish-haskell"
   "Path to `stylish-haskell' executable."
@@ -934,6 +935,15 @@ newlines and extra whitespace in signature before insertion."
       (let ((col (current-column)))
         (insert sig "\n")
         (indent-to col)))))
+
+(defun haskell-mode-add-language-pragma (extension)
+  "Insert a {-# LANGUAGE _ #-} pragma at the top of the current
+buffer for the given extension."
+  (interactive
+   (list (completing-read "Extension: " haskell-ghc-supported-extensions)))
+  (save-excursion
+    (beginning-of-buffer)
+    (insert (format "{-# LANGUAGE %s #-}\n" extension))))
 
 (provide 'haskell-commands)
 ;;; haskell-commands.el ends here

--- a/tests/haskell-mode-tests.el
+++ b/tests/haskell-mode-tests.el
@@ -666,4 +666,13 @@ moves over sexps."
          (goto-char (point-min))
          (should (looking-at-p "main = return ()")))))))
 
+(ert-deftest haskell-mode-add-language-pragma-with-existing-text ()
+  (with-temp-buffer
+    (haskell-mode)
+    (insert "module Main where\n")
+    (end-of-buffer)
+    (haskell-mode-add-language-pragma "ViewPatterns")
+    (should (string= (buffer-string)
+                     "{-# LANGUAGE ViewPatterns #-}\nmodule Main where\n"))))
+
 (provide 'haskell-mode-tests)

--- a/tests/haskell-mode-tests.el
+++ b/tests/haskell-mode-tests.el
@@ -671,7 +671,7 @@ moves over sexps."
     (haskell-mode)
     (insert "module Main where\n")
     (end-of-buffer)
-    (haskell-mode-add-language-pragma "ViewPatterns")
+    (haskell-command-insert-language-pragma "ViewPatterns")
     (should (string= (buffer-string)
                      "{-# LANGUAGE ViewPatterns #-}\nmodule Main where\n"))))
 


### PR DESCRIPTION
I need to manually add `{-# LANUGAGE _ #-}` pragmas to the top of my modules pretty often, so I wrote a function to do this. I've been using it for a few days and found it really convenient, and other people liked the idea when I mentioned it on Twitter.

Called interactively it uses `haskell-ghc-supported-extensions` for completions which means less typing and no more errors like using `RecordWildcards` instead of `RecordWildCards`.

I bound it to `C-c C-e` on my own setup, but not sure whether it makes sense to include a keybinding for it by default.