### PR TITLE
fix typos

### DIFF
--- a/haskell-c2hs.el
+++ b/haskell-c2hs.el
@@ -111,7 +111,7 @@
                        (opt (+ ,ws)
                             (group-n 3
                                      "as")))
-                  ;; TODO: fun hook highlighting is incompelete
+                  ;; TODO: fun hook highlighting is incomplete
                   (seq (group-n 2
                                 (or "call"
                                     "fun")

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -31,7 +31,7 @@
 ;;
 ;; For major use function `haskell-completions-grab-prefix' is supposed, and
 ;; other prefix grabbing functions are used internally by it.  So, only this
-;; funciton have prefix minimal length functionality and invokes predicate
+;; function have prefix minimal length functionality and invokes predicate
 ;; function `haskell-completions-can-grab-prefix'.
 
 ;;; Code:
@@ -226,7 +226,7 @@ identifier at point depending on result of function
              (type 'haskell-completions-identifier-prefix)
              (case-fold-search nil)
              value)
-        ;; we need end position of result, becase of
+        ;; we need end position of result, because of
         ;; `haskell-ident-pos-at-point' ignores trailing whitespace, e.g. the
         ;; result will be same for `map|` and `map  |` invocations.
         (when (<= p end)

--- a/haskell-decl-scan.el
+++ b/haskell-decl-scan.el
@@ -513,7 +513,7 @@ positions and the type is one of the symbols \"variable\", \"datatype\",
                             (skip-chars-backward " \t")
                             (point))))))
           ;; If we did not manage to extract a name, cancel this
-          ;; declaration (eg. when line ends in "=> ").
+          ;; declaration (e.g. when line ends in "=> ").
           (if (string-match "^[ \t]*$" name) (setq name nil))
           (setq type 'instance)))
         ;; Move past start of current declaration.

--- a/haskell-font-lock.el
+++ b/haskell-font-lock.el
@@ -161,7 +161,7 @@ font faces assigned as if respective mode was enabled."
 
 ;; This used to be `font-lock-variable-name-face' but it doesn't result in
 ;; a highlighting that's consistent with other modes (it's mostly used
-;; for function defintions).
+;; for function definitions).
 (defface haskell-definition-face
   '((t :inherit font-lock-function-name-face))
   "Face used to highlight Haskell definitions."

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -1232,7 +1232,7 @@ START if non-nil is a presumed start pos of the current definition."
                    (setq open (haskell-indent-offset-after-info)))
           (list (list (haskell-indent-after-keyword-column open start))))))
 
-     ;; open structure? ie  ( { [
+     ;; open structure? i.e.  ( { [
      ((setq open (haskell-indent-open-structure start (point)))
       (haskell-indent-inside-paren open))
 
@@ -1434,7 +1434,7 @@ TYPE is either 'guard or 'rhs."
 
 (defun haskell-indent-align-guards-and-rhs (_start _end)
   "Align the guards and rhs of functions in the region, which must be active."
-  ;; The `start' and `end' args are dummys right now: they're just there so
+  ;; The `start' and `end' args are dummies right now: they're just there so
   ;; we can use the "r" interactive spec which properly signals an error.
   (interactive "*r")
   (haskell-indent-align-def t 'guard)

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -241,9 +241,9 @@ indentation points to the right, we switch going to the left."
   ;; try to repeat
   (when (not (haskell-indentation-indent-line-repeat))
     (setq haskell-indentation-dyn-last-direction nil)
-    ;; parse error is intentionally not cought here, it may come from
+    ;; parse error is intentionally not caught here, it may come from
     ;; `haskell-indentation-find-indentations', but escapes the scope
-    ;; and aborts the opertaion before any moving happens
+    ;; and aborts the operation before any moving happens
     (let* ((cc (current-column))
            (ci (haskell-indentation-current-indentation))
            (inds (save-excursion

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -531,7 +531,7 @@ be set to the preferred literate style."
       (when (nth 4 ppss)
         ;; go to the end of a comment, there is nothing to see inside
         ;; a comment so we might as well just skip over it
-        ;; immediatelly
+        ;; immediately
         (setq ppss (parse-partial-sexp (point) (point-max) nil nil ppss
                                        'syntax-table)))
       (when (nth 8 ppss)

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -122,7 +122,7 @@ Returns one of the following symbols:
 + interactive-error
 + no-error
 
-*Warning*: this funciton covers only three kind of responses:
+*Warning*: this function covers only three kind of responses:
 
 * \"unknown command …\"
   REPL missing requested command

--- a/tests/haskell-font-lock-tests.el
+++ b/tests/haskell-font-lock-tests.el
@@ -129,7 +129,7 @@
 
 (ert-deftest haskell-syntactic-test-18a-multiline ()
   "Backtick operators multiline"
-  ;; strangely thins works in interactive session
+  ;; strangely this works in interactive session
   :expected-result :failed
   (check-properties
    '(" `"
@@ -143,7 +143,7 @@
   "Syntax for hierarchical modules when on the first line."
   ;; note that quite many things here are not consistent but for now
   ;; this test describes what it is. When on the first column
-  ;; font-lock thins we are defining (.) operator. Not good.
+  ;; font-lock thinks we are defining (.) operator. Not good.
   :expected-result :failed
   (check-properties
    '("A1.B.C"


### PR DESCRIPTION
haskell-c2hs.el
haskell-completions.el
haskell-decl-scan.el
haskell-font-lock.el
haskell-indent.el
haskell-indentation.el
haskell-mode.el
haskell-utils.el
tests/haskell-font-lock-tests.el