### PR TITLE
Fixed build errors.

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -360,7 +360,8 @@ OTHER-WINDOW use `find-file-other-window'."
 (defconst haskell-cabal-conditional-regexp "^[ \t]*\\(\\if\\|else\\|}\\)")
 
 (defun haskell-cabal-classify-line ()
-  "Classify the current line into 'section-header 'subsection-header 'section-data 'comment and 'empty '"
+  "Classify the current line into 'section-header 'subsection-header
+'section-data 'comment and 'empty '"
   (save-excursion
     (beginning-of-line)
     (cond
@@ -493,7 +494,8 @@ OTHER-WINDOW use `find-file-other-window'."
           ((equal component-type "benchmark")  "bench"))))
 
 (defun haskell-cabal-enum-targets (&optional process-type)
-  "Enumerate .cabal targets. PROCESS-TYPE determines the format of the returned target."
+  "Enumerate .cabal targets. PROCESS-TYPE determines the format of the
+returned target."
   (let ((cabal-file (haskell-cabal-find-file))
         (process-type (if process-type process-type 'ghci)))
     (when (and cabal-file (file-readable-p cabal-file))
@@ -925,7 +927,9 @@ resulting buffer-content.  Unmark line at the end."
 (defun haskell-cabal-line-filename ()
   "Expand filename in current line according to the subsection type
 
-Module names in exposed-modules and other-modules are expanded by replacing each dot (.) in the module name with a forward slash (/) and appending \".hs\"
+Module names in exposed-modules and other-modules are expanded by
+replacing each dot (.) in the module name with a forward slash (/) and
+appending \".hs\"
 
 Example: Foo.Bar.Quux ==> Foo/Bar/Quux.hs
 

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -232,8 +232,9 @@ file), then this function returns nil."
 
 ;;;###autoload
 (defun haskell-cabal-get-dir (&optional use-defaults)
-  "Get the Cabal dir for a new project. Various ways of figuring this out,
-   and indeed just prompting the user. Do them all."
+  "Get the Cabal dir for a new project.
+Various ways of figuring this out, and indeed just prompting the user.  Do them
+all."
   (let* ((file (haskell-cabal-find-file))
          (dir (if file (file-name-directory file) default-directory)))
     (if use-defaults
@@ -360,8 +361,9 @@ OTHER-WINDOW use `find-file-other-window'."
 (defconst haskell-cabal-conditional-regexp "^[ \t]*\\(\\if\\|else\\|}\\)")
 
 (defun haskell-cabal-classify-line ()
-  "Classify the current line into 'section-header 'subsection-header
-'section-data 'comment and 'empty '"
+  "Classify the current line's type.
+Possible results are 'section-header 'subsection-header 'section-data 'comment
+and 'empty '"
   (save-excursion
     (beginning-of-line)
     (cond
@@ -494,8 +496,8 @@ OTHER-WINDOW use `find-file-other-window'."
           ((equal component-type "benchmark")  "bench"))))
 
 (defun haskell-cabal-enum-targets (&optional process-type)
-  "Enumerate .cabal targets. PROCESS-TYPE determines the format of the
-returned target."
+  "Enumerate .cabal targets.
+PROCESS-TYPE determines the format of the returned target."
   (let ((cabal-file (haskell-cabal-find-file))
         (process-type (if process-type process-type 'ghci)))
     (when (and cabal-file (file-readable-p cabal-file))
@@ -925,11 +927,10 @@ resulting buffer-content.  Unmark line at the end."
                     haskell-cabal-source-bearing-sections))))
 
 (defun haskell-cabal-line-filename ()
-  "Expand filename in current line according to the subsection type
+  "Expand filename in current line according to the subsection type.
 
-Module names in exposed-modules and other-modules are expanded by
-replacing each dot (.) in the module name with a forward slash (/) and
-appending \".hs\"
+Module names in exposed-modules and other-modules are expanded by replacing each
+dot (.) in the module name with a forward slash (/) and appending \".hs\"
 
 Example: Foo.Bar.Quux ==> Foo/Bar/Quux.hs
 

--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -41,36 +41,41 @@
 
 (defcustom haskell-compile-cabal-build-command
   "cabal build --ghc-option=-ferror-spans"
-  "Default build command to use for `haskell-cabal-build' when a cabal file is detected.
+  "Default build command to use for `haskell-cabal-build' when a cabal
+file is detected.
 For legacy compat, `%s' is replaced by the cabal package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-cabal-build-alt-command
   "cabal clean -s && cabal build --ghc-option=-ferror-spans"
-  "Alternative build command to use when `haskell-cabal-build' is called with a negative prefix argument.
-For legacy compat, `%s' is replaced by the cabal package top folder."
+  "Alternative build command to use when `haskell-cabal-build' is
+called with a negative prefix argument.  For legacy compat, `%s' is
+replaced by the cabal package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-stack-build-command
   "stack build --fast"
-  "Default build command to use for `haskell-stack-build' when a stack file is detected.
-For legacy compat, `%s' is replaced by the stack package top folder."
+  "Default build command to use for `haskell-stack-build' when a stack
+file is detected.  For legacy compat, `%s' is replaced by the stack
+package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-stack-build-alt-command
   "stack clean && stack build --fast"
-  "Alternative build command to use when `haskell-stack-build' is called with a negative prefix argument.
-For legacy compat, `%s' is replaced by the stack package top folder."
+  "Alternative build command to use when `haskell-stack-build' is
+called with a negative prefix argument.  For legacy compat, `%s' is
+replaced by the stack package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-command
   "ghc -Wall -ferror-spans -fforce-recomp -c %s"
-  "Default build command to use for `haskell-cabal-build' when no cabal or stack file is detected.
-The `%s' placeholder is replaced by the current buffer's filename."
+  "Default build command to use for `haskell-cabal-build' when no
+cabal or stack file is detected.  The `%s' placeholder is replaced by
+the current buffer's filename."
   :group 'haskell-compile
   :type 'string)
 
@@ -83,8 +88,8 @@ The `%s' placeholder is replaced by the current buffer's filename."
 (defcustom haskell-compiler-type
   'auto
   "Controls whether to use cabal, stack, or ghc to compile.
-   Auto (the default) means infer from the presence of a cabal or stack spec file,
-   following same rules as haskell-process-type."
+Auto (the default) means infer from the presence of a cabal or stack
+spec file, following same rules as haskell-process-type."
     :type '(choice (const auto) (const ghc) (const stack) (const cabal))
     :group 'haskell-compile)
 (make-variable-buffer-local 'haskell-compiler-type)

--- a/haskell-compile.el
+++ b/haskell-compile.el
@@ -41,41 +41,41 @@
 
 (defcustom haskell-compile-cabal-build-command
   "cabal build --ghc-option=-ferror-spans"
-  "Default build command to use for `haskell-cabal-build' when a cabal
-file is detected.
+  "Default build command to use for `haskell-cabal-build'.
+It is used when a cabal file is detected.
 For legacy compat, `%s' is replaced by the cabal package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-cabal-build-alt-command
   "cabal clean -s && cabal build --ghc-option=-ferror-spans"
-  "Alternative build command to use when `haskell-cabal-build' is
-called with a negative prefix argument.  For legacy compat, `%s' is
-replaced by the cabal package top folder."
+  "Alternative build command to use when `haskell-cabal-build'.
+It is used when `haskell-cabal-build' is called with a negative prefix argument.
+For legacy compat, `%s' is replaced by the cabal package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-stack-build-command
   "stack build --fast"
-  "Default build command to use for `haskell-stack-build' when a stack
-file is detected.  For legacy compat, `%s' is replaced by the stack
-package top folder."
+  "Default build command to use for `haskell-stack-build'.
+It is used when a stack file is detected.
+For legacy compat, `%s' is replaced by the stack package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-stack-build-alt-command
   "stack clean && stack build --fast"
-  "Alternative build command to use when `haskell-stack-build' is
-called with a negative prefix argument.  For legacy compat, `%s' is
-replaced by the stack package top folder."
+  "Alternative build command to use when `haskell-stack-build'.
+It is used when `haskell-stack-build' is called with a negative prefix argument.
+For legacy compat, `%s' is replaced by the stack package top folder."
   :group 'haskell-compile
   :type 'string)
 
 (defcustom haskell-compile-command
   "ghc -Wall -ferror-spans -fforce-recomp -c %s"
-  "Default build command to use for `haskell-cabal-build' when no
-cabal or stack file is detected.  The `%s' placeholder is replaced by
-the current buffer's filename."
+  "Default build command to use for `haskell-cabal-build'.
+It is used when no cabal or stack file is detected.
+The `%s' placeholder is replaced by the current buffer's filename."
   :group 'haskell-compile
   :type 'string)
 
@@ -88,8 +88,8 @@ the current buffer's filename."
 (defcustom haskell-compiler-type
   'auto
   "Controls whether to use cabal, stack, or ghc to compile.
-Auto (the default) means infer from the presence of a cabal or stack
-spec file, following same rules as haskell-process-type."
+Auto (the default) means infer from the presence of a cabal or stack spec file,
+following same rules as haskell-process-type."
     :type '(choice (const auto) (const ghc) (const stack) (const cabal))
     :group 'haskell-compile)
 (make-variable-buffer-local 'haskell-compiler-type)

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -172,8 +172,8 @@ pass additional flags to `ghc'."
 
 (defcustom haskell-process-do-cabal-format-string
   ":!cd %s && %s"
-  "The way to run cabal commands. It takes two arguments -- the
-directory and the command.
+  "The way to run cabal commands.
+It takes two arguments -- the directory and the command.
 See `haskell-process-do-cabal' for more details."
   :group 'haskell-interactive
   :type 'string)
@@ -242,8 +242,8 @@ is a member of the hidden package, blah blah."
 
 (defcustom haskell-process-suggest-overloaded-strings
   t
-  "Suggest adding OverloadedStrings pragma to file when getting type
-mismatches with [Char]."
+  "Suggest adding OverloadedStrings pragma to file.
+It is used when getting type mismatches with [Char]."
   :type 'boolean
   :group 'haskell-interactive)
 

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -172,7 +172,8 @@ pass additional flags to `ghc'."
 
 (defcustom haskell-process-do-cabal-format-string
   ":!cd %s && %s"
-  "The way to run cabal commands. It takes two arguments -- the directory and the command.
+  "The way to run cabal commands. It takes two arguments -- the
+directory and the command.
 See `haskell-process-do-cabal' for more details."
   :group 'haskell-interactive
   :type 'string)
@@ -241,7 +242,8 @@ is a member of the hidden package, blah blah."
 
 (defcustom haskell-process-suggest-overloaded-strings
   t
-  "Suggest adding OverloadedStrings pragma to file when getting type mismatches with [Char]."
+  "Suggest adding OverloadedStrings pragma to file when getting type
+mismatches with [Char]."
   :type 'boolean
   :group 'haskell-interactive)
 

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -434,7 +434,8 @@ Returns the location of the start of the comment, nil otherwise."
         (haskell-indent-skip-blanks-and-newlines-forward end))))
 
 (defun haskell-indent-next-symbol-safe (end)
-  "Puts point to the next following symbol, or to end if there are no more symbols in the sexp."
+  "Puts point to the next following symbol, or to end if there are no
+more symbols in the sexp."
   (condition-case _errlist (haskell-indent-next-symbol end)
     (error (goto-char end))))
 

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -434,8 +434,8 @@ Returns the location of the start of the comment, nil otherwise."
         (haskell-indent-skip-blanks-and-newlines-forward end))))
 
 (defun haskell-indent-next-symbol-safe (end)
-  "Puts point to the next following symbol, or to end if there are no
-more symbols in the sexp."
+  "Puts point if there are no more symbols in the sexp.
+The point is put to the next following symbol, or to end."
   (condition-case _errlist (haskell-indent-next-symbol end)
     (error (goto-char end))))
 

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -48,9 +48,9 @@
   "Mark used for the old beginning of the prompt.")
 
 (defun haskell-interactive-prompt-regex ()
-  "Generate a regex for searching for any occurrence of the prompt\
-at the beginning of the line.  This should prevent any
-interference with prompts that look like haskell expressions."
+  "Generate a regex for searching for any occurrence of the prompt at
+the beginning of the line.  This should prevent any interference with
+prompts that look like haskell expressions."
   (concat "^" (regexp-quote haskell-interactive-prompt)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -48,9 +48,10 @@
   "Mark used for the old beginning of the prompt.")
 
 (defun haskell-interactive-prompt-regex ()
-  "Generate a regex for searching for any occurrence of the prompt at
-the beginning of the line.  This should prevent any interference with
-prompts that look like haskell expressions."
+  "Generate a regex for searching whether prompt or not.
+The regex is for searching for any occurrence of the prompt at the beginning of
+the line.  This should prevent any interference with prompts that look like
+haskell expressions."
   (concat "^" (regexp-quote haskell-interactive-prompt)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/haskell-lexeme.el
+++ b/haskell-lexeme.el
@@ -453,9 +453,9 @@ Possible results are:
 - 'char: for char literals
 - 'number: for decimal, float, hexadecimal and octal number literals
 - 'template-haskell-quote: for a string of apostrophes for template
-  haskell
-- 'template-haskell-quasi-quote: for a string of apostrophes for
-  template haskell
+   haskell
+- 'template-haskell-quasi-quote: for a string of apostrophes for template
+   haskell
 
 Note that for qualified symbols (match-string 1) returns the
 unqualified identifier or symbol.  Further qualification for

--- a/haskell-lexeme.el
+++ b/haskell-lexeme.el
@@ -452,8 +452,10 @@ Possible results are:
 - 'string: for strings literals
 - 'char: for char literals
 - 'number: for decimal, float, hexadecimal and octal number literals
-- 'template-haskell-quote: for a string of apostrophes for template haskell
-- 'template-haskell-quasi-quote: for a string of apostrophes for template haskell
+- 'template-haskell-quote: for a string of apostrophes for template
+  haskell
+- 'template-haskell-quasi-quote: for a string of apostrophes for
+  template haskell
 
 Note that for qualified symbols (match-string 1) returns the
 unqualified identifier or symbol.  Further qualification for

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -1142,7 +1142,8 @@ successful, nil otherwise."
  "2015-11-11")
 
 (defun haskell-mode-toggle-scc-at-point ()
-  "If point is in an SCC annotation, kill the annotation.  Otherwise, try to insert a new annotation."
+  "If point is in an SCC annotation, kill the annotation.
+Otherwise, try to insert a new annotation."
   (interactive)
   (if (not (haskell-mode-try-kill-scc-at-point))
       (if (not (haskell-mode-try-insert-scc-at-point))
@@ -1181,7 +1182,8 @@ Uses `haskell-guess-module-name-from-file-name'."
 
 (defvar haskell-auto-insert-module-format-string
   "-- | \n\nmodule %s where\n\n"
-  "Template string that will be inserted in new haskell buffers via `haskell-auto-insert-module-template'.")
+  "Template string that will be inserted in new haskell buffers via
+`haskell-auto-insert-module-template'.")
 
 (defun haskell-auto-insert-module-template ()
   "Insert a module template for the newly created buffer."

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -1182,7 +1182,8 @@ Uses `haskell-guess-module-name-from-file-name'."
 
 (defvar haskell-auto-insert-module-format-string
   "-- | \n\nmodule %s where\n\n"
-  "Template string that will be inserted in new haskell buffers via
+  "Template string for the `haskell-auto-insert-module-template' command.
+It will be inserted in new haskell buffers via
 `haskell-auto-insert-module-template'.")
 
 (defun haskell-auto-insert-module-template ()

--- a/haskell-move-nested.el
+++ b/haskell-move-nested.el
@@ -34,7 +34,8 @@
 
 ;;;###autoload
 (defun haskell-move-nested (cols)
-  "Shift the nested off-side-rule block adjacent to point by COLS columns to the right.
+  "Shift the nested off-side-rule block adjacent to point by COLS
+columns to the right.
 
 In Transient Mark mode, if the mark is active, operate on the contents
 of the region instead.

--- a/haskell-move-nested.el
+++ b/haskell-move-nested.el
@@ -34,7 +34,8 @@
 
 ;;;###autoload
 (defun haskell-move-nested (cols)
-  "Shift the nested off-side-rule block adjacent to point by COLS
+  "Shift the nested off-side-rule block adjacent to point.
+It shift the nested off-side-rule block adjacent to point by COLS
 columns to the right.
 
 In Transient Mark mode, if the mark is active, operate on the contents

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -205,8 +205,8 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
     t))
 
 (defun haskell-process-send-string (process string)
-  "Try to send a string to the process's process. Ask to restart if
-it's not running."
+  "Try to send a string to the process's process.
+Ask to restart if it's not running."
   (let ((child (haskell-process-process process)))
     (if (equal 'run (process-status child))
         (let ((out (concat string "\n")))

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -205,7 +205,8 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
     t))
 
 (defun haskell-process-send-string (process string)
-  "Try to send a string to the process's process. Ask to restart if it's not running."
+  "Try to send a string to the process's process. Ask to restart if
+it's not running."
   (let ((child (haskell-process-process process)))
     (if (equal 'run (process-status child))
         (let ((out (concat string "\n")))

--- a/haskell.el
+++ b/haskell.el
@@ -446,10 +446,11 @@ Give optional NEXT-P parameter to override value of
                       (list "build --ghc-options=-fforce-recomp"))))))
 
 (defun haskell-process-file-loadish (command reload-p module-buffer)
-  "Run a loading-ish COMMAND that wants to pick up type errors and
-things like that.  RELOAD-P indicates whether the notification should
-say 'reloaded' or 'loaded'.  MODULE-BUFFER may be used for various
-things, but is optional."
+  "Run a loading-ish COMMAND.
+For example, a COMMAND that wants to pick up type errors and things like that.
+RELOAD-P indicates whether the notification
+should say 'reloaded' or 'loaded'.  MODULE-BUFFER may be used
+for various things, but is optional."
   (let ((session (haskell-session)))
     (haskell-session-current-dir session)
     (when haskell-process-check-cabal-config-on-load

--- a/haskell.el
+++ b/haskell.el
@@ -446,10 +446,10 @@ Give optional NEXT-P parameter to override value of
                       (list "build --ghc-options=-fforce-recomp"))))))
 
 (defun haskell-process-file-loadish (command reload-p module-buffer)
-  "Run a loading-ish COMMAND that wants to pick up type errors\
-and things like that.  RELOAD-P indicates whether the notification
-should say 'reloaded' or 'loaded'.  MODULE-BUFFER may be used
-for various things, but is optional."
+  "Run a loading-ish COMMAND that wants to pick up type errors and
+things like that.  RELOAD-P indicates whether the notification should
+say 'reloaded' or 'loaded'.  MODULE-BUFFER may be used for various
+things, but is optional."
   (let ((session (haskell-session)))
     (haskell-session-current-dir session)
     (when haskell-process-check-cabal-config-on-load

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -73,7 +73,8 @@ directory structure."
 
 (defvar inferior-haskell-multiline-prompt-re
   "^\\*?[[:upper:]][\\._[:alnum:]]*\\(?: \\*?[[:upper:]][\\._[:alnum:]]*\\)*| "
-  "Regular expression for matching multiline prompt (the one inside :{ ... :} blocks).")
+  "Regular expression for matching multiline prompt
+(the one inside :{ ... :} blocks).")
 
 (defconst inferior-haskell-error-regexp-alist
   `(;; Format of error messages used by GHCi.

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -73,8 +73,8 @@ directory structure."
 
 (defvar inferior-haskell-multiline-prompt-re
   "^\\*?[[:upper:]][\\._[:alnum:]]*\\(?: \\*?[[:upper:]][\\._[:alnum:]]*\\)*| "
-  "Regular expression for matching multiline prompt
-(the one inside :{ ... :} blocks).")
+  "Regular expression for matching multiline prompt.
+the one inside :{ ... :} blocks.")
 
 (defconst inferior-haskell-error-regexp-alist
   `(;; Format of error messages used by GHCi.

--- a/w3m-haddock.el
+++ b/w3m-haddock.el
@@ -42,15 +42,15 @@
 
 (defcustom haskell-w3m-haddock-dirs
   '("~/.cabal/share/doc/")
-  "The path to your cabal documentation dir. It should contain
-directories of package-name-x.x.
+  "The path to your cabal documentation dir.
+It should contain directories of package-name-x.x.
 
 You can rebind this if you're using hsenv by adding it to your
 .dir-locals.el in your project root. E.g.
 
     ((haskell-mode .
       ((haskell-w3m-haddock-dirs .
-       (\"/home/chris/Projects/foobar/.hsenv/cabal/share/doc\")))))
+        (\"/home/chris/Projects/foobar/.hsenv/cabal/share/doc\")))))
 
 "
   :group 'haskell

--- a/w3m-haddock.el
+++ b/w3m-haddock.el
@@ -48,7 +48,9 @@ directories of package-name-x.x.
 You can rebind this if you're using hsenv by adding it to your
 .dir-locals.el in your project root. E.g.
 
-    ((haskell-mode . ((haskell-w3m-haddock-dirs . (\"/home/chris/Projects/foobar/.hsenv/cabal/share/doc\")))))
+    ((haskell-mode .
+      ((haskell-w3m-haddock-dirs .
+       (\"/home/chris/Projects/foobar/.hsenv/cabal/share/doc\")))))
 
 "
   :group 'haskell


### PR DESCRIPTION
rel: #1779 

Hello,

When building with Emacs 28.1, there were several places where an error occurred because the docstring had more than 80 characters.
I have adjusted the number of characters per line in the docstring where the error occurs.

If there are line breaks in the wrong place, please feel free to correct it.

Thank you.
