### PR TITLE
Correct parenthese matching error

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -677,9 +677,9 @@ happened since function invocation)."
                             (cdr (reverse haskell-utils-async-post-command-flag))))
                ;; Present the result only when response is valid and not asked
                ;; to insert result
-               (haskell-command-echo-or-present response)))
+               (haskell-command-echo-or-present response))))
 
-            (haskell-utils-async-stop-watching-changes init-buffer))))))))
+          (haskell-utils-async-stop-watching-changes init-buffer)))))))
 
 (make-obsolete 'haskell-process-generate-tags
                'haskell-mode-generate-tags


### PR DESCRIPTION
The emacs upstream will raise an error now when `otherwise` or `t` clause is not the last clause in a `cl-case`. There is a such `cl-case` in `haskell-commands.el` which is apparently a typo and should be fixed.

Reference: https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=6d8f5161ead689b7a2e44a7de0a695f0ab4c833b