### PR TITLE
Fix misplaced parenthesis

### DIFF
--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -677,9 +677,9 @@ happened since function invocation)."
                             (cdr (reverse haskell-utils-async-post-command-flag))))
                ;; Present the result only when response is valid and not asked
                ;; to insert result
-               (haskell-command-echo-or-present response)))
+               (haskell-command-echo-or-present response))))
 
-            (haskell-utils-async-stop-watching-changes init-buffer))))))))
+          (haskell-utils-async-stop-watching-changes init-buffer)))))))
 
 (make-obsolete 'haskell-process-generate-tags
                'haskell-mode-generate-tags


### PR DESCRIPTION
I `doom/upgrade`d my Emacs today, and it started complaining about:

```
Misplaced t or ‘otherwise’ clause
```

It seems one of the parentheses was misplaced, creating a case branch after `otherwise` which should not be there.