### PR TITLE
Hoogle: colorize hoogle cli output using haskell-mode font-lock

### DIFF
--- a/haskell-hoogle.el
+++ b/haskell-hoogle.el
@@ -59,11 +59,6 @@ If nil, use the Hoogle web-site."
           (const :tag "fp-complete" "https://www.stackage.org/lts/hoogle?q=%s")
           string))
 
-(defcustom haskell-hoogle-colorize-with-haskell-mode t
-  "Whether to use haskell-mode to colorize hoogles's CLI output."
-  :group 'haskell
-  :type 'boolean)
-
 ;;;###autoload
 (defun haskell-hoogle (query &optional info)
   "Do a Hoogle search for QUERY.
@@ -76,24 +71,21 @@ is asked to show extra info for the items matching QUERY.."
     (let* ((command (concat (if (functionp haskell-hoogle-command)
                                 (funcall haskell-hoogle-command)
                               haskell-hoogle-command)
-                          (if info " -i " "")
-                          " --color " (shell-quote-argument query)))
-         (output (shell-command-to-string command)))
+                            (if info " -i " "")
+                            " --color " (shell-quote-argument query)))
+           (output (shell-command-to-string command)))
       (with-help-window "*hoogle*"
         (with-current-buffer standard-output
-          (if haskell-hoogle-colorize-with-haskell-mode
-              (let ((outs (ansi-color-filter-apply output)))
-                (delay-mode-hooks (haskell-mode))
-                (if info
-                    (let ((lns (split-string output "\n" t " ")))
-                      (insert (car lns) "\n\n")
-                      (dolist (ln (cdr lns)) (insert "-- " ln "\n")))
-                  (insert outs)
-                  (forward-line -1)
-                  (when (looking-at-p "^plus more results") (insert "\n-- ")))
-              (view-mode))
-          (insert output)
-          (ansi-color-apply-on-region (point-min) (point-max))))))))
+          (let ((outs (ansi-color-filter-apply output)))
+            (delay-mode-hooks (haskell-mode))
+            (if info
+                (let ((lns (split-string output "\n" t " ")))
+                  (insert (car lns) "\n\n")
+                  (dolist (ln (cdr lns)) (insert "-- " ln "\n")))
+              (insert outs)
+              (forward-line -1)
+              (when (looking-at-p "^plus more results") (insert "\n-- ")))
+            (view-mode)))))))
 
 ;;;###autoload
 (defalias 'hoogle 'haskell-hoogle)
@@ -106,9 +98,9 @@ is asked to show extra info for the items matching QUERY.."
 
 (defcustom haskell-hoogle-server-command (lambda (port)
                                            (list "hoogle" "server"
-                                            "--local"
-                                            "-p"
-                                            (number-to-string port)))
+                                                 "--local"
+                                                 "-p"
+                                                 (number-to-string port)))
   "Command used to start the local hoogle server."
   :group 'haskell
   :type 'function


### PR DESCRIPTION
It's been a long time since hoogle command line interface lost the ability to
output ANSI colors (see https://github.com/ndmitchell/hoogle/issues/133).

This patch makes haskell-hoogle to use emacs font lock to fontify its output,
with a custom flag to opt out.