### PR TITLE
Remove needless quotes from keylist of case macro

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -702,7 +702,7 @@ Respect the COMMA-STYLE, see
 `haskell-cabal-strip-list-and-detect-style' for the possible
 styles."
   (cl-case comma-style
-    ('before
+    (before
      (goto-char (point-min))
      (while (haskell-cabal-ignore-line-p) (forward-line))
      (indent-to 2)
@@ -710,14 +710,14 @@ styles."
      (haskell-cabal-each-line
       (unless (haskell-cabal-ignore-line-p)
         (insert ", "))))
-    ('after
+    (after
      (goto-char (point-max))
      (while (equal 0 (forward-line -1))
        (unless (haskell-cabal-ignore-line-p)
          (end-of-line)
          (insert ",")
          (beginning-of-line))))
-    ('single
+    (single
      (goto-char (point-min))
      (while (not (eobp))
        (end-of-line)

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -653,11 +653,11 @@ happened since function invocation)."
           (cl-case res-type
             ;; neither popup presentation buffer
             ;; nor insert response in error case
-            ('unknown-command
+            (unknown-command
              (message "This command requires GHCi 8+ or GHCi-ng. Please read command description for details."))
-            ('option-missing
+            (option-missing
              (message "Could not infer type signature. You need to load file first. Also :set +c is required, see customization `haskell-interactive-set-+c'. Please read command description for details."))
-            ('interactive-error (message "Wrong REPL response: %s" sig))
+            (interactive-error (message "Wrong REPL response: %s" sig))
             (otherwise
              (if insert-value
                  ;; Only insert type signature and do not present it

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -308,11 +308,11 @@ PREFIX should be a list such one returned by
     (when (not (eql typ 'haskell-completions-general-prefix))
       (let ((candidates
              (cl-case typ
-               ('haskell-completions-pragma-name-prefix
+               (haskell-completions-pragma-name-prefix
                 haskell-completions--pragma-names)
-               ('haskell-completions-ghc-option-prefix
+               (haskell-completions-ghc-option-prefix
                 haskell-ghc-supported-options)
-               ('haskell-completions-language-extension-prefix
+               (haskell-completions-language-extension-prefix
                 haskell-ghc-supported-extensions)
                (otherwise
                 (append (when (bound-and-true-p haskell-tags-on-save)

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -265,9 +265,9 @@ list of modules where missed IDENT was found."
                      (get-buffer-create "*haskell-process-log*"))
       (switch-to-buffer-other-window (get-buffer "*haskell-process-log*")))
      (t (let ((app-name (cl-ecase (haskell-process-type)
-                          ('ghci haskell-process-path-cabal)
-                          ('cabal-repl haskell-process-path-cabal)
-                          ('stack-ghci haskell-process-path-stack))))
+                          (ghci haskell-process-path-cabal)
+                          (cabal-repl haskell-process-path-cabal)
+                          (stack-ghci haskell-process-path-stack))))
           (haskell-process-queue-command
            process
            (make-haskell-command
@@ -566,12 +566,12 @@ When MODULE-BUFFER is non-NIL, paint error overlays."
   "Show the '(Compiling|Loading) X' message."
   (let ((msg (concat
               (cl-ecase type
-                ('compiling
+                (compiling
                  (if haskell-interactive-mode-include-file-name
                      (format "Compiling: %s (%s)" module-name file-name)
                    (format "Compiling: %s" module-name)))
-                ('loading (format "Loading: %s" module-name))
-                ('import-cycle
+                (loading (format "Loading: %s" module-name))
+                (import-cycle
                  (format "Module has an import cycle: %s" module-name)))
               (if th " [TH]" ""))))
     (haskell-mode-message-line msg)

--- a/haskell-process.el
+++ b/haskell-process.el
@@ -77,7 +77,7 @@ Do not actually start any process.
 HPTYPE is the result of calling `'haskell-process-type`' function."
   (let ((session-name (haskell-session-name session)))
     (cl-ecase hptype
-      ('ghci
+      (ghci
        (append (list (format "Starting inferior GHCi process %s ..."
                              haskell-process-path-ghci)
                      session-name
@@ -86,7 +86,7 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
                       (list
                        (append (haskell-process-path-to-list haskell-process-path-ghci)
                                haskell-process-args-ghci)))))
-      ('cabal-repl
+      (cabal-repl
        (append (list (format "Starting inferior `cabal repl' process using %s ..."
                              haskell-process-path-cabal)
                      session-name
@@ -99,7 +99,7 @@ HPTYPE is the result of calling `'haskell-process-type`' function."
                         haskell-process-args-cabal-repl
                         (let ((target (haskell-session-target session)))
                           (if target (list target) nil)))))))
-      ('stack-ghci
+      (stack-ghci
        (append (list (format "Starting inferior stack GHCi process using %s" haskell-process-path-stack)
                      session-name
                      nil)

--- a/inf-haskell.el
+++ b/inf-haskell.el
@@ -55,14 +55,14 @@
   "Return the command with the arguments to start the repl based on the
 directory structure."
   (cl-ecase (haskell-process-type)
-    ('ghci       (cond ((eq system-type 'cygwin) `("ghcii.sh" ,@haskell-process-args-ghci))
-                       (t (append
-                           (if (listp haskell-process-path-ghci)
-                               haskell-process-path-ghci
-                             (list haskell-process-path-ghci))
-                           haskell-process-args-ghci))))
-    ('cabal-repl `(,haskell-process-path-cabal "repl" ,@haskell-process-args-cabal-repl))
-    ('stack-ghci `(,haskell-process-path-stack "ghci" ,@haskell-process-args-stack-ghci))))
+    (ghci       (cond ((eq system-type 'cygwin) `("ghcii.sh" ,@haskell-process-args-ghci))
+                      (t (append
+                          (if (listp haskell-process-path-ghci)
+                              haskell-process-path-ghci
+                            (list haskell-process-path-ghci))
+                          haskell-process-args-ghci))))
+    (cabal-repl `(,haskell-process-path-cabal "repl" ,@haskell-process-args-cabal-repl))
+    (stack-ghci `(,haskell-process-path-stack "ghci" ,@haskell-process-args-stack-ghci))))
 
 (defconst inferior-haskell-info-xref-re
   "-- Defined at \\(.+\\):\\([0-9]+\\):\\([0-9]+\\)\\(?:-\\([0-9]+\\)\\)?$")


### PR DESCRIPTION
Development Emacs(29.0.50) generates following byte-compile warnings. This PR fixes warnings like below ones.

```
haskell-cabal.el:704:12: Warning: Case 'before will match ‘quote’.  If that’s
    intended, write (before quote) instead.  Otherwise, don’t quote ‘before’.
haskell-cabal.el:704:12: Warning: Case 'after will match ‘quote’.  If that’s
    intended, write (after quote) instead.  Otherwise, don’t quote ‘after’.
haskell-cabal.el:704:12: Warning: Case 'single will match ‘quote’.  If that’s
    intended, write (single quote) instead.  Otherwise, don’t quote ‘single’.
```