### PR TITLE
Replace obsoleted functions

### DIFF
--- a/haskell-collapse.el
+++ b/haskell-collapse.el
@@ -43,7 +43,7 @@
   "Returns `t' if line is empty or composed only of whitespace."
   (save-excursion
     (beginning-of-line)
-    (= (point-at-eol)
+    (= (line-end-position)
        (progn (skip-chars-forward "[:blank:]") (point)))))
 
 (defun haskell-indented-block ()
@@ -92,7 +92,7 @@ indentation if dir=-1"
   (save-excursion
     (goto-char (point-max))
     (while (zerop (forward-line -1))
-      (goto-char (point-at-bol))
+      (goto-char (line-beginning-position))
       (when (= (current-indentation) 0) (haskell-hide-toggle)))))
 
 (defvar haskell-collapse-mode-map


### PR DESCRIPTION
point-at-bol and point-at-eol will be obsoleted since Emacs 29.1. This PR fixes the following byte-compile warnings.

```
In haskell-blank-line-p:
haskell-collapse.el:46:9: Warning: ‘point-at-eol’ is an obsolete function (as
    of 29.1); use ‘line-end-position’ or ‘pos-eol’ instead.

In haskell-hide-toggle-all:
haskell-collapse.el:95:19: Warning: ‘point-at-bol’ is an obsolete function (as
    of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
```