### PR TITLE
Escape single quote in docstring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ $(AUTOLOADS): $(ELFILES)
 	$(BATCH) \
 		--eval '(setq make-backup-files nil)' \
 		--eval "(setq generated-autoload-file (concat command-line-default-directory \"/\" \"$@\"))" \
+		--eval "(require 'autoload)" \
 		-f batch-update-autoloads "."
 # check if autoloads will really load
 	$(BATCH) -l "$@"

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -362,8 +362,8 @@ OTHER-WINDOW use `find-file-other-window'."
 
 (defun haskell-cabal-classify-line ()
   "Classify the current line's type.
-Possible results are 'section-header 'subsection-header 'section-data 'comment
-and 'empty '"
+Possible results are \\='section-header \\='subsection-header \\='section-data
+\\='comment and \\='empty"
   (save-excursion
     (beginning-of-line)
     (cond

--- a/haskell-completions.el
+++ b/haskell-completions.el
@@ -144,7 +144,7 @@ whitespace or new line, otherwise returns nil.
 
 (defun haskell-completions-grab-pragma-prefix ()
   "Grab completion prefix for pragma completions.
-Returns a list of form '(prefix-start-position
+Returns a list of form \\='(prefix-start-position
 prefix-end-position prefix-value prefix-type) for pramga names
 such as WARNING, DEPRECATED, LANGUAGE etc.  Also returns
 completion prefixes for options in case OPTIONS_GHC pragma, or
@@ -214,7 +214,7 @@ pragma is supported also."
 
 (defun haskell-completions-grab-identifier-prefix ()
   "Grab completion prefix for identifier at point.
-Returns a list of form '(prefix-start-position
+Returns a list of form \\='(prefix-start-position
 prefix-end-position prefix-value prefix-type) for haskell
 identifier at point depending on result of function
 `haskell-ident-pos-at-point'."
@@ -265,7 +265,7 @@ identifier at point depending on result of function
 
 (defun haskell-completions-grab-prefix (&optional minlen)
    "Grab prefix at point for possible completion.
-Returns a list of form '(prefix-start-position
+Returns a list of form \\='(prefix-start-position
 prefix-end-position prefix-value prefix-type) depending on
 situation, e.g. is it needed to complete pragma, module name,
 arbitrary identifier, etc.  Returns nil in case it is

--- a/haskell-customize.el
+++ b/haskell-customize.el
@@ -53,7 +53,7 @@ Used for locating additional package data files.")
 
 Customize this variable to see the supported symbol values.
 
-When set to 'auto (the default), the directory contents and
+When set to \\='auto (the default), the directory contents and
 available programs will be used to make a best guess at the
 process type and the project directory.
 
@@ -86,7 +86,7 @@ The following example function arranges for all haskell process
 commands to be started in the current nix-shell environment:
 
   (lambda (argv) (append (list \"nix-shell\" \"-I\" \".\" \"--command\" )
-                    (list (mapconcat 'identity argv \" \"))))
+                    (list (mapconcat \\='identity argv \" \"))))
 
 See Info Node `(emacs)Directory Variables' for a way to set this option on
 a per-project basis."
@@ -367,7 +367,7 @@ read-only property."
   '()
   "Support a mapping from module to import lines.
 
-E.g. '((\"Data.Map\" . \"import qualified Data.Map as M
+E.g. \\='((\"Data.Map\" . \"import qualified Data.Map as M
 import Data.Map (Map)
 \"))
 
@@ -413,9 +413,9 @@ presence of a *.cabal file or stack.yaml file or something similar.")
 (defun haskell-build-type ()
   "Looks for cabal and stack spec files.
    When found, returns a pair (TAG . DIR)
-   where TAG is 'cabal-project, 'cabal-sandbox. 'cabal, or 'stack;
+   where TAG is \\='cabal-project, \\='cabal-sandbox. \\='cabal, or \\='stack;
    and DIR is the directory containing cabal or stack file.
-   When none found, DIR is nil, and TAG is 'ghc"
+   When none found, DIR is nil, and TAG is \\='ghc"
   ;; REVIEW maybe just 'cabal is enough.
   (let ((cabal-project (locate-dominating-file default-directory "cabal.project"))
         (cabal-sandbox (locate-dominating-file default-directory "cabal.sandbox.config"))
@@ -439,8 +439,8 @@ presence of a *.cabal file or stack.yaml file or something similar.")
      (t (error "Could not find any installation of GHC.")))))
 
 (defun haskell-process-type ()
-  "Return `haskell-process-type', or a guess if that variable is 'auto.
-   Converts the obsolete 'cabal-new-repl to its equivalent 'cabal-repl.
+  "Return `haskell-process-type', or a guess if that variable is \\='auto.
+   Converts the obsolete \\='cabal-new-repl to its equivalent \\='cabal-repl.
    May also set `inferior-haskell-root-dir'"
   (cond
    ((eq 'cabal-new-repl haskell-process-type)

--- a/haskell-indent.el
+++ b/haskell-indent.el
@@ -1324,7 +1324,7 @@ of the regions to move."
 (defun haskell-indent-align-def (p-arg type)
   "Align guards or rhs within the current definition before point.
 If P-ARG is t align all defs up to the mark.
-TYPE is either 'guard or 'rhs."
+TYPE is either \\='guard or \\='rhs."
   (save-excursion
     (let (start-block end-block
                       (maxcol (if (eq type 'rhs) haskell-indent-rhs-align-column 0))

--- a/haskell-indentation.el
+++ b/haskell-indentation.el
@@ -793,7 +793,7 @@ For example
          (throw 'parse-end nil))))))
 
 (defun haskell-indentation-toplevel-where ()
-  "Parse 'where' that we may hit as a standalone in module declaration."
+  "Parse \\='where\\=' that we may hit as a standalone in module declaration."
   (haskell-indentation-read-next-token)
 
   (when (eq current-token 'end-tokens)
@@ -1160,13 +1160,13 @@ yet. Keep the list in ascending order."
 
 The following symbols are used as pseudo tokens:
 
-'layout-item: A new item in a layout list.  The next token
+\\='layout-item: A new item in a layout list.  The next token
               will be the first token from the item.
 
-'layout-end:  the end of a layout list.  Next token will be
+\\='layout-end:  the end of a layout list.  Next token will be
               the first token after the layout list.
 
-'end-tokens:  back at point where we started, following-token
+\\='end-tokens:  back at point where we started, following-token
               will be set to the next token.
 
 Pseudo tokens are used only when implicit-layout-active is

--- a/haskell-interactive-mode.el
+++ b/haskell-interactive-mode.el
@@ -396,7 +396,7 @@ SESSION, otherwise operate on the current buffer."
                           'rear-nonsticky t)))))
 
 (defun haskell-interactive-mode-goto-end-point ()
-  "Go to the 'end' of the buffer (before the prompt)."
+  "Go to the \\='end\\=' of the buffer (before the prompt)."
   (goto-char haskell-interactive-mode-prompt-start)
   (goto-char (line-beginning-position)))
 

--- a/haskell-lexeme.el
+++ b/haskell-lexeme.el
@@ -91,11 +91,11 @@ Using this function is more efficient than matching against the
 regexp `haskell-lexeme-qid-or-qsym'.
 
 Returns:
-  'qid - if matched a qualified id: 'Data.Map' or 'Map'
-  'qsym - if matched a qualified id: 'Monad.>>=' or '>>='
-  'qprefix - if matched only modid prefix: 'Data.'
+  \\='qid - if matched a qualified id: \\='Data.Map\\=' or \\='Map\\='
+  \\='qsym - if matched a qualified id: \\='Monad.>>=\\=' or \\='>>=\\='
+  \\='qprefix - if matched only modid prefix: \\='Data.\\='
 
-After successful 'qid or 'qsym match (match-string 1) will return
+After successful \\='qid or \\='qsym match (match-string 1) will return
 the unqualified part (if any)."
   (let ((begin (point))
         (match-data-old (match-data)))
@@ -357,8 +357,8 @@ After successful match:
   "Non-nil when point is just in front of Template Haskell
 quaisquote literal.
 
-Quasi quotes start with '[xxx|' or '[$xxx|' sequence and end with
-  '|]'. The 'xxx' is a quoter name. There is no escaping mechanism
+Quasi quotes start with \\='[xxx|\\=' or \\='[$xxx|\\=' sequence and end with
+  \\='|]\\='. The \\='xxx\\=' is a quoter name. There is no escaping mechanism
 provided for the ending sequence.
 
 Regexp has subgroup expressions:
@@ -368,8 +368,8 @@ Regexp has subgroup expressions:
  (match-text 4) matches the closing vertical bar
                 or nil if at the end of the buffer.
 
-Note that this function excludes 'e', 't', 'd', 'p' as quoter
-names according to Template Haskell specification."
+Note that this function excludes \\='e\\=', \\='t\\=', \\='d'\\=, \\='p\\='
+as quoter names according to Template Haskell specification."
   (let ((match-data-old (match-data)))
     (if (and
          (looking-at (rx-to-string `(: "[" (optional "$")
@@ -445,16 +445,16 @@ type of Haskell token recognized.  Use `match-string',
 result.
 
 Possible results are:
-- 'special: for chars [](){}`,;
-- 'comment: for single line comments
-- 'nested-comment: for multiline comments
-- 'qsymid: for qualified identifiers or symbols
-- 'string: for strings literals
-- 'char: for char literals
-- 'number: for decimal, float, hexadecimal and octal number literals
-- 'template-haskell-quote: for a string of apostrophes for template
+- \\='special: for chars [](){}`,;
+- \\='comment: for single line comments
+- \\='nested-comment: for multiline comments
+- \\='qsymid: for qualified identifiers or symbols
+- \\='string: for strings literals
+- \\='char: for char literals
+- \\='number: for decimal, float, hexadecimal and octal number literals
+- \\='template-haskell-quote: for a string of apostrophes for template
    haskell
-- 'template-haskell-quasi-quote: for a string of apostrophes for template
+- \\='template-haskell-quasi-quote: for a string of apostrophes for template
    haskell
 
 Note that for qualified symbols (match-string 1) returns the

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -563,7 +563,7 @@ When MODULE-BUFFER is non-NIL, paint error overlays."
                  t)))))))
 
 (defun haskell-interactive-show-load-message (session type module-name file-name echo th)
-  "Show the '(Compiling|Loading) X' message."
+  "Show the \\='(Compiling|Loading) X\\=' message."
   (let ((msg (concat
               (cl-ecase type
                 (compiling

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -788,7 +788,7 @@ your Emacs configuration. To do that you can customize
 `haskell-mode-hook' or add lines to your .emacs file. For
 example, to enable `interactive-haskell-mode', use the following:
 
-    (add-hook 'haskell-mode-hook 'interactive-haskell-mode)
+    (add-hook \\='haskell-mode-hook \\='interactive-haskell-mode)
 
 Minor modes that work well with `haskell-mode':
 

--- a/haskell-utils.el
+++ b/haskell-utils.el
@@ -114,7 +114,7 @@ characters."
     (replace-regexp-in-string "\r?\n" "" s)))
 
 (defun haskell-utils-repl-response-error-status (response)
-  "Parse response REPL's RESPONSE for errors.
+  "Parse response REPL\\='s RESPONSE for errors.
 Returns one of the following symbols:
 
 + unknown-command
@@ -128,10 +128,10 @@ Returns one of the following symbols:
   REPL missing requested command
 * \"<interactive>:3:5: …\"
   interactive REPL error
-* \"Couldn't guess that module name. Does it exist?\"
+* \"Couldn\\='t guess that module name. Does it exist?\"
   (:type-at and maybe some other commands error)
 * *all other reposnses* are treated as success reposneses and
-  'no-error is returned."
+  \\='no-error is returned."
   (if response
       (let ((first-line (car (split-string response "\n" t))))
         (cond

--- a/haskell.el
+++ b/haskell.el
@@ -449,7 +449,7 @@ Give optional NEXT-P parameter to override value of
   "Run a loading-ish COMMAND.
 For example, a COMMAND that wants to pick up type errors and things like that.
 RELOAD-P indicates whether the notification
-should say 'reloaded' or 'loaded'.  MODULE-BUFFER may be used
+should say \\='reloaded\\=' or \\='loaded\\='.  MODULE-BUFFER may be used
 for various things, but is optional."
   (let ((session (haskell-session)))
     (haskell-session-current-dir session)


### PR DESCRIPTION
Development Emacs(version 29) warns not escaped quotes in docstring as below. This PR fixes this issue and makes `make` command success on development Emacs too.

```
In haskell-cabal-classify-line:
haskell-cabal.el:363:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)
```
