### PR TITLE
Define haskell-mode-hook before haskell-mode

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -743,6 +743,26 @@ Prefix ARG is handled as per `delete-indentation'."
       (funcall #'electric-pair-default-inhibit ch)))
 
 ;; The main mode functions
+(defcustom haskell-mode-hook '(haskell-indentation-mode interactive-haskell-mode)
+  "List of functions to run after `haskell-mode' is enabled.
+
+Use to enable minor modes coming with `haskell-mode' or run an
+arbitrary function.
+
+Note that  `haskell-indentation-mode' and `haskell-indent-mode' should not be
+run at the same time."
+  :group 'haskell
+  :type 'hook
+  :options '(capitalized-words-mode
+             flyspell-prog-mode
+             haskell-decl-scan-mode
+             haskell-indent-mode
+             haskell-indentation-mode
+             highlight-uses-mode
+             imenu-add-menubar-index
+             interactive-haskell-mode
+             turn-on-haskell-unicode-input-method))
+
 ;;;###autoload
 (define-derived-mode haskell-mode prog-mode "Haskell"
   "Major mode for editing Haskell programs.
@@ -858,26 +878,6 @@ Minor modes that work well with `haskell-mode':
     (setq-local electric-pair-inhibit-predicate 'haskell-mode--inhibit-bracket-inside-comment-or-default))
 
   (haskell-indentation-mode))
-
-(defcustom haskell-mode-hook '(haskell-indentation-mode interactive-haskell-mode)
-  "List of functions to run after `haskell-mode' is enabled.
-
-Use to enable minor modes coming with `haskell-mode' or run an
-arbitrary function.
-
-Note that  `haskell-indentation-mode' and `haskell-indent-mode' should not be
-run at the same time."
-  :group 'haskell
-  :type 'hook
-  :options '(capitalized-words-mode
-             flyspell-prog-mode
-             haskell-decl-scan-mode
-             haskell-indent-mode
-             haskell-indentation-mode
-             highlight-uses-mode
-             imenu-add-menubar-index
-             interactive-haskell-mode
-             turn-on-haskell-unicode-input-method))
 
 (defun haskell-fill-paragraph (justify)
   (save-excursion


### PR DESCRIPTION
If `define-derived-mode haskell-mode` comes before `defcustom haskell-mode-hook`, custom will report `haskell-mode-hook` as being changed outside of customize.  This prevents customizations from taking effect.  Swapping the order of definitions fixes this.

Fixes #1480.  Note that what @phil-s mentioned in that issue about clobbering the docstring is not a problem since Emacs 26.1, thanks to [this commit](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=3e7ebbe1bd5d33476190c789d17e4dd2d5f1bdfb), so I didn't bother with the workaround he suggested.