### PR TITLE
Fix permanent haskell-doc mode.

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -832,8 +832,6 @@ Minor modes that work well with `haskell-mode':
   (setq-local parse-sexp-ignore-comments nil)
   (setq-local syntax-propertize-function #'haskell-syntax-propertize)
 
-  ;; Set things up for eldoc-mode.
-  (setq-local eldoc-documentation-function 'haskell-doc-current-info)
   ;; Set things up for imenu.
   (setq-local imenu-create-index-function 'haskell-ds-create-imenu-index)
   ;; Set things up for font-lock.


### PR DESCRIPTION
The `eldoc-documentation-function` is turned on regardless if `haskell-doc-mode` is on or off, and it is hard to find a way to disable it.

`haskell-doc-mode` still works as intended, and actually turns off the eldoc popup when the mode is disabled.