### PR TITLE
change lib-target in haskell-cabal-enum-targets to support multiple library components.

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -515,7 +515,9 @@ PROCESS-TYPE determines the format of the returned target."
                        (val (car (split-string
                                   (haskell-cabal-section-value section)))))
                   (if (equal (downcase component-type) "library")
-                      (let* ((lib-name (if (eq 'val "") package-name val))
+                      (let* ((lib-name (if (not val)
+                                           (if (eq 'stack-ghci process-type) "lib" package-name)
+                                           val))
                              (lib-target (concat package-name ":" lib-name))
                              )
                         (push lib-target matches))

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -515,11 +515,8 @@ PROCESS-TYPE determines the format of the returned target."
                        (val (car (split-string
                                   (haskell-cabal-section-value section)))))
                   (if (equal (downcase component-type) "library")
-                      (let* ((lib-name (if (not val)
-                                           (if (eq 'stack-ghci process-type) "lib" package-name)
-                                           val))
-                             (lib-target (concat package-name ":" lib-name))
-                             )
+                      (let* ((lib-name (or val (if (eq 'stack-ghci process-type) "lib" package-name)))
+                             (lib-target (concat package-name ":" lib-name)))
                         (push lib-target matches))
                     (push (concat  (when (eq 'stack-ghci process-type)
                                      (concat package-name ":"))

--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -515,9 +515,9 @@ PROCESS-TYPE determines the format of the returned target."
                        (val (car (split-string
                                   (haskell-cabal-section-value section)))))
                   (if (equal (downcase component-type) "library")
-                      (let ((lib-target (if (eq 'stack-ghci process-type)
-                                            (concat package-name ":lib")
-                                          (concat "lib:" package-name))))
+                      (let* ((lib-name (if (eq 'val "") package-name val))
+                             (lib-target (concat package-name ":" lib-name))
+                             )
                         (push lib-target matches))
                     (push (concat  (when (eq 'stack-ghci process-type)
                                      (concat package-name ":"))


### PR DESCRIPTION
Fixes #1796.