### PR TITLE
ghci-script-mode: Fix script loading by `ghci-script-mode-load`.

### DIFF
--- a/ghci-script-mode.el
+++ b/ghci-script-mode.el
@@ -55,9 +55,9 @@
 (defun ghci-script-mode-load ()
   "Load the current script file into the GHCi session."
   (interactive)
-  (let ((buffer (haskell-session-interactive-buffer (haskell-session)))
-        (filename (buffer-file-name)))
-    (save-buffer)
+  (save-buffer)
+  (let ((filename (buffer-file-name))
+        (buffer (haskell-session-interactive-buffer (haskell-session))))
     (with-current-buffer buffer
       (set-marker haskell-interactive-mode-prompt-start (point-max))
       (haskell-interactive-mode-run-expr


### PR DESCRIPTION
The current version of `ghci-script-mode-load` is defined as 

``` elisp
(defun ghci-script-mode-load ()
  "Load the current script file into the GHCi session."
  (interactive)
  (let ((buffer (haskell-session-interactive-buffer (haskell-session)))
        (filename (buffer-file-name)))
    (save-buffer)
    (with-current-buffer buffer
      (set-marker haskell-interactive-mode-prompt-start (point-max))
      (haskell-interactive-mode-run-expr
       (concat ":script " filename)))))
```

The `let` binding calls `(haskell-session-interactive-buffer (haskell-session))` which changes the current buffer by calling `(haskell-interactive-switch)` at `haskell-interactive-mode.el::520`, this causes the wrong binding for `filename` and also causes the `save-buffer` part to prompt for which file to save the `*haskell-session*` buffer in, which when canceled cancels the rest of the command `(haskell-interactive-mode-run-expr (concat ":script " filename))`.
