### PR TITLE
Require flymake-proc to avoid compilation errors in Emacs HEAD

### DIFF
--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -129,6 +129,7 @@
 (require 'compile)
 (require 'etags)
 (require 'flymake)
+(require 'flymake-proc)
 (require 'outline)
 (require 'cl-lib)
 (require 'haskell-ghc-support)

--- a/haskell-mode.el
+++ b/haskell-mode.el
@@ -129,7 +129,7 @@
 (require 'compile)
 (require 'etags)
 (require 'flymake)
-(require 'flymake-proc)
+(require 'flymake-proc nil 'noerror)
 (require 'outline)
 (require 'cl-lib)
 (require 'haskell-ghc-support)


### PR DESCRIPTION
See #1825