### PR TITLE
Fix #1834: remove bad regex that was supposed to recognize a LANGUAGE suggestion

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -205,7 +205,13 @@ list of modules where missed IDENT was found."
             (string-match
              "Use \\([A-Z][A-Za-z]+\\) if you want to disable this"
              msg)
-            (string-match "use \\([A-Z][A-Za-z]+\\)" msg)
+            ;; Andreas Abel, 2024-01-10, https://github.com/haskell/haskell-mode/issues/1834
+            ;; The following regex also matches the new x-partial warning
+            ;; "Consider refactoring to use Data.List.NonEmpty"
+            ;; which would result in a suggestion to
+            ;; "Add {-# LANGUAGE Data #-} to the top of the file?"
+            ;; Thus, we disable it.
+            ;; (string-match "use \\([A-Z][A-Za-z]+\\)" msg)
             (string-match "You need \\([A-Z][A-Za-z]+\\)" msg)))
          (when haskell-process-suggest-language-pragmas
            (haskell-process-suggest-pragma

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -205,13 +205,8 @@ list of modules where missed IDENT was found."
             (string-match
              "Use \\([A-Z][A-Za-z]+\\) if you want to disable this"
              msg)
-            ;; Andreas Abel, 2024-01-10, https://github.com/haskell/haskell-mode/issues/1834
-            ;; The following regex also matches the new x-partial warning
-            ;; "Consider refactoring to use Data.List.NonEmpty"
-            ;; which would result in a suggestion to
-            ;; "Add {-# LANGUAGE Data #-} to the top of the file?"
-            ;; Thus, we disable it.
-            ;; (string-match "use \\([A-Z][A-Za-z]+\\)" msg)
+            (and (string-match "use \\([A-Z][A-Za-z]+\\)" msg)
+                 (not (string-match "refactoring to use" msg)))
             (string-match "You need \\([A-Z][A-Za-z]+\\)" msg)))
          (when haskell-process-suggest-language-pragmas
            (haskell-process-suggest-pragma


### PR DESCRIPTION
Remove bad regex that was supposed to recognize a LANGUAGE suggestion.

This regex fires unfortunately on GHC 9.8's new `x-partial` warning,
destroying the UX with obnoxious questions whether to "add LANGUAGE Data".

Closes #1834.
