### PR TITLE
haskell-process-load-complete: handle ghc 9.10 message

### DIFF
--- a/haskell-load.el
+++ b/haskell-load.el
@@ -134,6 +134,10 @@ actual Emacs buffer of the module being loaded."
                 process
                 "Failed, no modules loaded\\.$") ;; for ghc 8.4
                nil)
+              ((haskell-process-consume
+                process
+                "Failed, unloaded all modules\\.$") ;; for ghc 9.10
+               nil)
               (t
                (error (message "Unexpected response from haskell process.")))))
          (modules (haskell-process-extract-modules buffer))

--- a/haskell-load.el
+++ b/haskell-load.el
@@ -106,38 +106,8 @@ actual Emacs buffer of the module being loaded."
     (with-current-buffer (haskell-interactive-mode-splices-buffer session)
       (erase-buffer)))
   (let* ((ok (cond
-              ((haskell-process-consume
-                process
-                "Ok, \\(?:[0-9]+\\) modules? loaded\\.$")
-               t)
-               ((haskell-process-consume
-                process
-                "Ok, \\(?:[a-z]+\\) modules? loaded\\.$") ;; for ghc 8.4
-               t)
-              ((haskell-process-consume
-                process
-                "Failed, \\(?:[0-9]+\\) modules? loaded\\.$")
-               nil)
-              ((haskell-process-consume
-                process
-                "Failed, \\(?:[a-z]+\\) modules? loaded\\.$") ;; ghc 8.6.3 says so
-               nil)
-              ((haskell-process-consume
-                process
-                "Ok, modules loaded: \\(.+\\)\\.$")
-               t)
-              ((haskell-process-consume
-                process
-                "Failed, modules loaded: \\(.+\\)\\.$")
-               nil)
-              ((haskell-process-consume
-                process
-                "Failed, no modules loaded\\.$") ;; for ghc 8.4
-               nil)
-              ((haskell-process-consume
-                process
-                "Failed, unloaded all modules\\.$") ;; for ghc 9.10
-               nil)
+              ((haskell-process-consume process "Ok, .*$") t)
+              ((haskell-process-consume process "Failed, .*$") nil)
               (t
                (error (message "Unexpected response from haskell process.")))))
          (modules (haskell-process-extract-modules buffer))


### PR DESCRIPTION
ghc 9.10 and later can respond to `:load` with "Failed, unloaded all modules." Unfortunately `haskell-process-load-complete` does not recognize this response. This PR fixes this. To simplify and future-proof the code I've adjusted `haskell-process-load-complete` to look for the regexes `Ok, .*$` or `Failed, .*$`. Alternatively, if you'd prefer to narrowly add the "Failed, unloaded all modules." message, [you could cherry-pick this commit.](https://github.com/haskell/haskell-mode/commit/337c41e146e47c5f92b28009c535fe9e72cfad76)

This may possibly fix https://github.com/haskell/haskell-mode/issues/1642.