### PR TITLE
ci: Test only the latest Emacs minor version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,14 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 25.1
           - 25.3
-          - 26.1
           - 26.3
-          - 27.1
           - 27.2
-          - 28.1
           - 28.2
-          - 29.1
+          - 29.4
           - snapshot
         include:
-          - emacs_version: 29.1
+          - emacs_version: 29.4
             target: deploy-manual
     steps:
     - uses: cachix/install-nix-action@V27


### PR DESCRIPTION
It's generally enough to only test the latest minor version. 🤔 So we can lower the CI time.