### PR TITLE
Load and run expr

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -398,11 +398,16 @@ Give optional NEXT-P parameter to override value of
                                 nil
                                 (current-buffer)))
 
-(defun haskell-load-and-run ()
-  "Loads the current buffer and runs the main function."
-  (interactive)
+(defvar haskell-load-and-run-expr-history nil
+  "History of expressions used in `haskell-load-and-run'.")
+
+(defun haskell-load-and-run (expr)
+  "Load the current buffer and run EXPR, e.g. \"main\"."
+  (interactive (list (read-string "Run expression: "
+                                  (car haskell-load-and-run-expr-history)
+                                  'haskell-load-and-run-expr-history)))
   (haskell-process-load-file)
-  (haskell-interactive-mode-run-expr "main"))
+  (haskell-interactive-mode-run-expr expr))
 
 ;;;###autoload
 (defun haskell-process-reload ()

--- a/haskell.el
+++ b/haskell.el
@@ -38,6 +38,7 @@
 (defvar interactive-haskell-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-l") 'haskell-process-load-file)
+    (define-key map (kbd "C-c RET") 'haskell-load-and-run)  ;; == C-c C-m
     (define-key map (kbd "C-c C-r") 'haskell-process-reload)
     (define-key map (kbd "C-c C-t") 'haskell-process-do-type)
     (define-key map (kbd "C-c C-i") 'haskell-process-do-info)
@@ -396,6 +397,12 @@ Give optional NEXT-P parameter to override value of
                                                        (buffer-file-name)))
                                 nil
                                 (current-buffer)))
+
+(defun haskell-load-and-run ()
+  "Loads the current buffer and runs the main function."
+  (interactive)
+  (haskell-process-load-file)
+  (haskell-interactive-mode-run-expr "main"))
 
 ;;;###autoload
 (defun haskell-process-reload ()


### PR DESCRIPTION
_following from PR #1861_ 

Thanks a lot! This works well for me.

In the future it could be [modified to use completing-read](https://github.com/zaz/haskell-mode/compare/load-and-run-expr..completing-read?expand=1) or similar, but I find that pops up a buffer that is annoyingly large and what you wrote already works great.