### PR TITLE
haskell-cabal: fix (comment-dwim) by correcting comment-start-skip

### DIFF
--- a/haskell-cabal.el
+++ b/haskell-cabal.el
@@ -175,7 +175,7 @@ it from list if one of the following conditions are hold:
   (add-hook 'change-major-mode-hook 'haskell-cabal-unregister-buffer nil 'local)
   (add-hook 'kill-buffer-hook 'haskell-cabal-unregister-buffer nil 'local)
   (setq-local comment-start "-- ")
-  (setq-local comment-start-skip "\\(^[ \t]*\\)--[ \t]*")
+  (setq-local comment-start-skip "--[ \t]*")
   (setq-local comment-end "")
   (setq-local comment-end-skip "[ \t]*\\(\\s>\\|\n\\)")
   (setq-local indent-line-function 'haskell-cabal-indent-line)


### PR DESCRIPTION
Prior to this commit using (comment-dwim) over a comment in .cabal file that doesn't start at the beginning of a line resulted in it adding even more comments. E.g. this:

    -- comment not at the beginning of a line

resulted in:

    -- -- comment not at the beginning of a line

This is because `comment-start-skip` was including whitespace that isn't part of the comment syntax. Fix this by only limiting the regexp to the comment part.

The resulting regexp is basically same as the one in haskell-mode, barring that that one also takes into account `{-` comment starter, which isn't a thing in .cabal files.

Fixes: https://github.com/haskell/haskell-mode/issues/1743