### PR TITLE
Fix incorrect face usage and undeclared list elements type

### DIFF
--- a/haskell-c2hs.el
+++ b/haskell-c2hs.el
@@ -34,12 +34,12 @@
 (add-to-list 'auto-mode-alist '("\\.chs\\'" . haskell-c2hs-mode))
 
 (defface haskell-c2hs-hook-pair-face
-  '((t (:inherit 'font-lock-preprocessor-face)))
+  '((t (:inherit font-lock-preprocessor-face)))
   "Face for highlighting {#...#} pairs."
   :group 'haskell)
 
 (defface haskell-c2hs-hook-name-face
-  '((t (:inherit 'font-lock-keyword-face)))
+  '((t (:inherit font-lock-keyword-face)))
   "Face for highlighting c2hs hook names."
   :group 'haskell)
 

--- a/haskell-commands.el
+++ b/haskell-commands.el
@@ -46,7 +46,7 @@
 (defcustom haskell-mode-stylish-haskell-args nil
   "Arguments to pass to program specified by haskell-mode-stylish-haskell-path."
   :group 'haskell
-  :type 'list)
+  :type '(list string))
 
 (defcustom haskell-interactive-set-+c
   t


### PR DESCRIPTION
This fixes a few warnings. Couldn't fix more because it complains `if-let` being an obsolete macro and that `if-let*` should be preferred, but I'm not sure what's the best course of action here. `if-let*` appeared since 26.1, so it's either upping the minimal version 26.1 or adding a wrapper for older Emacses. Emacs 26.1 was released in 2018.