### PR TITLE
Do not redefine xref-prompt-for-identifier

### DIFF
--- a/haskell.el
+++ b/haskell.el
@@ -324,7 +324,7 @@ If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
              (haskell-interactive-mode-error-backward)
              (haskell-interactive-jump-to-error-line)))))
 
-(defvar xref-prompt-for-identifier nil)
+(defvar xref-prompt-for-identifier)
 
 ;;;###autoload
 (defun haskell-mode-jump-to-tag (&optional next-p)


### PR DESCRIPTION
The correct way to declare a variable as dynamically bound but defined elsewhere is to use defvar with a variable name but no value.  Otherwise, this causes the following unwanted side-effect when pressing `C-h v xref-prompt-for-identifier`:

```
xref-prompt-for-identifier is a variable defined in ‘haskell.el’.
```